### PR TITLE
Added Mercurial as VCS

### DIFF
--- a/lib/rubycritic/source_control_systems/base.rb
+++ b/lib/rubycritic/source_control_systems/base.rb
@@ -58,3 +58,4 @@ end
 
 require "rubycritic/source_control_systems/double"
 require "rubycritic/source_control_systems/git"
+require "rubycritic/source_control_systems/mercurial"

--- a/lib/rubycritic/source_control_systems/mercurial.rb
+++ b/lib/rubycritic/source_control_systems/mercurial.rb
@@ -1,0 +1,29 @@
+module Rubycritic
+  module SourceControlSystem
+
+    class Mercurial < Base
+      register_system
+
+      def self.supported?
+        `hg verify 2>&1` && $?.success?
+      end
+
+      def has_revision?
+        false
+      end
+
+      def revisions_count(path)
+        `hg log #{path.shellescape} --template '1'`.size
+      end
+
+      def date_of_last_commit(path)
+        `hg log #{path.shellescape} --template '{date|isodate}' --limit 1`.chomp
+      end
+
+      def self.to_s
+        "Mercurial"
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
Quick add of Mercurial as VCS.
Unfortunately Mercurial by default does not support stashing uncommited changes. The extension needes (i.e. shelve) may not be activated. A more soffisticated approach could check if the extension is active and then use the shelve for stashing.
