### PR TITLE
Change CLI to open critique file

### DIFF
--- a/lib/rubycritic/cli.rb
+++ b/lib/rubycritic/cli.rb
@@ -36,7 +36,7 @@ module Rubycritic
       if @main_command
         analysed_modules = Orchestrator.new.critique(@argv)
         report_location = Reporter::Main.new(analysed_modules).generate_report
-        puts "New critique at #{report_location}"
+        `open #{report_location}`
       end
 
       STATUS_SUCCESS


### PR DESCRIPTION
It's not very helpful to just provide a file location when you run rubycritic. It would be more helpful if the file just opened up in a browser.
