### PR TITLE
convert complexity to integer in case nil

### DIFF
--- a/lib/rubycritic/core/analysed_module.rb
+++ b/lib/rubycritic/core/analysed_module.rb
@@ -20,7 +20,7 @@ module Rubycritic
     end
 
     def cost
-      @cost ||= smells.map(&:cost).inject(0, :+) + (complexity / 25)
+      @cost ||= smells.map(&:cost).inject(0, :+) + (complexity.to_i / 25)
     end
 
     def rating


### PR DESCRIPTION
Unsure if this can/would ever happen in rubycritic naturally, but using AnalyzedModue in a new gem I'm working on, I had complexity as a nil value there causing an exception, this seems slightly preferable.
