### PR TITLE
Use Reek 1.6.5 instead of 1.6.3

### DIFF
--- a/rubycritic.gemspec
+++ b/rubycritic.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "virtus", "~> 1.0"
   spec.add_runtime_dependency "flay", "2.4.0"
   spec.add_runtime_dependency "flog", "4.2.1"
-  spec.add_runtime_dependency "reek", "1.6.3"
+  spec.add_runtime_dependency "reek", "1.6.5"
   spec.add_runtime_dependency "parser", ">= 2.2.0", "< 3.0"
 
   spec.add_development_dependency "bundler", "~> 1.3"


### PR DESCRIPTION
Reek with version on the interval of [1.5.0, 1.6.4] is unable to parse code that passes an iterator to super -- this is fixed in 1.6.5:

https://github.com/troessner/reek/issues/379

The changes in 1.6.4 / 1.6.5 are pretty small:

1.6.5
----

* (mvz) Make NestedIterator not break when iterator is called on super.

1.6.4
---
* (maser) Fix file arguments without TTY