### PR TITLE
Suppress ratings.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.3.0 / 2015-02-16
+
+* [FEATURE] New CLI option `--deduplicate-symlinks` to deduplicate symlinks (by LeeXGreen)
+* [CHANGE] Update to Reek 1.6.5 (from 1.6.3)
+* [CHANGE] Remove ruby2ruby dependency
+
 # 1.2.1 / 2015-01-17
 
 * [FEATURE] Support Ruby 2.2
@@ -8,7 +14,7 @@
 
 * [FEATURE] Add CI mode that only analyses the last commit
 * [FEATURE] Add partial support for Mercurial
-* [FEATURE] Allow using Rubycritic programatically
+* [FEATURE] Allow using RubyCritic programatically
 * [CHANGE] Update to Reek 1.6.0 (from 1.3.8)
 
 # 1.1.1 / 2014-07-29

--- a/lib/rubycritic/cli/options.rb
+++ b/lib/rubycritic/cli/options.rb
@@ -25,6 +25,10 @@ module Rubycritic
             @deduplicate_symlinks = true
           end
 
+          opts.on("--suppress-ratings", "Suppress letter grade ratings") do
+            @suppress_ratings = true
+          end
+
           opts.on_tail("-v", "--version", "Show gem's version") do
             @mode = :version
           end
@@ -45,7 +49,8 @@ module Rubycritic
           :mode => @mode,
           :root => @root,
           :deduplicate_symlinks => @deduplicate_symlinks,
-          :paths => paths
+          :paths => paths,
+          :suppress_ratings => @suppress_ratings
         }
       end
 

--- a/lib/rubycritic/configuration.rb
+++ b/lib/rubycritic/configuration.rb
@@ -1,12 +1,14 @@
 module Rubycritic
   class Configuration
     attr_reader :root
-    attr_accessor :source_control_system, :mode, :deduplicate_symlinks
+    attr_accessor :source_control_system, :mode, :deduplicate_symlinks,
+      :suppress_ratings
 
     def set(options)
       self.mode = options[:mode] || :default
       self.root = options[:root] || "tmp/rubycritic"
       self.deduplicate_symlinks = options[:deduplicate_symlinks] || false
+      self.suppress_ratings = options[:suppress_ratings] || false
     end
 
     def root=(path)

--- a/lib/rubycritic/report_generators/templates/code_file.html.erb
+++ b/lib/rubycritic/report_generators/templates/code_file.html.erb
@@ -1,5 +1,7 @@
 <div class="file-header group">
-  <span class="rating-<%= @analysed_module.rating.to_s.downcase %> circled-text circle "><%= @analysed_module.rating %></span>
+  <% unless Config.suppress_ratings %>
+    <span class="rating-<%= @analysed_module.rating.to_s.downcase %> circled-text circle "><%= @analysed_module.rating %></span>
+  <% end %>
   <h2 class="file-name"><%= @analysed_module.name %></h2>
 
   <span class="file-committed-at">

--- a/lib/rubycritic/report_generators/templates/code_index.html.erb
+++ b/lib/rubycritic/report_generators/templates/code_index.html.erb
@@ -6,11 +6,13 @@
     <th class="numeric-cell" title="Overall amount of code in a file">Complexity</th>
     <th class="numeric-cell" title="Amount of code that is similar to other code">Duplication</th>
     <th class="numeric-cell">Smells</th>
-    <th class="centered-cell last-cell">Rating</th>
-  </tr>
-</thead>
-<tbody>
-  <% @analysed_modules.each do |analysed_module| %>
+    <% unless Config.suppress_ratings %>
+      <th class="centered-cell last-cell">Rating</th>
+    <% end %>
+    </tr>
+  </thead>
+  <tbody>
+    <% @analysed_modules.each do |analysed_module| %>
     <tr>
       <td class="first-cell">
         <a href="<%= file_path(analysed_module.pathname.sub_ext('.html')) %>"><%= analysed_module.name %></a>
@@ -19,8 +21,10 @@
       <td class="numeric-cell"><%= analysed_module.complexity %></td>
       <td class="numeric-cell"><%= analysed_module.duplication %></td>
       <td class="numeric-cell"><%= analysed_module.smells.length %></td>
-      <td class="centered-cell last-cell"><span class="rating-<%= analysed_module.rating.to_s.downcase %> circled-text circle"><%= analysed_module.rating %></span></td>
+      <% unless Config.suppress_ratings %>
+        <td class="centered-cell last-cell"><span class="rating-<%= analysed_module.rating.to_s.downcase %> circled-text circle"><%= analysed_module.rating %></span></td>
+      <% end %>
     </tr>
-  <% end %>
+    <% end %>
 </tbody>
 </table>

--- a/lib/rubycritic/version.rb
+++ b/lib/rubycritic/version.rb
@@ -1,3 +1,3 @@
 module Rubycritic
-  VERSION = "1.2.1"
+  VERSION = "1.3.0"
 end

--- a/test/lib/rubycritic/source_locator_test.rb
+++ b/test/lib/rubycritic/source_locator_test.rb
@@ -30,11 +30,13 @@ describe Rubycritic::SourceLocator do
       Rubycritic::SourceLocator.new(initial_paths).paths.must_match_array final_paths
     end
 
-    it "finds all the files, ignoring symlinks" do
-      Rubycritic::Config.stubs(:deduplicate_symlinks).returns(true)
-      initial_paths = ["."]
-      final_paths = ["dir1/file1.rb", "file0.rb"]
-      Rubycritic::SourceLocator.new(initial_paths).paths.must_match_array final_paths
+    context "when configured to deduplicate symlinks" do
+      it "it favors a file over a symlink if they both point to the same target" do
+        Rubycritic::Config.stubs(:deduplicate_symlinks).returns(true)
+        initial_paths = ["file0.rb", "file0_symlink.rb"]
+        final_paths = ["file0.rb"]
+        Rubycritic::SourceLocator.new(initial_paths).paths.must_match_array final_paths
+      end
     end
 
     it "cleans paths of consecutive slashes and useless dots" do

--- a/test/samples/reek/not_smelly.rb
+++ b/test/samples/reek/not_smelly.rb
@@ -12,7 +12,7 @@ class Perfume
     end
   end
 
-  def method_with_too_many_statements
+  def allow_many_statements
     do_something
     do_something
     do_something


### PR DESCRIPTION
Rubycritic provides useful reports, but I’m completely uninterested in having letter grades assigned to code. It is the main reason that I will not use Code Climate.

I can understand if you’re not interested in this particular pull request, but I think that this is a *good* change for more mature teams.

I don’t think it would be bad to offer a Rubycritic configuration file for projects to use, possibly in conjunction with guard-rubycritic.