### PR TITLE
Experiments for adding a global score/rating

### DIFF
--- a/lib/rubycritic/analysers_runner.rb
+++ b/lib/rubycritic/analysers_runner.rb
@@ -1,5 +1,4 @@
-require "rubycritic/source_locator"
-require "rubycritic/core/analysed_module"
+require "rubycritic/core/analysed_modules_collection"
 require "rubycritic/analysers/smells/flay"
 require "rubycritic/analysers/smells/flog"
 require "rubycritic/analysers/smells/reek"
@@ -29,9 +28,7 @@ module Rubycritic
     end
 
     def analysed_modules
-      @analysed_modules ||= SourceLocator.new(@paths).pathnames.map do |pathname|
-        AnalysedModule.new(:pathname => pathname)
-      end
+      @analysed_modules ||= AnalysedModulesCollection.new(@paths)
     end
   end
 

--- a/lib/rubycritic/core/analysed_modules_collection.rb
+++ b/lib/rubycritic/core/analysed_modules_collection.rb
@@ -1,0 +1,49 @@
+require "rubycritic/source_locator"
+require "rubycritic/core/analysed_module"
+
+module Rubycritic
+  class AnalysedModulesCollection
+    include Enumerable
+
+    # Limit used to prevent very bad modules to have excessive impact in the
+    # overall result. See #limited_cost_for
+    COST_LIMIT = 32
+    # Score goes from 0 (worst) to 100 (perfect)
+    MAX_SCORE = 100
+    # Projects with an average cost of 16 (or above) will score 0, since 16
+    # is where the worst possible rating (F) starts
+    ZERO_SCORE_COST = 16
+    COST_MULTIPLIER = MAX_SCORE.to_f / ZERO_SCORE_COST
+
+    def initialize(paths)
+      @modules = SourceLocator.new(paths).pathnames.map do |pathname|
+        AnalysedModule.new(:pathname => pathname)
+      end
+    end
+
+    def each(&block)
+      @modules.each(&block)
+    end
+
+    def to_json(*options)
+      @modules.to_json(*options)
+    end
+
+    def score
+      MAX_SCORE - average_limited_cost * COST_MULTIPLIER
+    rescue
+      0.0
+    end
+
+    private
+
+    def average_limited_cost
+      avg = map { |mod| limited_cost_for(mod) }.reduce(:+) / @modules.size.to_f
+      [avg, ZERO_SCORE_COST].min
+    end
+
+    def limited_cost_for(mod)
+      [mod.cost, COST_LIMIT].min
+    end
+  end
+end

--- a/lib/rubycritic/generators/html/overview.rb
+++ b/lib/rubycritic/generators/html/overview.rb
@@ -10,6 +10,8 @@ module Rubycritic
 
         def initialize(analysed_modules)
           @turbulence_data = Turbulence.data(analysed_modules)
+          @score = analysed_modules.score
+          @max_score = AnalysedModulesCollection::MAX_SCORE
         end
 
         def file_name

--- a/lib/rubycritic/generators/html/templates/overview.html.erb
+++ b/lib/rubycritic/generators/html/templates/overview.html.erb
@@ -1,3 +1,7 @@
+<div class="chart-container">
+  <h2>Score: <%= @score.round(2) %> / <%= @max_score %></h2>
+</div>
+
 <div id="js-chart-container" class="chart-container"></div>
 
 <script type="text/javascript">

--- a/lib/rubycritic/generators/json/simple.rb
+++ b/lib/rubycritic/generators/json/simple.rb
@@ -20,7 +20,8 @@ module Rubycritic
                 :version => Rubycritic::VERSION
               }
             },
-            :analysed_modules => @analysed_modules
+            :analysed_modules => @analysed_modules,
+            :score => @analysed_modules.score
           }
         end
       end

--- a/test/lib/rubycritic/core/analysed_modules_collection_test.rb
+++ b/test/lib/rubycritic/core/analysed_modules_collection_test.rb
@@ -1,0 +1,109 @@
+require "test_helper"
+require "rubycritic/core/analysed_modules_collection"
+
+describe Rubycritic::AnalysedModulesCollection do
+  subject { Rubycritic::AnalysedModulesCollection.new(paths) }
+
+  describe ".new" do
+    context "with an empty path" do
+      let(:paths) { "" }
+
+      it "returns an empty collection" do
+        subject.count.must_equal 0
+      end
+    end
+
+    context "with a list of files" do
+      let(:paths) { %w(test/samples/doesnt_exist.rb test/samples/unparsable.rb test/samples/empty.rb) }
+
+      it "registers one AnalysedModule element per existent file" do
+        subject.count.must_equal 2
+        subject.all? { |a| a.is_a?(Rubycritic::AnalysedModule) }.must_equal true
+      end
+    end
+
+    context "with a directory" do
+      let(:paths) { "test/samples/" }
+
+      it "recursively registers all files" do
+        subject.count.must_equal 13
+      end
+    end
+
+    context "with redundant paths" do
+      let(:paths) { %w(test/samples/flog test/samples/flog/complex.rb) }
+
+      it "returns a redundant collection" do
+        subject.count.must_equal 3
+      end
+    end
+  end
+
+  describe "#score" do
+    context "with no modules" do
+      let(:paths) { "" }
+
+      it "returns zero" do
+        subject.score.must_equal 0.0
+      end
+    end
+
+    context "with not analysed modules" do
+      let(:paths) { "test/samples/flog" }
+
+      it "returns zero" do
+        subject.score.must_equal 0.0
+      end
+    end
+
+    context "with analysed modules" do
+      before do
+        subject.each_with_index do |mod, i|
+          mod.expects(:cost).returns costs[i]
+        end
+      end
+
+      let(:paths) { %w(test/samples/flog test/samples/flay) }
+
+      context "with perfect modules" do
+        let(:costs) { [0.0, 0.0, 0.0, 0.0] }
+
+        it "returns the maximum score" do
+          subject.score.must_equal 100.0
+        end
+      end
+
+      context "with very bad modules" do
+        let(:costs) { [16.0, 16.0, 16.0, 16.0] }
+
+        it "returns zero" do
+          subject.score.must_equal 0.0
+        end
+      end
+
+      context "with horrible modules" do
+        let(:costs) { [32.0, 32.0, 32.0, 32.0] }
+
+        it "returns zero" do
+          subject.score.must_equal 0.0
+        end
+      end
+
+      context "with mixed modules" do
+        let(:costs) { [32.0, 2.0, 0.0, 2.0] }
+
+        it "properly calculates the score" do
+          subject.score.must_equal 43.75
+        end
+      end
+
+      context "with a module above the cost limit" do
+        let(:costs) { [220.0, 2.0, 0.0, 2.0] }
+
+        it "reduces the impact in the result" do
+          subject.score.must_equal 43.75
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
In https://github.com/whitesmith/rubycritic/issues/9#issuecomment-77242630 it was suggested to open a pull request to start discussing possible alternatives to implement global rating/scoring for a whole project/repository (ala CodeClimate).

It makes sense to me to just use the average cost of all analyzed modules and present that number in some meaningful way, either as a rating or as a number between 5 (perfect) and 0 (crap).

Since in this PR I want to focus the discussion on the way of turning the average cost into something meaningful I did almost no intrusive changes to the existing code apart from adding some ```puts``` so we can see the values without changing the reports yet.

After preparing this PR, I saw #32. I have not gone through its code yet, but it seems to include a very well though mechanism to achieve the same goal, so maybe we are already close enough to have global ratings in rubycritic and this PR is useless. If it's the case, don't hesitate to close it right away.