### PR TITLE
limit churn by commits within the last year

### DIFF
--- a/lib/rubycritic/source_control_systems/git.rb
+++ b/lib/rubycritic/source_control_systems/git.rb
@@ -13,7 +13,7 @@ module Rubycritic
       end
 
       def revisions_count(path)
-        `git log --follow --format=%h #{path.shellescape}`.count("\n")
+        `git log --follow --since=#{(Time.now - 31_449_600).to_date.to_s} --format=%h #{path.shellescape}`.count("\n")
       end
 
       def date_of_last_commit(path)


### PR DESCRIPTION
I think limiting the church calculations by 1 year seems reasonable, and greatly speeds up the calculation time for really old projects. Also I think from a metric perspective it makes sense, churn that is over 1 year old doesn't seem like a valuable thing to pay attention to in my mind.