### PR TITLE
First pass without tests allow specific analysers

### DIFF
--- a/lib/rubycritic/analysers_runner.rb
+++ b/lib/rubycritic/analysers_runner.rb
@@ -23,12 +23,8 @@ module Rubycritic
       @paths = paths
     end
 
-    def run
-      run_with_specified_analysers(ANALYSERS)
-    end
-
-    def run_with_specified_analysers(analysers)
-      analysers.each { |analyser| analyser.new(analysed_modules).run }
+    def run(analysers = nil)
+      (analysers || ANALYSERS).each { |analyser| analyser.new(analysed_modules).run }
       analysed_modules
     end
 

--- a/lib/rubycritic/analysers_runner.rb
+++ b/lib/rubycritic/analysers_runner.rb
@@ -24,7 +24,11 @@ module Rubycritic
     end
 
     def run
-      ANALYSERS.each { |analyser| analyser.new(analysed_modules).run }
+      run_with_specified_analysers(ANALYSERS)
+    end
+
+    def run_with_specified_analysers(analysers)
+      analysers.each { |analyser| analyser.new(analysed_modules).run }
       analysed_modules
     end
 

--- a/lib/rubycritic/commands/ci.rb
+++ b/lib/rubycritic/commands/ci.rb
@@ -14,9 +14,9 @@ module Rubycritic
         report(critique)
       end
 
-      def critique(opts={})
-        if analysers = opts[:analysers]
-          AnalysersRunner.new(@paths).run_with_specified_analysers(analysers)
+      def critique(opts = {})
+        if opts[:analysers]
+          AnalysersRunner.new(@paths).run_with_specified_analysers(opts[:analysers])
         else
           AnalysersRunner.new(@paths).run
         end

--- a/lib/rubycritic/commands/ci.rb
+++ b/lib/rubycritic/commands/ci.rb
@@ -15,11 +15,7 @@ module Rubycritic
       end
 
       def critique(opts = {})
-        if opts[:analysers]
-          AnalysersRunner.new(@paths).run_with_specified_analysers(opts[:analysers])
-        else
-          AnalysersRunner.new(@paths).run
-        end
+        AnalysersRunner.new(@paths).run(opts[:analysers])
       end
 
       def report(analysed_modules)

--- a/lib/rubycritic/commands/ci.rb
+++ b/lib/rubycritic/commands/ci.rb
@@ -14,8 +14,12 @@ module Rubycritic
         report(critique)
       end
 
-      def critique
-        AnalysersRunner.new(@paths).run
+      def critique(opts={})
+        if analysers = opts[:analysers]
+          AnalysersRunner.new(@paths).run_with_specified_analysers(analysers)
+        else
+          AnalysersRunner.new(@paths).run
+        end
       end
 
       def report(analysed_modules)

--- a/lib/rubycritic/commands/default.rb
+++ b/lib/rubycritic/commands/default.rb
@@ -15,9 +15,17 @@ module Rubycritic
         report(critique)
       end
 
-      def critique
-        analysed_modules = AnalysersRunner.new(@paths).run
+      def critique(opts={})
+        analysed_modules = generate_analysed_modules(opts)
         RevisionComparator.new(@paths).set_statuses(analysed_modules)
+      end
+
+      def generate_analysed_modules(opts)
+        if analysers = opts[:analysers]
+          AnalysersRunner.new(@paths).run_with_specified_analysers(analysers)
+        else
+          AnalysersRunner.new(@paths).run
+        end
       end
 
       def report(analysed_modules)

--- a/lib/rubycritic/commands/default.rb
+++ b/lib/rubycritic/commands/default.rb
@@ -15,14 +15,14 @@ module Rubycritic
         report(critique)
       end
 
-      def critique(opts={})
+      def critique(opts = {})
         analysed_modules = generate_analysed_modules(opts)
         RevisionComparator.new(@paths).set_statuses(analysed_modules)
       end
 
       def generate_analysed_modules(opts)
-        if analysers = opts[:analysers]
-          AnalysersRunner.new(@paths).run_with_specified_analysers(analysers)
+        if opts[:analysers]
+          AnalysersRunner.new(@paths).run_with_specified_analysers(opts[:analysers])
         else
           AnalysersRunner.new(@paths).run
         end

--- a/lib/rubycritic/commands/default.rb
+++ b/lib/rubycritic/commands/default.rb
@@ -16,16 +16,8 @@ module Rubycritic
       end
 
       def critique(opts = {})
-        analysed_modules = generate_analysed_modules(opts)
+        analysed_modules = AnalysersRunner.new(@paths).run(opts[:analysers])
         RevisionComparator.new(@paths).set_statuses(analysed_modules)
-      end
-
-      def generate_analysed_modules(opts)
-        if opts[:analysers]
-          AnalysersRunner.new(@paths).run_with_specified_analysers(opts[:analysers])
-        else
-          AnalysersRunner.new(@paths).run
-        end
       end
 
       def report(analysed_modules)


### PR DESCRIPTION
@guilhermesimoes I need to figure out some tests for this (it looks like nothing currently tests the create/critique methods, unless I missed it somewhere?), but what do you think as a basic approach? I think this gives me what I need to speed up debt_ceiling, and seems pretty flexible (also allows users to write their own new Analyser classes and pass them in, though for my use case I'll probably just do `Rubycritic::AnalysersRunner::ANALYSERS - [Analyser::Churn]` if that works, or maybe `- [Rubycritic::Analyser::Churn]` ? I'm gonna play around with this a bit more, but thought I'd submit for thoughts.