### PR TITLE
Require Reek 2.0.2.

### DIFF
--- a/lib/rubycritic/analysers/helpers/reek.rb
+++ b/lib/rubycritic/analysers/helpers/reek.rb
@@ -8,7 +8,7 @@ module Rubycritic
     DEFAULT_CONFIG_FILE = File.expand_path("../config.reek", __FILE__)
 
     def initialize(paths)
-      config = OpenStruct.new(:options => OpenStruct.new(:config_file => DEFAULT_CONFIG_FILE))
+      config = OpenStruct.new(:config_file => DEFAULT_CONFIG_FILE)
       ::Reek::Configuration::AppConfiguration.initialize_with(config)
       super(Array(paths))
     end

--- a/rubycritic.gemspec
+++ b/rubycritic.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "virtus", "~> 1.0"
   spec.add_runtime_dependency "flay", "2.4.0"
   spec.add_runtime_dependency "flog", "4.2.1"
-  spec.add_runtime_dependency "reek", "1.6.5"
+  spec.add_runtime_dependency "reek", "2.0.2"
   spec.add_runtime_dependency "parser", ">= 2.2.0", "< 3.0"
 
   spec.add_development_dependency "bundler", "~> 1.3"


### PR DESCRIPTION
RubyCritic crashes (because Reek crashes) when analyzed code contains a call to `super` with parameters and a block. I hoped Reek 2.0.2 would fix it. It turns out it doesn't, but it's a known bug (troessner/reek#404) and it's slated to be fixed in 2.0.3.

This PR makes RubyCritic work with 2.0.2. I'm not sure how useful it is on its own, but it should make an eventual upgrade to 2.0.3 (or some future version) easier.
