### PR TITLE
Bump reek dependency to ~> 2.0.4

### DIFF
--- a/rubycritic.gemspec
+++ b/rubycritic.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "virtus", "~> 1.0"
   spec.add_runtime_dependency "flay", "2.4.0"
   spec.add_runtime_dependency "flog", "4.2.1"
-  spec.add_runtime_dependency "reek", "2.0.2"
+  spec.add_runtime_dependency "reek", "2.0.4"
   spec.add_runtime_dependency "parser", ">= 2.2.0", "< 3.0"
 
   spec.add_development_dependency "bundler", "~> 1.3"


### PR DESCRIPTION
Bump reek minimum version to 2.0.4 to get a fix for Issue #45.

Also use optimistic version dependency as reek seems to properly use
semantic versioning.