### PR TITLE
adding documentation link for reek smells

### DIFF
--- a/lib/rubycritic/analysers/smells/reek.rb
+++ b/lib/rubycritic/analysers/smells/reek.rb
@@ -5,6 +5,8 @@ module Rubycritic
   module Analyser
 
     class ReekSmells
+      REEK_WIKI = "https://github.com/troessner/reek/wiki/"
+
       def initialize(analysed_modules)
         @analysed_modules = analysed_modules
       end
@@ -25,11 +27,12 @@ module Rubycritic
 
       def create_smell(smell)
         Smell.new(
-          :locations => smell_locations(smell.source, smell.lines),
-          :context   => smell.context,
-          :message   => smell.message,
-          :type      => smell.smell_type,
-          :cost      => 0
+          :locations      => smell_locations(smell.source, smell.lines),
+          :context        => smell.context,
+          :message        => smell.message,
+          :type           => smell.smell_type,
+          :documentation  => smell_documentation(smell.smell_type),
+          :cost           => 0
         )
       end
 
@@ -37,6 +40,10 @@ module Rubycritic
         file_lines.uniq.map do |file_line|
           Location.new(file_path, file_line)
         end.sort
+      end
+
+      def smell_documentation(smell_type)
+        REEK_WIKI + smell_type.gsub(/([a-z\d])([A-Z])/, '\1-\2')
       end
     end
 

--- a/lib/rubycritic/core/smell.rb
+++ b/lib/rubycritic/core/smell.rb
@@ -13,6 +13,7 @@ module Rubycritic
     attribute :score
     attribute :status
     attribute :type
+    attribute :documentation
 
     def at_location?(other_location)
       locations.any? { |location| location == other_location }

--- a/lib/rubycritic/generators/html/templates/smelly_line.html.erb
+++ b/lib/rubycritic/generators/html/templates/smelly_line.html.erb
@@ -3,7 +3,12 @@
 <ul class="nocode smells js-smells">
 <% @smells.each do |smell| %>
   <li class="smell <%= smell.status %>">
-    <span class="description"><%= smell %>
+    <span class="description">
+      <% if smell.documentation %>
+        <a href="<%= smell.documentation %>" target="_blank" ><%= smell %></a>
+      <% else %>
+        <%= smell %>
+      <% end %>
       <% if smell.multiple_locations? %>
         <% smell.locations.each_with_index do |location, index| %>
           <a href="<%= smell_location_path(location) %>" class="js-smell-location"><%= index %></a>

--- a/test/lib/rubycritic/analysers/smells/reek_test.rb
+++ b/test/lib/rubycritic/analysers/smells/reek_test.rb
@@ -17,6 +17,11 @@ describe Rubycritic::Analyser::ReekSmells do
       smell = @analysed_module.smells.first
       smell.message.must_equal "has boolean parameter 'reek'"
     end
+
+    it "has documentation link" do
+      smell = @analysed_module.smells.first
+      smell.documentation.must_equal "https://github.com/troessner/reek/wiki/Boolean-Parameter"
+    end
   end
 
   context "when analysing a file with smells ignored in config.reek" do


### PR DESCRIPTION
It may be helpfull to jump from the smell directly to its documentation to learn more about the smell and get an idea how to fix them. This PR adds therefore links to reek smells. 

The links are defined by the smell type and will point to the reek wiki entries. 

Let me know what you think about this idea ;) 