### PR TITLE
Fix to allow using --mode-ci and --format json at the same time

### DIFF
--- a/lib/rubycritic/generators/json/simple.rb
+++ b/lib/rubycritic/generators/json/simple.rb
@@ -1,4 +1,5 @@
 require "json"
+require "rubycritic/version"
 
 module Rubycritic
   module Generator


### PR DESCRIPTION
When trying to run RubyCritic with both `--mode-ci` and `--format json` I was getting the following exception:

```
/trimmed_rvm_path/gems/rubycritic-1.4.0/lib/rubycritic/generators/json/simple.rb:20:in `data': uninitialized constant Rubycritic::VERSION (NameError)
  from /trimmed_rvm_path/gems/rubycritic-1.4.0/lib/rubycritic/generators/json/simple.rb:13:in `render'
  from /trimmed_rvm_path/gems/rubycritic-1.4.0/lib/rubycritic/generators/json_report.rb:12:in `generate_report'
  from /trimmed_rvm_path/gems/rubycritic-1.4.0/lib/rubycritic/reporter.rb:5:in `generate_report'
  from /trimmed_rvm_path/gems/rubycritic-1.4.0/lib/rubycritic/commands/ci.rb:22:in `report'
  from /trimmed_rvm_path/gems/rubycritic-1.4.0/lib/rubycritic/commands/ci.rb:14:in `execute'
  from /trimmed_rvm_path/gems/rubycritic-1.4.0/lib/rubycritic/cli/application.rb:16:in `execute'
  from /trimmed_rvm_path/gems/rubycritic-1.4.0/bin/rubycritic:5:in `<top (required)>'
  from /trimmed_rvm_path/bin/rubycritic:23:in `load'
  from /trimmed_rvm_path/bin/rubycritic:23:in `<main>'
  from /trimmed_rvm_path/bin/ruby_executable_hooks:15:in `eval'
  from /trimmed_rvm_path/bin/ruby_executable_hooks:15:in `<main>'
```

This simply adds the relevant require to rubycritic/generators/json/simple.rb
