### PR TITLE
Add emacs report

### DIFF
--- a/lib/rubycritic/cli/options.rb
+++ b/lib/rubycritic/cli/options.rb
@@ -19,10 +19,11 @@ module Rubycritic
 
           opts.on(
             "-f", "--format [FORMAT]",
-            [:html, :json],
+            [:html, :json, :emacs],
             "Report smells in the given format:",
             "  html (default)",
-            "  json"
+            "  json",
+            "  emacs"
           ) do |format|
             @format = format
           end

--- a/lib/rubycritic/core/analysed_module.rb
+++ b/lib/rubycritic/core/analysed_module.rb
@@ -8,11 +8,11 @@ module Rubycritic
 
     attribute :name
     attribute :pathname
-    attribute :smells,        Array,   :default => []
+    attribute :smells, Array, :default => []
     attribute :churn
     attribute :committed_at
     attribute :complexity
-    attribute :duplication,   Integer, :default => 0
+    attribute :duplication, Integer, :default => 0
     attribute :methods_count
 
     def path

--- a/lib/rubycritic/core/location.rb
+++ b/lib/rubycritic/core/location.rb
@@ -18,6 +18,10 @@ module Rubycritic
       "#{pathname}:#{line}"
     end
 
+    def to_s_with_realpath
+      "#{pathname.realpath.to_s}:#{line}"
+    end
+
     def to_h
       {
         :path => pathname.to_s,

--- a/lib/rubycritic/core/location.rb
+++ b/lib/rubycritic/core/location.rb
@@ -19,7 +19,7 @@ module Rubycritic
     end
 
     def to_s_with_realpath
-      "#{pathname.realpath.to_s}:#{line}"
+      "#{pathname.realpath}:#{line}"
     end
 
     def to_h

--- a/lib/rubycritic/generators/emacs/render_tool.rb
+++ b/lib/rubycritic/generators/emacs/render_tool.rb
@@ -12,17 +12,20 @@ module Rubycritic
         # render outputs the report in a format that's
         # easy to read in the Emacs and Sublime text editor.
         def render
-          @analysed_modules.each do |analysed_module|
-            analysed_module.smells.each do |smell|
+          render_lines = []
+          @analysed_modules.map do |analysed_module|
+            analysed_module.smells.map do |smell|
               message = "[#{smell.status}] " # "status": "old",
               message << "#{smell.type} - " # "type": "DuplicateCode"
               message << "#{smell.context} " # "context": "Identical code",
               message << "#{smell.message}" # "message": "found in 2 nodes",
-              smell.locations.each do |location|
-                output.printf("%s:%d:%d: %s: %s\n", file, location, 0, "W", message)
+              smell.locations.map do |location|
+                render_lines << "#{location.to_s_with_realpath}:1: W: #{message}"
               end
             end
           end
+          render_lines << ""
+          render_lines.join("\n")
         end
 
       end

--- a/lib/rubycritic/generators/emacs/render_tool.rb
+++ b/lib/rubycritic/generators/emacs/render_tool.rb
@@ -1,0 +1,31 @@
+require "json"
+
+module Rubycritic
+  module Generator
+    module Emacs
+
+      class RenderTool
+        def initialize(analysed_modules)
+          @analysed_modules = analysed_modules
+        end
+
+        # render outputs the report in a format that's
+        # easy to read in the Emacs and Sublime text editor.
+        def render
+          @analysed_modules.each do |analysed_module|
+            analysed_module.smells.each do |smell|
+              message = "[#{smell.status}] " # "status": "old",
+              message << "#{smell.type} - " # "type": "DuplicateCode"
+              message << "#{smell.context} " # "context": "Identical code",
+              message << "#{smell.message}" # "message": "found in 2 nodes",
+              smell.locations.each do |location|
+                output.printf("%s:%d:%d: %s: %s\n", file, location, 0, "W", message)
+              end
+            end
+          end
+        end
+
+      end
+    end
+  end
+end

--- a/lib/rubycritic/generators/emacs_report.rb
+++ b/lib/rubycritic/generators/emacs_report.rb
@@ -1,0 +1,23 @@
+require "rubycritic/generators/emacs/render_tool"
+
+module Rubycritic
+  module Generator
+
+    class EmacsReport
+      def initialize(analysed_modules)
+        @analysed_modules = analysed_modules
+      end
+
+      def generate_report
+        print generator.render
+      end
+
+      private
+
+      def generator
+        Emacs::RenderTool.new(@analysed_modules)
+      end
+    end
+
+  end
+end

--- a/lib/rubycritic/reporter.rb
+++ b/lib/rubycritic/reporter.rb
@@ -10,6 +10,9 @@ module Rubycritic
       when :json
         require "rubycritic/generators/json_report"
         Generator::JsonReport
+      when :emacs
+        require "rubycritic/generators/emacs_report"
+        Generator::EmacsReport
       else
         require "rubycritic/generators/html_report"
         Generator::HtmlReport


### PR DESCRIPTION
Adds emacs report, and allows usage of rubycritic from sublime lint ( https://github.com/pedrocarmona/SublimeLinter-contrib-rubycritic )