### PR TITLE
Update flay, flog and reek dependencies

### DIFF
--- a/lib/rubycritic/analysers/helpers/reek.rb
+++ b/lib/rubycritic/analysers/helpers/reek.rb
@@ -7,11 +7,9 @@ module Rubycritic
   class Reek < ::Reek::Examiner
     DEFAULT_CONFIG_FILE = File.expand_path("../config.reek", __FILE__)
 
-    def initialize(paths)
-      config = OpenStruct.new(:config_file => DEFAULT_CONFIG_FILE)
-      ::Reek::Configuration::AppConfiguration.initialize_with(config)
-      super(Array(paths))
+    def initialize(pathname)
+      config = ::Reek::Configuration::AppConfiguration.from_path(DEFAULT_CONFIG_FILE)
+      super(pathname, [], :configuration => config)
     end
   end
-
 end

--- a/lib/rubycritic/analysers/smells/reek.rb
+++ b/lib/rubycritic/analysers/smells/reek.rb
@@ -18,7 +18,7 @@ module Rubycritic
       private
 
       def add_smells_to(analysed_module)
-        Reek.new(analysed_module.path).smells.each do |smell|
+        Reek.new(analysed_module.pathname).smells.each do |smell|
           analysed_module.smells << create_smell(smell)
         end
       end

--- a/rubycritic.gemspec
+++ b/rubycritic.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.require_path  = "lib"
 
   spec.add_runtime_dependency "virtus", "~> 1.0"
-  spec.add_runtime_dependency "flay", "2.4.0"
+  spec.add_runtime_dependency "flay", "2.6.1"
   spec.add_runtime_dependency "flog", "4.2.1"
   spec.add_runtime_dependency "reek", "2.0.4"
   spec.add_runtime_dependency "parser", ">= 2.2.0", "< 3.0"

--- a/rubycritic.gemspec
+++ b/rubycritic.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "virtus", "~> 1.0"
   spec.add_runtime_dependency "flay", "2.6.1"
-  spec.add_runtime_dependency "flog", "4.2.1"
+  spec.add_runtime_dependency "flog", "4.3.2"
   spec.add_runtime_dependency "reek", "2.0.4"
   spec.add_runtime_dependency "parser", ">= 2.2.0", "< 3.0"
 

--- a/rubycritic.gemspec
+++ b/rubycritic.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "virtus", "~> 1.0"
   spec.add_runtime_dependency "flay", "2.6.1"
   spec.add_runtime_dependency "flog", "4.3.2"
-  spec.add_runtime_dependency "reek", "2.0.4"
+  spec.add_runtime_dependency "reek", "3.6.0"
   spec.add_runtime_dependency "parser", ">= 2.2.0", "< 3.0"
 
   spec.add_development_dependency "bundler", "~> 1.3"

--- a/test/lib/rubycritic/analysers/smells/reek_test.rb
+++ b/test/lib/rubycritic/analysers/smells/reek_test.rb
@@ -4,7 +4,8 @@ require "rubycritic/analysers/smells/reek"
 describe Rubycritic::Analyser::ReekSmells do
   context "when analysing a smelly file" do
     before do
-      @analysed_module = AnalysedModuleDouble.new(:path => "test/samples/reek/smelly.rb", :smells => [])
+      pathname = Pathname.new("test/samples/reek/smelly.rb")
+      @analysed_module = AnalysedModuleDouble.new(:pathname => pathname, :smells => [])
       analysed_modules = [@analysed_module]
       Rubycritic::Analyser::ReekSmells.new(analysed_modules).run
     end
@@ -21,7 +22,8 @@ describe Rubycritic::Analyser::ReekSmells do
 
   context "when analysing a file with smells ignored in config.reek" do
     before do
-      @analysed_module = AnalysedModuleDouble.new(:path => "test/samples/reek/not_smelly.rb", :smells => [])
+      pathname = Pathname.new("test/samples/reek/not_smelly.rb")
+      @analysed_module = AnalysedModuleDouble.new(:pathname => pathname, :smells => [])
       analysed_modules = [@analysed_module]
       Rubycritic::Analyser::ReekSmells.new(analysed_modules).run
     end


### PR DESCRIPTION
We are using rubycritic as part of out automatic review process @ Plataformatec and we have been using this branch with updated dependencies (mostly for `reek` latest changes) for a while and has been running smoothly so far. Anyone looking for an update version of rubycritic can check out this fork and try it locally.

**Update** Reek 3 doesn't support Ruby 1.9, so we have a failed build here. Should that be a no-go for using Reek 3 with RubyCritic here?


Related to #58.