### PR TITLE
Drop support for Ruby 1.9.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,17 @@
+sudo: false
+cache: bundler
 language: ruby
-
+script:
+  - bundle exec rake
 rvm:
-  - 1.9.3
-  - 2.0.0
+  - 2.0
   - 2.1
   - 2.2
-  - jruby
   - rbx-2
+  - jruby
+matrix:
+  allow_failures:
+    - rvm: rbx-2
+    - rvm: jruby
+  fast_finish: true
 
-script: "bundle exec rake"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,15 @@
-sudo: false
-cache: bundler
 language: ruby
-script:
-  - bundle exec rake
+
 rvm:
   - 2.0
   - 2.1
   - 2.2
-  - rbx-2
   - jruby
+  - rbx-2
 matrix:
   allow_failures:
     - rvm: rbx-2
     - rvm: jruby
   fast_finish: true
 
+script: "bundle exec rake"

--- a/README.md
+++ b/README.md
@@ -107,6 +107,19 @@ If you're fond of Guard you might like [guard-rubycritic][4]. It automatically a
 
 For continuous integration, you can give [Jenkins CI][5] a spin. With it, you can [easily build your own (poor-man's) Code Climate][6]!
 
+Compatibility
+---------------
+
+RubyCritic is supporting:
+
+* 2.0
+* 2.1
+* 2.2
+
+Note that we do not support Ruby 1.9 anymore.
+
+If you're still on ruby 1.9 you'll have to use the last version of RubyCritic that supports it, which would be 1.4.0.
+
 Improving RubyCritic
 --------------------
 


### PR DESCRIPTION
Fixes #68 
I'd vote for then having a separate "bump version to 2.0" pull request and then release 2.0 as fast as possible so we can get #67 going ;)