### PR TITLE
Bump version to 2.1.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 2.1.0 / 2015-11-11
+
+* [CHANGE] Bump flay dependency to 2.6.1.
+* [CHANGE] Bump reek dependency to 3.6.0.
+* [CHANGE] Bump flog dependency to 4.3.2.
+
 # 2.0.0 / 2015-11-11
 
 * [CHANGE] Drop support for ruby 1.9

--- a/lib/rubycritic/version.rb
+++ b/lib/rubycritic/version.rb
@@ -1,3 +1,3 @@
 module Rubycritic
-  VERSION = "2.0.0"
+  VERSION = "2.1.0"
 end


### PR DESCRIPTION
We merged #67 so let's get a new version out there.
The dependency bump is significant, 2 + 1 minor version bumps for flay and flog and a major version bump for Reek. This warrants a major version bump in RubyCritic as well in my mind.