### PR TITLE
Bump Reek to 3.8.0 and RubyCritic to 2.4.1.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.4.1 / 2015-12-27
+
+* [CHANGE] Bump Reek to 3.8.1
+
 # 2.4.0 / 2015-12-26
 
 * [FEATURE] Add progress bar functionality (by Nate Holland)

--- a/lib/rubycritic/version.rb
+++ b/lib/rubycritic/version.rb
@@ -1,3 +1,3 @@
 module Rubycritic
-  VERSION = "2.4.0"
+  VERSION = "2.4.1"
 end

--- a/rubycritic.gemspec
+++ b/rubycritic.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "virtus", "~> 1.0"
   spec.add_runtime_dependency "flay", "2.6.1"
   spec.add_runtime_dependency "flog", "4.3.2"
-  spec.add_runtime_dependency "reek", "3.7.1"
+  spec.add_runtime_dependency "reek", "3.8.1"
   spec.add_runtime_dependency "parser", ">= 2.2.0", "< 3.0"
 
   spec.add_development_dependency "bundler", "~> 1.3"


### PR DESCRIPTION
We recently implemented and released a nice new smell detector for [unused private instance methods](https://github.com/troessner/reek/pull/794) and I thought it would be awesome if we had this one in RubyCritic available as well ;)