### PR TITLE
prepend gem lib path when using rubycritic executable

### DIFF
--- a/bin/rubycritic
+++ b/bin/rubycritic
@@ -1,5 +1,9 @@
 #!/usr/bin/env ruby
 
+# Always look in the lib directory of this gem
+# first when searching the load path
+$LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
+
 require "rubycritic/cli/application"
 
 exit Rubycritic::Cli::Application.new(ARGV).execute


### PR DESCRIPTION
This makes it a little easier to do dev on the gem locally by allowing you to call `bin/rubycritic` which will look in your dev copy instead of pulling an installed gem's files