### PR TITLE
delegate Rubycritic.create to CommandFactory

### DIFF
--- a/lib/rubycritic.rb
+++ b/lib/rubycritic.rb
@@ -1,22 +1,7 @@
-require "rubycritic/configuration"
+require "rubycritic/command_factory"
 
 module Rubycritic
   def self.create(options = {})
-    options_hash = options.to_h
-    Config.set(options_hash)
-    case Config.mode
-    when :version
-      require "rubycritic/commands/version"
-      Command::Version.new
-    when :help
-      require "rubycritic/commands/help"
-      Command::Help.new(options.help_text)
-    when :ci
-      require "rubycritic/commands/ci"
-      Command::Ci.new(options_hash[:paths])
-    else
-      require "rubycritic/commands/default"
-      Command::Default.new(options_hash[:paths])
-    end
+    CommandFactory.create(options)
   end
 end

--- a/lib/rubycritic.rb
+++ b/lib/rubycritic.rb
@@ -1,7 +1,4 @@
 require "rubycritic/command_factory"
 
 module Rubycritic
-  def self.create(options = {})
-    CommandFactory.create(options)
-  end
 end

--- a/lib/rubycritic/cli/application.rb
+++ b/lib/rubycritic/cli/application.rb
@@ -1,5 +1,6 @@
 require "rubycritic"
 require "rubycritic/cli/options"
+require "rubycritic/command_factory"
 
 module Rubycritic
   module Cli
@@ -13,7 +14,7 @@ module Rubycritic
 
       def execute
         parsed_options = @options.parse
-        ::Rubycritic.create(parsed_options).execute
+        ::Rubycritic::CommandFactory.create(parsed_options).execute
         STATUS_SUCCESS
       rescue OptionParser::InvalidOption => error
         $stderr.puts "Error: #{error}"

--- a/lib/rubycritic/command_factory.rb
+++ b/lib/rubycritic/command_factory.rb
@@ -1,0 +1,24 @@
+require "rubycritic/configuration"
+
+module Rubycritic
+  class CommandFactory
+    def self.create(options = {})
+      options_hash = options.to_h
+      Config.set(options_hash)
+      case Config.mode
+      when :version
+        require "rubycritic/commands/version"
+        Command::Version.new
+      when :help
+        require "rubycritic/commands/help"
+        Command::Help.new(options.help_text)
+      when :ci
+        require "rubycritic/commands/ci"
+        Command::Ci.new(options_hash[:paths])
+      else
+        require "rubycritic/commands/default"
+        Command::Default.new(options_hash[:paths])
+      end
+    end
+  end
+end


### PR DESCRIPTION
Small suggestion. I kept forgetting that `Rubycritic.create` returned a `Command` instance