### PR TITLE
Add a minimum score option to the command line interface

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,7 @@ AllCops:
     - '**/Rakefile'
   Exclude:
     - 'test/samples/**/*'
+    - 'tmp/**/*'
   # By default, the rails cops are not run. Override in project or home
   # directory .rubocop.yml files, or by giving the -R/--rails option.
   RunRailsCops: false

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ $ rubycritic --help
 |--------------------------|-------------------------------------------------------|
 | `-v/--version`           | Displays the current version and exits                |
 | `-p/--path`              | Sets the output directory (tmp/rubycritic by default) |
+| `-s/--minimum-score`     | Set a minimum score                                   |
 | `--mode-ci`              | Uses CI mode (faster, but only analyses last commit)  |
 | `--deduplicate-symlinks` | De-duplicate symlinks based on their final target     |
 | `--suppress-ratings`     | Suppress letter ratings                               |

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,7 @@
 require "bundler/gem_tasks"
 require "rake/testtask"
 require "rubocop/rake_task"
+require "cucumber/rake/task"
 
 Rake::TestTask.new do |task|
   task.libs.push "lib"
@@ -8,6 +9,10 @@ Rake::TestTask.new do |task|
   task.pattern = "test/**/*_test.rb"
 end
 
+Cucumber::Rake::Task.new(:features) do |t|
+  t.cucumber_opts = "features --format progress --color"
+end
+
 RuboCop::RakeTask.new
 
-task :default => [:test, :rubocop]
+task :default => [:test, :features, :rubocop]

--- a/features/command_line_interface/minimum_score.feature
+++ b/features/command_line_interface/minimum_score.feature
@@ -1,0 +1,39 @@
+Feature: Break if overall score is bellow minimum
+  In order to break the Continuous Integration builds based on a score threshold
+  Rubycritic returns the exit status according with the score
+
+  Scenario: Status indicates a success when not using --minimum-score
+    Given the smelly file 'smelly.rb' with a score of 93.75
+    When I run rubycritic smelly.rb
+    Then the exit status indicates a success
+
+  Scenario: Status indicates an error when score below the minimum
+    Given the smelly file 'smelly.rb' with a score of 93.75
+    When I run rubycritic --minimum-score 100 smelly.rb
+    Then the exit status indicates an error
+
+  Scenario: Status indicates a success when score is above the minimum
+    Given the smelly file 'smelly.rb' with a score of 93.75
+    When I run rubycritic --minimum-score 93 smelly.rb
+    Then the exit status indicates a success
+
+  Scenario: Status indicates a success when score is equal the minimum
+    Given the clean file 'clean.rb' with a score of 100
+    When I run rubycritic --minimum-score 100 clean.rb
+    Then the exit status indicates a success
+
+  Scenario: Prints the score on output
+    Given the smelly file 'smelly.rb' with a score of 93.75
+    When I run rubycritic smelly.rb
+    Then the output should contain:
+    """
+    Score: 93.75
+    """
+
+  Scenario: Prints a message informing the score is below the minimum
+    Given the empty file 'empty.rb' with a score of 0
+    When I run rubycritic --minimum-score 100 empty.rb
+    Then the output should contain:
+    """
+    Score (0.0) is below the minimum 100
+    """

--- a/features/command_line_interface/options.feature
+++ b/features/command_line_interface/options.feature
@@ -1,0 +1,35 @@
+Feature: Rubycritic can be controlled using command-line options
+  In order to change Rubycritic's default behaviour
+  As a developer
+  I want to supply options on the command line
+
+  Scenario: return non-zero status on bad option
+    When I run rubycritic --no-such-option
+    Then the exit status indicates an error
+    And it reports the error "Error: invalid option: --no-such-option"
+    And there is no output on stdout
+
+  Scenario: display the current version number
+    When I run rubycritic --version
+    Then it succeeds
+    And it reports the current version
+
+  Scenario: display the help information
+    When I run rubycritic --help
+    Then it succeeds
+    And it reports:
+      """
+      Usage: rubycritic [options] [paths]
+          -p, --path [PATH]                Set path where report will be saved (tmp/rubycritic by default)
+          -f, --format [FORMAT]            Report smells in the given format:
+                                             html (default)
+                                             json
+                                             console
+          -s, --minimum-score [MIN_SCORE]  Set a minimum score
+          -m, --mode-ci                    Use CI mode (faster, but only analyses last commit)
+              --deduplicate-symlinks       De-duplicate symlinks based on their final target
+              --suppress-ratings           Suppress letter ratings
+          -v, --version                    Show gem's version
+          -h, --help                       Show this message
+
+      """

--- a/features/step_definitions/rubycritic_steps.rb
+++ b/features/step_definitions/rubycritic_steps.rb
@@ -1,0 +1,31 @@
+When(/^I run rubycritic (.*)$/) do |args|
+  rubycritic(args)
+end
+
+Then(/^the exit status indicates an error$/) do
+  expect(last_command_started).to have_exit_status(Rubycritic::Command::StatusReporter::SCORE_BELOW_MINIMUM)
+end
+
+Then(/^the exit status indicates a success$/) do
+  expect(last_command_started).to have_exit_status(Rubycritic::Command::StatusReporter::SUCCESS)
+end
+
+Then(/^it reports:$/) do |report|
+  expect(last_command_started).to have_output_on_stdout(report.gsub('\n', "\n"))
+end
+
+Then(/^there is no output on stdout$/) do
+  expect(last_command_started).to have_output_on_stdout("")
+end
+
+Then(/^it reports the current version$/) do
+  expect(last_command_started).to have_output("RubyCritic #{Rubycritic::VERSION}\n")
+end
+
+Then(/^it reports the error ['"](.*)['"]$/) do |string|
+  expect(last_command_started).to have_output_on_stderr(/#{Regexp.escape(string)}/)
+end
+
+Then(/^it succeeds$/) do
+  expect(last_command_started).to have_exit_status(Rubycritic::Command::StatusReporter::SUCCESS)
+end

--- a/features/step_definitions/sample_file_steps.rb
+++ b/features/step_definitions/sample_file_steps.rb
@@ -1,0 +1,30 @@
+Given(/^the smelly file 'smelly.rb'/) do
+  contents = <<-EOS.strip_heredoc
+    class AllTheMethods
+      def method_missing(method, *args, &block)
+        message = "I"
+        eval "message = ' did not'"
+        eval "message << ' exist,'"
+        eval "message << ' but now'"
+        eval "message << ' I do.'"
+        self.class.send(:define_method, method) { "I did not exist, but now I do." }
+        self.send(method)
+      end
+    end
+  EOS
+  write_file("smelly.rb", contents)
+end
+
+Given(/^the clean file 'clean.rb'/) do
+  contents = <<-EOS.strip_heredoc
+    # Explanatory comment
+    class Clean
+      def foo; end
+    end
+  EOS
+  write_file("clean.rb", contents)
+end
+
+Given(/^the empty file 'empty.rb'/) do
+  write_file("clean.rb", "")
+end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,0 +1,31 @@
+require_relative "../../lib/rubycritic"
+require_relative "../../lib/rubycritic/cli/application"
+require_relative "../../lib/rubycritic/commands/status_reporter"
+require "aruba/cucumber"
+require "minitest/spec"
+
+#
+# Provides runner methods used in the cucumber steps.
+#
+class RubycriticWorld
+  extend MiniTest::Assertions
+  attr_accessor :assertions
+
+  def initialize
+    self.assertions = 0
+  end
+
+  def rubycritic(args)
+    run_simple("rubycritic #{args}", false)
+  end
+end
+
+World do
+  RubycriticWorld.new
+end
+
+Before do
+  Aruba.configure do |config|
+    config.exit_timeout = 30
+  end
+end

--- a/lib/rubycritic/cli/application.rb
+++ b/lib/rubycritic/cli/application.rb
@@ -14,11 +14,17 @@ module Rubycritic
 
       def execute
         parsed_options = @options.parse
-        ::Rubycritic::CommandFactory.create(parsed_options).execute
-        STATUS_SUCCESS
+
+        reporter = Rubycritic::CommandFactory.create(parsed_options.to_h).execute
+        print(reporter.status_message)
+        reporter.status
       rescue OptionParser::InvalidOption => error
         $stderr.puts "Error: #{error}"
         STATUS_ERROR
+      end
+
+      def print(message)
+        $stdout.puts message
       end
     end
   end

--- a/lib/rubycritic/cli/options.rb
+++ b/lib/rubycritic/cli/options.rb
@@ -27,6 +27,10 @@ module Rubycritic
             @format = format
           end
 
+          opts.on("-s", "--minimum-score [MIN_SCORE]", "Set a minimum score") do |min_score|
+            @minimum_score = Integer(min_score)
+          end
+
           opts.on("-m", "--mode-ci", "Use CI mode (faster, but only analyses last commit)") do
             @mode = :ci
           end
@@ -50,10 +54,6 @@ module Rubycritic
         self
       end
 
-      def help_text
-        @parser.help
-      end
-
       def to_h
         {
           :mode => @mode,
@@ -61,7 +61,9 @@ module Rubycritic
           :format => @format,
           :deduplicate_symlinks => @deduplicate_symlinks,
           :paths => paths,
-          :suppress_ratings => @suppress_ratings
+          :suppress_ratings => @suppress_ratings,
+          :help_text => @parser.help,
+          :minimum_score => @minimum_score || 0
         }
       end
 

--- a/lib/rubycritic/command_factory.rb
+++ b/lib/rubycritic/command_factory.rb
@@ -3,21 +3,24 @@ require "rubycritic/configuration"
 module Rubycritic
   class CommandFactory
     def self.create(options = {})
-      options_hash = options.to_h
-      Config.set(options_hash)
-      case Config.mode
+      Config.set(options)
+      command_class(Config.mode).new(options)
+    end
+
+    def self.command_class(mode)
+      case mode
       when :version
         require "rubycritic/commands/version"
-        Command::Version.new
+        Command::Version
       when :help
         require "rubycritic/commands/help"
-        Command::Help.new(options.help_text)
+        Command::Help
       when :ci
         require "rubycritic/commands/ci"
-        Command::Ci.new(options_hash[:paths])
+        Command::Ci
       else
         require "rubycritic/commands/default"
-        Command::Default.new(options_hash[:paths])
+        Command::Default
       end
     end
   end

--- a/lib/rubycritic/commands/base.rb
+++ b/lib/rubycritic/commands/base.rb
@@ -1,0 +1,16 @@
+require "rubycritic/commands/status_reporter"
+
+module Rubycritic
+  module Command
+    class Base
+      def initialize(options)
+        @options = options
+        @status_reporter = Rubycritic::Command::StatusReporter.new(@options)
+      end
+
+      def execute
+        raise NotImplementedError
+      end
+    end
+  end
+end

--- a/lib/rubycritic/commands/ci.rb
+++ b/lib/rubycritic/commands/ci.rb
@@ -1,25 +1,13 @@
 require "rubycritic/source_control_systems/base"
 require "rubycritic/analysers_runner"
 require "rubycritic/reporter"
+require "rubycritic/commands/default"
 
 module Rubycritic
   module Command
-    class Ci
-      def initialize(paths)
-        @paths = paths
-        Config.source_control_system = SourceControlSystem::Base.create
-      end
-
-      def execute
-        report(critique)
-      end
-
+    class Ci < Default
       def critique
         AnalysersRunner.new(@paths).run
-      end
-
-      def report(analysed_modules)
-        Reporter.generate_report(analysed_modules)
       end
     end
   end

--- a/lib/rubycritic/commands/default.rb
+++ b/lib/rubycritic/commands/default.rb
@@ -2,17 +2,20 @@ require "rubycritic/source_control_systems/base"
 require "rubycritic/analysers_runner"
 require "rubycritic/revision_comparator"
 require "rubycritic/reporter"
+require "rubycritic/commands/base"
 
 module Rubycritic
   module Command
-    class Default
-      def initialize(paths)
-        @paths = paths
+    class Default < Base
+      def initialize(options)
+        super
+        @paths = options[:paths]
         Config.source_control_system = SourceControlSystem::Base.create
       end
 
       def execute
         report(critique)
+        @status_reporter
       end
 
       def critique
@@ -22,6 +25,7 @@ module Rubycritic
 
       def report(analysed_modules)
         Reporter.generate_report(analysed_modules)
+        @status_reporter.score = analysed_modules.score
       end
     end
   end

--- a/lib/rubycritic/commands/help.rb
+++ b/lib/rubycritic/commands/help.rb
@@ -1,12 +1,11 @@
+require "rubycritic/commands/base"
+
 module Rubycritic
   module Command
-    class Help
-      def initialize(help_text)
-        @help_text = help_text
-      end
-
+    class Help < Base
       def execute
-        puts @help_text
+        puts @options[:help_text]
+        @status_reporter
       end
     end
   end

--- a/lib/rubycritic/commands/status_reporter.rb
+++ b/lib/rubycritic/commands/status_reporter.rb
@@ -1,0 +1,43 @@
+module Rubycritic
+  module Command
+    class StatusReporter
+      attr_reader :status, :status_message
+      SUCCESS = 0
+      SCORE_BELOW_MINIMUM = 1
+
+      def initialize(options)
+        @options = options
+        @status = SUCCESS
+      end
+
+      def score=(score)
+        @score = score
+        update_status
+      end
+
+      private
+
+      def update_status
+        @status = current_status
+        update_status_message
+      end
+
+      def current_status
+        satisfy_minimum_score_rule ? SUCCESS : SCORE_BELOW_MINIMUM
+      end
+
+      def satisfy_minimum_score_rule
+        @score >= @options[:minimum_score]
+      end
+
+      def update_status_message
+        case @status
+        when SUCCESS
+          @status_message = "Score: #{@score}"
+        when SCORE_BELOW_MINIMUM
+          @status_message = "Score (#{@score}) is below the minimum #{@options[:minimum_score]}"
+        end
+      end
+    end
+  end
+end

--- a/lib/rubycritic/commands/version.rb
+++ b/lib/rubycritic/commands/version.rb
@@ -1,10 +1,12 @@
 require "rubycritic/version"
+require "rubycritic/commands/base"
 
 module Rubycritic
   module Command
-    class Version
+    class Version < Base
       def execute
         puts "RubyCritic #{VERSION}"
+        @status_reporter
       end
     end
   end

--- a/rubycritic.gemspec
+++ b/rubycritic.gemspec
@@ -26,7 +26,9 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "reek", "3.8.1"
   spec.add_runtime_dependency "parser", ">= 2.2.0", "< 3.0"
 
+  spec.add_development_dependency "aruba"
   spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_development_dependency "cucumber"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "minitest", "~> 5.3"
   spec.add_development_dependency "mocha", "~> 1.0"

--- a/test/lib/rubycritic/commands/status_reporter_test.rb
+++ b/test/lib/rubycritic/commands/status_reporter_test.rb
@@ -1,0 +1,67 @@
+require "test_helper"
+require "rubycritic/commands/status_reporter"
+require "rubycritic/cli/options"
+
+describe Rubycritic::Command::StatusReporter do
+  let(:success_status) { Rubycritic::Command::StatusReporter::SUCCESS }
+  let(:score_below_minimum) { Rubycritic::Command::StatusReporter::SCORE_BELOW_MINIMUM }
+
+  describe "with default options" do
+    before do
+      @options = Rubycritic::Cli::Options.new([])
+      @options.parse
+      @reporter = Rubycritic::Command::StatusReporter.new(@options.to_h)
+    end
+
+    it "has a default" do
+      @reporter.status.must_equal success_status
+      @reporter.status_message.must_be_nil
+    end
+
+    it "accept a score" do
+      @reporter.score = 50
+      @reporter.status.must_equal success_status
+      @reporter.status_message.must_equal "Score: 50"
+    end
+  end
+
+  describe "with minimum-score option" do
+    before do
+      @options = Rubycritic::Cli::Options.new(["-s", "99"])
+      @options.parse
+      @reporter = Rubycritic::Command::StatusReporter.new(@options.to_h)
+    end
+
+    it "has a default" do
+      @reporter.status.must_equal success_status
+      @reporter.status_message.must_be_nil
+    end
+
+    describe "when score is below minimum" do
+      let(:score) { 98 }
+      it "should return the correct status" do
+        @reporter.score = score
+        @reporter.status.must_equal score_below_minimum
+        @reporter.status_message.must_equal "Score (98) is below the minimum 99"
+      end
+    end
+
+    describe "when score is equal the minimum" do
+      let(:score) { 99 }
+      it "should return the correct status" do
+        @reporter.score = score
+        @reporter.status.must_equal success_status
+        @reporter.status_message.must_equal "Score: 99"
+      end
+    end
+
+    describe "when score is above the minimum" do
+      let(:score) { 100 }
+      it "should return the correct status" do
+        @reporter.score = score
+        @reporter.status.must_equal success_status
+        @reporter.status_message.must_equal "Score: 100"
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is the first step for #98. It work, but, I'm not completely happy with some choices, maybe you can provide some nice suggestions :)

First of all, I'm assuming that the responsibility for the exit code should be in the cli, not in the lib itself. Also, the minimum score feature belongs to the cli and not the lib itself. So, I think it is plausible to expect the lib commands to return the score. The problem with that is not all commands will have a score (eg. --help), so, it's not a great solution. Anyway, I implemented that way for now. Any suggestions are welcome.

I made a change in the CI command, now it inherit from the default command and overrides the `critique` method (The only difference between them). I made this to remove some code duplication. I don't know if this was the best thing to do, so, a feedback will be appreciated.
 

