### PR TITLE
Fix Rubycritic's Analysers running twice on the first run

### DIFF
--- a/rubycritic.gemspec
+++ b/rubycritic.gemspec
@@ -33,6 +33,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'cucumber'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'minitest', '~> 5.3'
-  spec.add_development_dependency 'mocha', '~> 1.0'
+  spec.add_development_dependency 'mocha', '~> 1.1'
   spec.add_development_dependency 'rubocop', '0.36.0'
 end

--- a/test/lib/rubycritic/revision_comparator_test.rb
+++ b/test/lib/rubycritic/revision_comparator_test.rb
@@ -1,0 +1,64 @@
+require 'test_helper'
+require 'rubycritic/revision_comparator'
+
+describe Rubycritic::RevisionComparator do
+  subject { Rubycritic::RevisionComparator.new([]) }
+
+  describe '#set_statuses' do
+    context 'in a SCS with :revision? == false' do
+      before do
+        Rubycritic::Config.expects(:source_control_system)
+                          .at_least_once
+                          .returns(stub(revision?: false))
+      end
+
+      it 'does not attempt to compare with previous results' do
+        subject.expects(:load_cached_analysed_modules).never
+        result = subject.set_statuses([])
+        result.must_equal([])
+      end
+    end
+
+    context 'in a SCS with :revision? == true' do
+      before do
+        Rubycritic::Config.expects(:source_control_system)
+                          .at_least_once
+                          .returns(stub(revision?: true))
+      end
+
+      context 'without previously cached results' do
+        before do
+          subject.expects(:revision_file).returns('foo')
+          File.expects(:file?).with('foo').returns(false)
+        end
+
+        it 'does not load them' do
+          Rubycritic::Serializer.expects(:new).never
+          subject.set_statuses([])
+        end
+
+        it 'does not invoke Rubycritic::SmellsStatusSetter' do
+          Rubycritic::SmellsStatusSetter.expects(:set).never
+          subject.set_statuses([])
+        end
+      end
+
+      context 'with previously cached results' do
+        before do
+          subject.expects(:revision_file).twice.returns('foo')
+          File.expects(:file?).with('foo').returns(true)
+          Rubycritic::Serializer.expects(:new).with('foo').returns(stub(load: []))
+        end
+
+        it 'loads them' do
+          subject.set_statuses([])
+        end
+
+        it 'invokes Rubycritic::SmellsStatusSetter' do
+          Rubycritic::SmellsStatusSetter.expects(:set).once
+          subject.set_statuses([])
+        end
+      end
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,6 @@
 require 'minitest/autorun'
 require 'minitest/pride'
-require 'mocha/setup'
+require 'mocha/mini_test'
 require 'ostruct'
 
 def context(*args, &block)


### PR DESCRIPTION
Fix #94 

This changes `RevisionComparator` so that it does not attempt any comparison if there is nothing to compare to!