### PR TITLE
Make JRuby an allowed failure.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ env:
 matrix:
   allow_failures:
     - rvm: ruby-head
+    - rvm: jruby-9.0.5.0
     - rvm: rbx-3
   fast_finish: true
 


### PR DESCRIPTION
I believe we missed that when we recently worked on our travis config. Jruby should always be an allowed failure. This will also make #127 green.