### PR TITLE
Specify runtime dependency on ruby_parser for ruby 2.3 support and other fixes

### DIFF
--- a/rubycritic.gemspec
+++ b/rubycritic.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'flog', '4.3.2'
   spec.add_runtime_dependency 'reek', '3.11'
   spec.add_runtime_dependency 'parser', '~> 2.3'
+  spec.add_runtime_dependency 'ruby_parser', '~> 3.8'
   spec.add_runtime_dependency 'colorize'
   spec.add_runtime_dependency 'launchy', '2.4.3'
 


### PR DESCRIPTION
Related to https://github.com/whitesmith/rubycritic/issues/117#issuecomment-189880517