### PR TITLE
Move smell deactivation from comment to config.

### DIFF
--- a/.todo.reek
+++ b/.todo.reek
@@ -77,6 +77,7 @@ DuplicateMethodCall:
   - Parser::AST::Node#module_name
 TooManyStatements:
   exclude:
+  - Rubycritic::RakeTask#initialize
   - Rubycritic::Analyser::Complexity#run
   - Parser::AST::Node#get_module_names
   - Rubycritic::Analyser::FlaySmells#run

--- a/lib/rubycritic/rake_task.rb
+++ b/lib/rubycritic/rake_task.rb
@@ -19,7 +19,6 @@ module Rubycritic
   #     task.paths = FileList['lib/**/*.rb', 'spec/**/*.rb']
   #   end
   #
-  # :reek:TooManyStatements: { max_statements: 6 }
   class RakeTask < ::Rake::TaskLib
     # Name of RubyCritic task. Defaults to :rubycritic.
     attr_writer :name


### PR DESCRIPTION
It's the only place where we do this (cause i put it there because of an error of judgement), should be in the configuration file where all the others are.