### PR TITLE
allow to use rubocop 0.40.0

### DIFF
--- a/rubycritic.gemspec
+++ b/rubycritic.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'flay', '2.7.0'
   spec.add_runtime_dependency 'flog', '4.3.2'
   spec.add_runtime_dependency 'reek', '4.0.1'
-  spec.add_runtime_dependency 'parser', '2.3.0.7'
+  spec.add_runtime_dependency 'parser', '2.3.1.0'
   spec.add_runtime_dependency 'ruby_parser', '~> 3.8'
   spec.add_runtime_dependency 'colorize'
   spec.add_runtime_dependency 'launchy', '2.4.3'


### PR DESCRIPTION
`rubocop` 0.40.0 requiers `parser` of more than 2.3.1.0.

Ref: https://github.com/bbatsov/rubocop/commit/2c050259d8685ea09a25b4ac327dd07c95d59a15