### PR TITLE
Fix Ruby[Cc]ritic case in rake task examples.

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Rubycritic::RakeTask.new
 A more sophisticated Rake task that would make use of all available configuration options could look like this:
 
 ```ruby
-RubyCritic::RakeTask.new do |task|
+Rubycritic::RakeTask.new do |task|
   # Name of RubyCritic task. Defaults to :rubycritic.
   task.name    = 'something_special'
 
@@ -172,7 +172,7 @@ RubyCritic will try to open the generated report with a browser by default. If y
 you can prevent this behaviour by setting the options correspondingly:
 
 ```ruby
-RubyCritic::RakeTask.new do |task|
+Rubycritic::RakeTask.new do |task|
   task.options = '--no-browser'
 end
 ```

--- a/lib/rubycritic/rake_task.rb
+++ b/lib/rubycritic/rake_task.rb
@@ -15,7 +15,7 @@ module Rubycritic
   #
   #   require 'rubycritic/rake_task'
   #
-  #   RubyCritic::RakeTask.new do |task|
+  #   Rubycritic::RakeTask.new do |task|
   #     task.paths = FileList['lib/**/*.rb', 'spec/**/*.rb']
   #   end
   #


### PR DESCRIPTION
The Rake task examples used `RubyCritic` as the module name, when it should be `Rubycritic`.

Using the uppercase version would result in the error message:
```
NameError: uninitialized constant RubyCritic
```