### PR TITLE
Eliminate RuboCop offenses to make CI build pass.

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -34,3 +34,9 @@ Style/ClassVars:
 # SupportedStyles: use_perl_names, use_english_names
 Style/SpecialGlobalVars:
   Enabled: false
+
+# Offense count: 1
+Style/MethodMissing:
+  Exclude: 
+    - 'lib/rubycritic/configuration.rb'
+

--- a/.todo.reek
+++ b/.todo.reek
@@ -136,3 +136,6 @@ UncommunicativeParameterName:
 ClassVariable:
   exclude:
   - Rubycritic::SourceControlSystem::Base
+BooleanParameter: 
+  exclude:
+  - Rubycritic::Config#self.respond_to_missing?

--- a/lib/rubycritic/configuration.rb
+++ b/lib/rubycritic/configuration.rb
@@ -31,5 +31,9 @@ module Rubycritic
     def self.method_missing(method, *args, &block)
       configuration.public_send(method, *args, &block)
     end
+
+    def self.respond_to_missing?(symbol, include_all = false)
+      configuration.respond_to_missing?(symbol) || super
+    end
   end
 end

--- a/lib/rubycritic/core/analysed_module.rb
+++ b/lib/rubycritic/core/analysed_module.rb
@@ -27,7 +27,7 @@ module Rubycritic
     end
 
     def complexity_per_method
-      if methods_count == 0
+      if methods_count.zero?
         'N/A'
       else
         complexity.fdiv(methods_count).round(1)


### PR DESCRIPTION
```
lib/rubycritic/configuration.rb:31:5: C: When using method_missing, define respond_to_missing? and fall back on super.

    def self.method_missing(method, *args, &block) ...

    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

lib/rubycritic/core/analysed_module.rb:30:10: C: Use methods_count.zero? instead of methods_count == 0.

      if methods_count == 0

         ^^^^^^^^^^^^^^^^^^
```
1) Disabled `Style/MethodMissing` check for that method.
2) Changed `methods_count == 0` to `methods_count.zero?`