### PR TITLE
Save json report to file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ rdoc
 spec/reports
 test/tmp
 test/version_tmp
+test/samples/report.json
 tmp
 .idea/
 .ruby-gemset

--- a/lib/rubycritic/generators/json/simple.rb
+++ b/lib/rubycritic/generators/json/simple.rb
@@ -1,5 +1,6 @@
 require 'json'
 require 'rubycritic/version'
+require 'pathname'
 
 module RubyCritic
   module Generator
@@ -8,6 +9,8 @@ module RubyCritic
         def initialize(analysed_modules)
           @analysed_modules = analysed_modules
         end
+
+        FILE_NAME = 'report.json'.freeze
 
         def render
           JSON.dump(data)
@@ -23,6 +26,14 @@ module RubyCritic
             analysed_modules: @analysed_modules,
             score: @analysed_modules.score
           }
+        end
+
+        def file_directory
+          @file_directory ||= Pathname.new(Config.root)
+        end
+
+        def file_pathname
+          Pathname.new(file_directory).join FILE_NAME
         end
       end
     end

--- a/lib/rubycritic/generators/json_report.rb
+++ b/lib/rubycritic/generators/json_report.rb
@@ -8,7 +8,10 @@ module RubyCritic
       end
 
       def generate_report
-        print generator.render
+        FileUtils.mkdir_p(generator.file_directory)
+        File.open(generator.file_pathname, 'w+') do |file|
+          file.write(generator.render)
+        end
       end
 
       private

--- a/rubycritic.gemspec
+++ b/rubycritic.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'aruba'
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'cucumber'
+  spec.add_development_dependency 'fakefs'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'minitest', '~> 5.3'
   spec.add_development_dependency 'mocha', '~> 1.1'

--- a/test/lib/rubycritic/generators/json_report_test.rb
+++ b/test/lib/rubycritic/generators/json_report_test.rb
@@ -1,0 +1,36 @@
+require 'test_helper'
+require 'rubycritic/core/analysed_modules_collection'
+require 'rubycritic/generators/json_report'
+require 'json'
+require 'fakefs/safe'
+
+describe RubyCritic::Generator::JsonReport do
+  describe '#generate_report' do
+    before(:each) do
+      FakeFS.activate!
+      create_analysed_modules_collection
+      generate_report
+    end
+
+    after(:each) { FakeFS.deactivate! }
+
+    it 'creates a report.json file' do
+      assert File.file?('test/samples/report.json'), 'expected report.json file to be created'
+    end
+
+    it 'report file has data inside' do
+      data = File.read('test/samples/report.json')
+      assert data != '', 'expected report file not to be empty'
+    end
+  end
+
+  def create_analysed_modules_collection
+    @analysed_modules_collection = RubyCritic::AnalysedModulesCollection.new('test/samples/')
+    RubyCritic::Config.root = 'test/samples'
+  end
+
+  def generate_report
+    report = RubyCritic::Generator::JsonReport.new(@analysed_modules_collection)
+    report.generate_report
+  end
+end


### PR DESCRIPTION
Hello!

I need to post-process json data generated in report which is not possible because now json data is printed to console. That's why I added a feature that creates a file 'report.json' in Config.root directory and saves json data there.

Tell me whether this feature needs testing.

With respect, Mykyta Troianov.