### PR TITLE
Update reek version and flog/flay/rubocop

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 source 'https://rubygems.org'
 
 # Specify your gem's dependencies in rubycritic.gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'bundler/gem_tasks'
 require 'rake/testtask'
 require 'rubocop/rake_task'

--- a/bin/rubycritic
+++ b/bin/rubycritic
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 # Always look in the lib directory of this gem
 # first when searching the load path

--- a/features/step_definitions/rake_task_steps.rb
+++ b/features/step_definitions/rake_task_steps.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 When(/^I run rake (\w*) with:$/) do |name, task_def|
   rake(name, task_def)
 end

--- a/features/step_definitions/rubycritic_steps.rb
+++ b/features/step_definitions/rubycritic_steps.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 When(/^I run rubycritic (.*)$/) do |args|
   rubycritic(args)
 end

--- a/features/step_definitions/sample_file_steps.rb
+++ b/features/step_definitions/sample_file_steps.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 Given(/^the smelly file 'smelly.rb'/) do
   contents = <<-EOS.strip_heredoc
     class AllTheMethods

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative '../../lib/rubycritic'
 require_relative '../../lib/rubycritic/cli/application'
 require_relative '../../lib/rubycritic/commands/status_reporter'

--- a/lib/rubycritic.rb
+++ b/lib/rubycritic.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'rubycritic/command_factory'
 
 module RubyCritic

--- a/lib/rubycritic/analysers/attributes.rb
+++ b/lib/rubycritic/analysers/attributes.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'rubycritic/analysers/helpers/methods_counter'
 require 'rubycritic/analysers/helpers/modules_locator'
 require 'rubycritic/colorize'

--- a/lib/rubycritic/analysers/churn.rb
+++ b/lib/rubycritic/analysers/churn.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'rubycritic/colorize'
 
 module RubyCritic

--- a/lib/rubycritic/analysers/complexity.rb
+++ b/lib/rubycritic/analysers/complexity.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'rubycritic/analysers/helpers/flog'
 require 'rubycritic/colorize'
 

--- a/lib/rubycritic/analysers/helpers/ast_node.rb
+++ b/lib/rubycritic/analysers/helpers/ast_node.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Parser
   module AST
     class Node

--- a/lib/rubycritic/analysers/helpers/flay.rb
+++ b/lib/rubycritic/analysers/helpers/flay.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'flay'
 
 module RubyCritic

--- a/lib/rubycritic/analysers/helpers/flog.rb
+++ b/lib/rubycritic/analysers/helpers/flog.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'flog'
 
 module RubyCritic

--- a/lib/rubycritic/analysers/helpers/methods_counter.rb
+++ b/lib/rubycritic/analysers/helpers/methods_counter.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'rubycritic/analysers/helpers/parser'
 
 module RubyCritic

--- a/lib/rubycritic/analysers/helpers/modules_locator.rb
+++ b/lib/rubycritic/analysers/helpers/modules_locator.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'rubycritic/analysers/helpers/parser'
 
 module RubyCritic

--- a/lib/rubycritic/analysers/helpers/parser.rb
+++ b/lib/rubycritic/analysers/helpers/parser.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'parser/current'
 require 'rubycritic/analysers/helpers/ast_node'
 

--- a/lib/rubycritic/analysers/helpers/reek.rb
+++ b/lib/rubycritic/analysers/helpers/reek.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'reek'
 
 module RubyCritic

--- a/lib/rubycritic/analysers/smells/flay.rb
+++ b/lib/rubycritic/analysers/smells/flay.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'rubycritic/analysers/helpers/flay'
 require 'rubycritic/core/smell'
 require 'rubycritic/colorize'

--- a/lib/rubycritic/analysers/smells/flog.rb
+++ b/lib/rubycritic/analysers/smells/flog.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'rubycritic/analysers/helpers/flog'
 require 'rubycritic/core/smell'
 require 'rubycritic/colorize'

--- a/lib/rubycritic/analysers/smells/reek.rb
+++ b/lib/rubycritic/analysers/smells/reek.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'rubycritic/analysers/helpers/reek'
 require 'rubycritic/core/smell'
 require 'rubycritic/colorize'

--- a/lib/rubycritic/analysers_runner.rb
+++ b/lib/rubycritic/analysers_runner.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'rubycritic/core/analysed_modules_collection'
 require 'rubycritic/analysers/smells/flay'
 require 'rubycritic/analysers/smells/flog'

--- a/lib/rubycritic/browser.rb
+++ b/lib/rubycritic/browser.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'launchy'
 
 module RubyCritic

--- a/lib/rubycritic/cli/application.rb
+++ b/lib/rubycritic/cli/application.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'rubycritic'
 require 'rubycritic/cli/options'
 require 'rubycritic/command_factory'

--- a/lib/rubycritic/cli/options.rb
+++ b/lib/rubycritic/cli/options.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'optparse'
 require 'rubycritic/browser'
 
@@ -6,12 +7,12 @@ module RubyCritic
     class Options
       def initialize(argv)
         @argv = argv
-        @parser = OptionParser.new
+        self.parser = OptionParser.new
       end
 
       # rubocop:disable Metrics/MethodLength
       def parse
-        @parser.new do |opts|
+        parser.new do |opts|
           opts.banner = 'Usage: rubycritic [options] [paths]'
 
           opts.on('-p', '--path [PATH]', 'Set path where report will be saved (tmp/rubycritic by default)') do |path|
@@ -26,35 +27,35 @@ module RubyCritic
             '  json',
             '  console'
           ) do |format|
-            @format = format
+            self.format = format
           end
 
           opts.on('-s', '--minimum-score [MIN_SCORE]', 'Set a minimum score') do |min_score|
-            @minimum_score = Integer(min_score)
+            self.minimum_score = Integer(min_score)
           end
 
           opts.on('-m', '--mode-ci', 'Use CI mode (faster, but only analyses last commit)') do
-            @mode = :ci
+            self.mode = :ci
           end
 
           opts.on('--deduplicate-symlinks', 'De-duplicate symlinks based on their final target') do
-            @deduplicate_symlinks = true
+            self.deduplicate_symlinks = true
           end
 
           opts.on('--suppress-ratings', 'Suppress letter ratings') do
-            @suppress_ratings = true
+            self.suppress_ratings = true
           end
 
           opts.on('--no-browser', 'Do not open html report with browser') do
-            @no_browser = true
+            self.no_browser = true
           end
 
           opts.on_tail('-v', '--version', "Show gem's version") do
-            @mode = :version
+            self.mode = :version
           end
 
           opts.on_tail('-h', '--help', 'Show this message') do
-            @mode = :help
+            self.mode = :help
           end
         end.parse!(@argv)
         self
@@ -62,20 +63,22 @@ module RubyCritic
 
       def to_h
         {
-          mode: @mode,
-          root: @root,
-          format: @format,
-          deduplicate_symlinks: @deduplicate_symlinks,
+          mode: mode,
+          root: root,
+          format: format,
+          deduplicate_symlinks: deduplicate_symlinks,
           paths: paths,
-          suppress_ratings: @suppress_ratings,
-          help_text: @parser.help,
-          minimum_score: @minimum_score || 0,
-          no_browser: @no_browser
+          suppress_ratings: suppress_ratings,
+          help_text: parser.help,
+          minimum_score: minimum_score || 0,
+          no_browser: no_browser
         }
       end
 
       private
 
+      attr_accessor :mode, :root, :format, :deduplicate_symlinks,
+                    :suppress_ratings, :minimum_score, :no_browser, :parser
       def paths
         if @argv.empty?
           ['.']

--- a/lib/rubycritic/colorize.rb
+++ b/lib/rubycritic/colorize.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module RubyCritic
   module Colorize
     def colorize(text, color_code)

--- a/lib/rubycritic/command_factory.rb
+++ b/lib/rubycritic/command_factory.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'rubycritic/configuration'
 
 module RubyCritic

--- a/lib/rubycritic/commands/base.rb
+++ b/lib/rubycritic/commands/base.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'rubycritic/commands/status_reporter'
 
 module RubyCritic

--- a/lib/rubycritic/commands/ci.rb
+++ b/lib/rubycritic/commands/ci.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'rubycritic/source_control_systems/base'
 require 'rubycritic/analysers_runner'
 require 'rubycritic/reporter'
@@ -7,8 +8,12 @@ module RubyCritic
   module Command
     class Ci < Default
       def critique
-        AnalysersRunner.new(@paths).run
+        AnalysersRunner.new(paths).run
       end
+
+      private
+
+      attr_reader :paths
     end
   end
 end

--- a/lib/rubycritic/commands/default.rb
+++ b/lib/rubycritic/commands/default.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'rubycritic/source_control_systems/base'
 require 'rubycritic/analysers_runner'
 require 'rubycritic/revision_comparator'
@@ -15,18 +16,22 @@ module RubyCritic
 
       def execute
         report(critique)
-        @status_reporter
+        status_reporter
       end
 
       def critique
-        analysed_modules = AnalysersRunner.new(@paths).run
-        RevisionComparator.new(@paths).set_statuses(analysed_modules)
+        analysed_modules = AnalysersRunner.new(paths).run
+        RevisionComparator.new(paths).set_statuses(analysed_modules)
       end
 
       def report(analysed_modules)
         Reporter.generate_report(analysed_modules)
-        @status_reporter.score = analysed_modules.score
+        status_reporter.score = analysed_modules.score
       end
+
+      private
+
+      attr_reader :paths, :status_reporter
     end
   end
 end

--- a/lib/rubycritic/commands/help.rb
+++ b/lib/rubycritic/commands/help.rb
@@ -1,12 +1,17 @@
+# frozen_string_literal: true
 require 'rubycritic/commands/base'
 
 module RubyCritic
   module Command
     class Help < Base
       def execute
-        puts @options[:help_text]
-        @status_reporter
+        puts options[:help_text]
+        status_reporter
       end
+
+      private
+
+      attr_reader :options, :status_reporter
     end
   end
 end

--- a/lib/rubycritic/commands/status_reporter.rb
+++ b/lib/rubycritic/commands/status_reporter.rb
@@ -1,7 +1,8 @@
+# frozen_string_literal: true
 module RubyCritic
   module Command
     class StatusReporter
-      attr_reader :status, :status_message
+      attr_reader :status, :status_message, :score
       SUCCESS = 0
       SCORE_BELOW_MINIMUM = 1
 
@@ -10,8 +11,8 @@ module RubyCritic
         @status = SUCCESS
       end
 
-      def score=(score)
-        @score = score.round(2)
+      def score=(input_score)
+        @score = input_score.round(2)
         update_status
       end
 
@@ -27,15 +28,15 @@ module RubyCritic
       end
 
       def satisfy_minimum_score_rule
-        @score >= @options[:minimum_score]
+        score >= @options[:minimum_score]
       end
 
       def update_status_message
         case @status
         when SUCCESS
-          @status_message = "Score: #{@score}"
+          @status_message = "Score: #{score}"
         when SCORE_BELOW_MINIMUM
-          @status_message = "Score (#{@score}) is below the minimum #{@options[:minimum_score]}"
+          @status_message = "Score (#{score}) is below the minimum #{@options[:minimum_score]}"
         end
       end
     end

--- a/lib/rubycritic/commands/version.rb
+++ b/lib/rubycritic/commands/version.rb
@@ -1,12 +1,14 @@
+# frozen_string_literal: true
 require 'rubycritic/version'
 require 'rubycritic/commands/base'
 
 module RubyCritic
   module Command
     class Version < Base
+      attr_reader :status_reporter
       def execute
         puts "RubyCritic #{VERSION}"
-        @status_reporter
+        status_reporter
       end
     end
   end

--- a/lib/rubycritic/configuration.rb
+++ b/lib/rubycritic/configuration.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module RubyCritic
   class Configuration
     attr_reader :root

--- a/lib/rubycritic/core/analysed_module.rb
+++ b/lib/rubycritic/core/analysed_module.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'virtus'
 require 'rubycritic/core/rating'
 

--- a/lib/rubycritic/core/analysed_modules_collection.rb
+++ b/lib/rubycritic/core/analysed_modules_collection.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'rubycritic/source_locator'
 require 'rubycritic/core/analysed_module'
 

--- a/lib/rubycritic/core/location.rb
+++ b/lib/rubycritic/core/location.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'pathname'
 
 module RubyCritic

--- a/lib/rubycritic/core/rating.rb
+++ b/lib/rubycritic/core/rating.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module RubyCritic
   class Rating
     def self.from_cost(cost)

--- a/lib/rubycritic/core/smell.rb
+++ b/lib/rubycritic/core/smell.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'virtus'
 require 'rubycritic/core/location'
 
@@ -70,7 +71,7 @@ module RubyCritic
     protected
 
     def state
-      [@context, @message, @score, @type]
+      [context, message, score, type]
     end
 
     private

--- a/lib/rubycritic/generators/console_report.rb
+++ b/lib/rubycritic/generators/console_report.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'rubycritic/generators/text/list'
 
 module RubyCritic

--- a/lib/rubycritic/generators/html/base.rb
+++ b/lib/rubycritic/generators/html/base.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'erb'
 require 'pathname'
 require 'rubycritic/generators/html/view_helpers'

--- a/lib/rubycritic/generators/html/code_file.rb
+++ b/lib/rubycritic/generators/html/code_file.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'rubycritic/generators/html/base'
 require 'rubycritic/generators/html/line'
 
@@ -22,14 +23,14 @@ module RubyCritic
         end
 
         def render
-          file_code = ''
+          file_code = []
           File.readlines(@pathname).each.with_index(LINE_NUMBER_OFFSET) do |line_text, line_number|
             location = Location.new(@pathname, line_number)
             line_smells = @analysed_module.smells_at_location(location)
             file_code << Line.new(file_directory, line_text, line_smells).render
           end
 
-          file_body = TEMPLATE.result(get_binding { file_code })
+          file_body = TEMPLATE.result(get_binding { file_code.join })
           LAYOUT_TEMPLATE.result(get_binding { file_body })
         end
       end

--- a/lib/rubycritic/generators/html/code_index.rb
+++ b/lib/rubycritic/generators/html/code_index.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'rubycritic/generators/html/base'
 
 module RubyCritic

--- a/lib/rubycritic/generators/html/line.rb
+++ b/lib/rubycritic/generators/html/line.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'cgi'
 require 'rubycritic/generators/html/base'
 

--- a/lib/rubycritic/generators/html/overview.rb
+++ b/lib/rubycritic/generators/html/overview.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'rubycritic/generators/html/base'
 require 'rubycritic/generators/html/turbulence'
 

--- a/lib/rubycritic/generators/html/smells_index.rb
+++ b/lib/rubycritic/generators/html/smells_index.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'rubycritic/generators/html/base'
 
 module RubyCritic

--- a/lib/rubycritic/generators/html/turbulence.rb
+++ b/lib/rubycritic/generators/html/turbulence.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'json'
 
 module RubyCritic

--- a/lib/rubycritic/generators/html/view_helpers.rb
+++ b/lib/rubycritic/generators/html/view_helpers.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module RubyCritic
   module ViewHelpers
     def timeago_tag(time)

--- a/lib/rubycritic/generators/html_report.rb
+++ b/lib/rubycritic/generators/html_report.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'fileutils'
 require 'rubycritic/configuration'
 require 'rubycritic/generators/html/overview'

--- a/lib/rubycritic/generators/json/simple.rb
+++ b/lib/rubycritic/generators/json/simple.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'json'
 require 'rubycritic/version'
 require 'pathname'

--- a/lib/rubycritic/generators/json_report.rb
+++ b/lib/rubycritic/generators/json_report.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'rubycritic/generators/json/simple'
 
 module RubyCritic

--- a/lib/rubycritic/generators/text/list.rb
+++ b/lib/rubycritic/generators/text/list.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'colorize'
 
 module RubyCritic

--- a/lib/rubycritic/rake_task.rb
+++ b/lib/rubycritic/rake_task.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'rake'
 require 'rake/tasklib'
 require 'English'

--- a/lib/rubycritic/reporter.rb
+++ b/lib/rubycritic/reporter.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module RubyCritic
   module Reporter
     def self.generate_report(analysed_modules)

--- a/lib/rubycritic/serializer.rb
+++ b/lib/rubycritic/serializer.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'fileutils'
 
 module RubyCritic

--- a/lib/rubycritic/smells_status_setter.rb
+++ b/lib/rubycritic/smells_status_setter.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module RubyCritic
   module SmellsStatusSetter
     def self.set(smells_before, smells_now)

--- a/lib/rubycritic/source_control_systems/base.rb
+++ b/lib/rubycritic/source_control_systems/base.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'shellwords'
 
 module RubyCritic

--- a/lib/rubycritic/source_control_systems/double.rb
+++ b/lib/rubycritic/source_control_systems/double.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module RubyCritic
   module SourceControlSystem
     class Double < Base

--- a/lib/rubycritic/source_control_systems/git.rb
+++ b/lib/rubycritic/source_control_systems/git.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module RubyCritic
   module SourceControlSystem
     class Git < Base

--- a/lib/rubycritic/source_control_systems/mercurial.rb
+++ b/lib/rubycritic/source_control_systems/mercurial.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module RubyCritic
   module SourceControlSystem
     class Mercurial < Base

--- a/rubycritic.gemspec
+++ b/rubycritic.gemspec
@@ -1,4 +1,5 @@
 # coding: utf-8
+# frozen_string_literal: true
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'rubycritic/version'
@@ -21,9 +22,9 @@ Gem::Specification.new do |spec|
   spec.require_path  = 'lib'
 
   spec.add_runtime_dependency 'virtus', '~> 1.0'
-  spec.add_runtime_dependency 'flay', '2.8.0'
-  spec.add_runtime_dependency 'flog', '4.4.0'
-  spec.add_runtime_dependency 'reek', '4.1.0'
+  spec.add_runtime_dependency 'flay', '~> 2.8'
+  spec.add_runtime_dependency 'flog', '~> 4.4'
+  spec.add_runtime_dependency 'reek', '~> 4.4'
   spec.add_runtime_dependency 'parser', '2.3.1.2'
   spec.add_runtime_dependency 'ruby_parser', '~> 3.8'
   spec.add_runtime_dependency 'colorize'
@@ -36,6 +37,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'minitest', '~> 5.3'
   spec.add_development_dependency 'mocha', '~> 1.1'
-  spec.add_development_dependency 'rubocop', '>= 0.41.1'
+  spec.add_development_dependency 'rubocop', '>= 0.42.0'
   spec.add_development_dependency 'pry-byebug'
 end

--- a/test/analysers_test_helper.rb
+++ b/test/analysers_test_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 
 class AnalysedModuleDouble < OpenStruct; end

--- a/test/lib/rubycritic/analysers/churn_test.rb
+++ b/test/lib/rubycritic/analysers/churn_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'analysers_test_helper'
 require 'rubycritic/analysers/churn'
 require 'rubycritic/source_control_systems/base'

--- a/test/lib/rubycritic/analysers/complexity_test.rb
+++ b/test/lib/rubycritic/analysers/complexity_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'analysers_test_helper'
 require 'rubycritic/analysers/complexity'
 

--- a/test/lib/rubycritic/analysers/helpers/methods_counter_test.rb
+++ b/test/lib/rubycritic/analysers/helpers/methods_counter_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'analysers_test_helper'
 require 'rubycritic/analysers/helpers/methods_counter'
 

--- a/test/lib/rubycritic/analysers/helpers/modules_locator_test.rb
+++ b/test/lib/rubycritic/analysers/helpers/modules_locator_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 require 'rubycritic/analysers/helpers/modules_locator'
 require 'rubycritic/core/analysed_module'

--- a/test/lib/rubycritic/analysers/smells/flay_test.rb
+++ b/test/lib/rubycritic/analysers/smells/flay_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 require 'rubycritic/analysers/smells/flay'
 require 'rubycritic/core/analysed_module'

--- a/test/lib/rubycritic/analysers/smells/flog_test.rb
+++ b/test/lib/rubycritic/analysers/smells/flog_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'analysers_test_helper'
 require 'rubycritic/analysers/smells/flog'
 

--- a/test/lib/rubycritic/analysers/smells/reek_test.rb
+++ b/test/lib/rubycritic/analysers/smells/reek_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'analysers_test_helper'
 require 'rubycritic/analysers/smells/reek'
 

--- a/test/lib/rubycritic/browser_test.rb
+++ b/test/lib/rubycritic/browser_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 require 'rubycritic/browser'
 

--- a/test/lib/rubycritic/commands/status_reporter_test.rb
+++ b/test/lib/rubycritic/commands/status_reporter_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 require 'rubycritic/commands/status_reporter'
 require 'rubycritic/cli/options'

--- a/test/lib/rubycritic/configuration_test.rb
+++ b/test/lib/rubycritic/configuration_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 require 'rubycritic/configuration'
 

--- a/test/lib/rubycritic/core/analysed_module_test.rb
+++ b/test/lib/rubycritic/core/analysed_module_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 require 'rubycritic/core/analysed_module'
 require 'rubycritic/core/smell'

--- a/test/lib/rubycritic/core/analysed_modules_collection_test.rb
+++ b/test/lib/rubycritic/core/analysed_modules_collection_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 require 'rubycritic/core/analysed_modules_collection'
 

--- a/test/lib/rubycritic/core/location_test.rb
+++ b/test/lib/rubycritic/core/location_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 require 'rubycritic/core/location'
 

--- a/test/lib/rubycritic/core/smell_test.rb
+++ b/test/lib/rubycritic/core/smell_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 require 'rubycritic/core/smell'
 

--- a/test/lib/rubycritic/core/smells_array_test.rb
+++ b/test/lib/rubycritic/core/smells_array_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 require 'rubycritic/core/smell'
 

--- a/test/lib/rubycritic/generators/console_report_test.rb
+++ b/test/lib/rubycritic/generators/console_report_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 require 'rubycritic/generators/console_report'
 require 'rubycritic/core/rating'

--- a/test/lib/rubycritic/generators/json_report_test.rb
+++ b/test/lib/rubycritic/generators/json_report_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 require 'rubycritic/core/analysed_modules_collection'
 require 'rubycritic/generators/json_report'

--- a/test/lib/rubycritic/generators/turbulence_test.rb
+++ b/test/lib/rubycritic/generators/turbulence_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 require 'rubycritic/generators/html/turbulence'
 

--- a/test/lib/rubycritic/generators/view_helpers_test.rb
+++ b/test/lib/rubycritic/generators/view_helpers_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 require 'rubycritic/generators/html/view_helpers'
 require 'pathname'

--- a/test/lib/rubycritic/revision_comparator_test.rb
+++ b/test/lib/rubycritic/revision_comparator_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 require 'rubycritic/revision_comparator'
 

--- a/test/lib/rubycritic/smells_status_setter_test.rb
+++ b/test/lib/rubycritic/smells_status_setter_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 require 'rubycritic/core/smell'
 require 'rubycritic/smells_status_setter'

--- a/test/lib/rubycritic/source_control_systems/base_test.rb
+++ b/test/lib/rubycritic/source_control_systems/base_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 require 'rubycritic/source_control_systems/base'
 

--- a/test/lib/rubycritic/source_control_systems/double_test.rb
+++ b/test/lib/rubycritic/source_control_systems/double_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 require 'rubycritic/source_control_systems/base'
 require_relative 'interfaces/basic'

--- a/test/lib/rubycritic/source_control_systems/git_test.rb
+++ b/test/lib/rubycritic/source_control_systems/git_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 require 'rubycritic/source_control_systems/base'
 require_relative 'interfaces/basic'

--- a/test/lib/rubycritic/source_control_systems/interfaces/basic.rb
+++ b/test/lib/rubycritic/source_control_systems/interfaces/basic.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module BasicInterface
   def test_implements_basic_interface
     assert_respond_to @system, :revisions_count

--- a/test/lib/rubycritic/source_control_systems/interfaces/time_travel.rb
+++ b/test/lib/rubycritic/source_control_systems/interfaces/time_travel.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # This interface is only used if `@system.revision?` returns `true`.
 module TimeTravelInterface
   def test_implements_time_travel_interface

--- a/test/lib/rubycritic/source_control_systems/mercurial_test.rb
+++ b/test/lib/rubycritic/source_control_systems/mercurial_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 require 'rubycritic/source_control_systems/base'
 require_relative 'interfaces/basic'

--- a/test/lib/rubycritic/source_locator_test.rb
+++ b/test/lib/rubycritic/source_locator_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 require 'rubycritic/source_locator'
 

--- a/test/lib/rubycritic/version_test.rb
+++ b/test/lib/rubycritic/version_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 require 'rubycritic/version'
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'minitest/autorun'
 require 'minitest/pride'
 require 'mocha/mini_test'


### PR DESCRIPTION
Reek had a bug, https://github.com/troessner/reek/issues/960 which is now fixed, but Rubycritic is using previous version.