### PR TITLE
Support Perforce source control system for Churn metric

### DIFF
--- a/lib/rubycritic/source_control_systems/base.rb
+++ b/lib/rubycritic/source_control_systems/base.rb
@@ -34,3 +34,4 @@ end
 require 'rubycritic/source_control_systems/double'
 require 'rubycritic/source_control_systems/git'
 require 'rubycritic/source_control_systems/mercurial'
+require 'rubycritic/source_control_systems/perforce'

--- a/lib/rubycritic/source_control_systems/perforce.rb
+++ b/lib/rubycritic/source_control_systems/perforce.rb
@@ -1,0 +1,108 @@
+require 'date'
+
+# frozen_string_literal: true
+module RubyCritic
+  module SourceControlSystem
+    PerforceStats = Struct.new(:filename, :revision, :last_commit, :opened?)
+
+    class Perforce < Base
+      register_system
+
+      def self.supported?
+        p4_client = ENV['P4CLIENT'] || ''
+        p4_installed? && !p4_client.empty? && in_client_directory?
+      end
+
+      def self.p4_installed?
+        p4_exe = Gem.win_platform? ? 'p4.exe' : 'p4'
+        ENV['PATH'].split(File::PATH_SEPARATOR).any? do |directory|
+          File.executable?(File.join(directory, p4_exe))
+        end
+      end
+
+      def self.in_client_directory?
+        p4_info = `p4 info`.each_line.select do |line|
+          line.start_with?('Client root', 'Current directory')
+        end
+
+        client_directory, current_directory = p4_info.map! { |info| info.split(': ').last.chomp }
+        child?(client_directory, current_directory)
+      end
+
+      def self.child?(root, target)
+        root_size = root.size
+        target_size = target.size
+        return false if target_size < root_size
+        target[0...root_size] == root &&
+          (target_size == root_size || [File::ALT_SEPARATOR, File::SEPARATOR].include?(target[root_size]))
+      end
+
+      def self.to_s
+        'Perforce'
+      end
+
+      def revisions_count(path)
+        perforce_files[Perforce.key_file(path)].revision.to_i
+      end
+
+      def date_of_last_commit(path)
+        DateTime.strptime(perforce_files[Perforce.key_file(path)].last_commit, '%s').strftime('%Y-%m-%d %H:%M:%S %z')
+      end
+
+      def revision?
+        !perforce_files.values.count(&:opened?).zero?
+      end
+
+      def self.build_file_cache
+        # Chun is very slow if files stats are requested one by one
+        # this fill a hash with the result of all ruby file in the current directory (and sub-directories)
+        {}.tap do |file_cache|
+          line_aggregator = []
+          `p4 fstat -F "clientFile=*.rb" -T clientFile,headRev,headTime,action #{Dir.getwd}...`.each_line do |line|
+            Perforce.compute_line(file_cache, line_aggregator, line)
+          end
+          # handle remaining lines
+          Perforce.insert_file_cache(file_cache, line_aggregator) if line_aggregator.any?
+        end
+      end
+
+      def self.compute_line(file_cache, line_aggregator, line)
+        if line.chomp.empty?
+          Perforce.insert_file_cache(file_cache, line_aggregator)
+        else
+          line_aggregator << line
+        end
+      end
+
+      def self.insert_file_cache(file_cache, lines)
+        perforce_stat = Perforce.compute_cache_lines(lines)
+        file_cache[perforce_stat.filename] = perforce_stat
+        lines.clear
+      end
+
+      def self.compute_cache_lines(lines)
+        perforce_lines = Hash[*lines.map { |line| line.split[1..-1] }.flatten]
+        PerforceStats.new(
+          Perforce.normalized_file_path(perforce_lines['clientFile']),
+          perforce_lines['headRev'],
+          perforce_lines['headTime'],
+          perforce_lines.key?('action')
+        )
+      end
+
+      def self.key_file(source_file_path)
+        Perforce.normalized_file_path(File.join(Dir.getwd, source_file_path))
+      end
+
+      def self.normalized_file_path(file_path)
+        file_path.downcase.tr('\\', '/')
+      end
+
+      private
+
+      def perforce_files
+        @perforce_files ||= Perforce.build_file_cache
+      end
+    end
+  end
+end

--- a/test/lib/rubycritic/source_control_systems/perforce_test.rb
+++ b/test/lib/rubycritic/source_control_systems/perforce_test.rb
@@ -1,0 +1,162 @@
+# frozen_string_literal: true
+require 'test_helper'
+require 'rubycritic/source_control_systems/base'
+
+describe RubyCritic::SourceControlSystem::Perforce do
+  before do
+    @system = RubyCritic::SourceControlSystem::Perforce.new
+  end
+
+  describe RubyCritic::SourceControlSystem::Perforce do
+    describe '::supported?' do
+      let(:path) do
+        ['/some/path', File::PATH_SEPARATOR, '/perforce/path/p4', File::PATH_SEPARATOR + '/other/useless_path'].join
+      end
+      let(:p4_client) { 'UNIT_TEST_CLIENT' }
+
+      context 'directory is under p4 client' do
+        it 'detects if Perforce is the source control used' do
+          ENV['PATH'] = path
+          ENV['P4CLIENT'] = p4_client
+          Gem.stubs(:win_platform?).returns(false)
+          File.stubs(:executable?).with('/some/path/p4').returns(false)
+          File.stubs(:executable?).with('/perforce/path/p4/p4').returns(true)
+          RubyCritic::SourceControlSystem::Perforce.stubs(:in_client_directory?).returns(true)
+
+          RubyCritic::SourceControlSystem::Perforce.supported?.must_equal true
+        end
+      end
+
+      context 'directory is not under p4 client' do
+        it 'returns false if no p4 executables are found' do
+          ENV['PATH'] = path
+          ENV['P4CLIENT'] = nil
+          Gem.stubs(:win_platform?).returns(false)
+          File.stubs(:executable?).with('/some/path/p4').returns(false)
+          File.stubs(:executable?).with('/perforce/path/p4/p4').returns(false)
+          File.stubs(:executable?).with('/other/useless_path/p4').returns(false)
+
+          RubyCritic::SourceControlSystem::Perforce.supported?.must_equal false
+        end
+
+        it 'returns false if no p4 client is set in environment variables' do
+          ENV['PATH'] = path
+          ENV['P4CLIENT'] = nil
+          Gem.stubs(:win_platform?).returns(false)
+          File.stubs(:executable?).with('/some/path/p4').returns(false)
+          File.stubs(:executable?).with('/perforce/path/p4/p4').returns(true)
+
+          RubyCritic::SourceControlSystem::Perforce.supported?.must_equal false
+        end
+
+        it 'returns false if the current directory is not under p4 client' do
+          ENV['PATH'] = path
+          ENV['P4CLIENT'] = p4_client
+          Gem.stubs(:win_platform?).returns(false)
+          File.stubs(:executable?).with('/some/path/p4').returns(false)
+          File.stubs(:executable?).with('/perforce/path/p4/p4').returns(true)
+          RubyCritic::SourceControlSystem::Perforce.stubs(:in_client_directory?).returns(false)
+
+          RubyCritic::SourceControlSystem::Perforce.supported?.must_equal false
+        end
+      end
+    end
+
+    describe '::in_client_directory?' do
+      context 'current directory is in p4 client' do
+        let(:p4_info) do
+          <<-END
+User name: unit_test_user
+Client name: UNIT_TEST_CLIENT
+Client host: MACHINE_NAME
+Client root: /path/to/client/root
+Current directory: /path/to/client/root/ruby_project/unit_test
+Peer address: 127.0.0.1::3000
+Client address: 127.0.0.1
+Server address: the.server.address.com
+          END
+        end
+
+        it 'calls p4 info and parse the result' do
+          RubyCritic::SourceControlSystem::Perforce.stubs(:`).with('p4 info').returns(p4_info)
+          RubyCritic::SourceControlSystem::Perforce.in_client_directory?.must_equal true
+        end
+      end
+
+      context 'current directory is not in p4 client' do
+        let(:p4_info) do
+          <<-END
+User name: unit_test_user
+Client name: UNIT_TEST_CLIENT
+Client host: MACHINE_NAME
+Client root: /path/to/client/root
+Current directory: /somewhere/else/ruby_project/unit_test
+Peer address: 127.0.0.1::3000
+Client address: 127.0.0.1
+Server address: the.server.address.com
+          END
+        end
+
+        it 'calls p4 info and parse the result' do
+          RubyCritic::SourceControlSystem::Perforce.stubs(:`).with('p4 info').returns(p4_info)
+          RubyCritic::SourceControlSystem::Perforce.in_client_directory?.must_equal false
+        end
+      end
+    end
+
+    describe 'retrieve informations' do
+      let(:p4_stats) do
+        <<-END
+... clientFile /path/to/client/a_ruby_file.rb
+... headTime 1473075551
+... headRev 16
+
+... clientFile /path/to/client/second_ruby_file.rb
+... headTime 1464601668
+... action opened
+... headRev 12
+        END
+      end
+
+      describe 'build_file_cache' do
+        it 'builds the perforce file cache' do
+          RubyCritic::SourceControlSystem::Perforce.stubs(:`).returns(p4_stats)
+          file_cache = @system.send(:perforce_files)
+          file_cache.size.must_equal 2
+
+          first_file = file_cache['/path/to/client/a_ruby_file.rb']
+          first_file.filename.must_equal '/path/to/client/a_ruby_file.rb'
+          first_file.revision.must_equal '16'
+          first_file.last_commit.must_equal '1473075551'
+          first_file.opened?.must_equal false
+
+          second_file = file_cache['/path/to/client/second_ruby_file.rb']
+          second_file.filename.must_equal '/path/to/client/second_ruby_file.rb'
+          second_file.revision.must_equal '12'
+          second_file.last_commit.must_equal '1464601668'
+          second_file.opened?.must_equal true
+        end
+      end
+
+      it 'retrieves the number revisions of the ruby files' do
+        Dir.stubs(:getwd).returns('/path/to/client')
+        RubyCritic::SourceControlSystem::Perforce.stubs(:`).once.returns(p4_stats)
+        @system.revisions_count('a_ruby_file.rb').must_equal 16
+        @system.revisions_count('second_ruby_file.rb').must_equal 12
+      end
+
+      it 'retrieves the date of the last commit of the ruby files' do
+        Dir.stubs(:getwd).returns('/path/to/client')
+        RubyCritic::SourceControlSystem::Perforce.stubs(:`).once.returns(p4_stats)
+        @system.date_of_last_commit('a_ruby_file.rb').must_equal '2016-09-05 11:39:11 +0000'
+        @system.date_of_last_commit('second_ruby_file.rb').must_equal '2016-05-30 09:47:48 +0000'
+      end
+
+      it 'retrieves the information if the ruby file is opened (in the changelist and ready to commit)' do
+        Dir.stubs(:getwd).returns('/path/to/client')
+        RubyCritic::SourceControlSystem::Perforce.stubs(:`).once.returns(p4_stats)
+        @system.revision?.must_equal true
+      end
+    end
+  end
+end


### PR DESCRIPTION
This pull request adds the support of Perforce as source control for the Churn metric.

When we request informations on a file, the Perforce client retrieves the statistic from the server, which is very slow.
For better performances, a cache is built with all ruby files present in the current directory. 

A new unit test is created to ensure the class respond to the "BasicInterface".

Let me know if something is missing.

**note**: I have developed this on Windows. 2 unit tests fail on my computer but it should be OK
[unit_tests_fail.txt](https://github.com/whitesmith/rubycritic/files/514254/unit_tests_fail.txt)
