### PR TITLE
GPL license conformance

### DIFF
--- a/lib/rubycritic/generators/text/list.rb
+++ b/lib/rubycritic/generators/text/list.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'colorize'
+require 'rainbow'
 
 module RubyCritic
   module Generator

--- a/lib/rubycritic/generators/text/templates/list.erb
+++ b/lib/rubycritic/generators/text/templates/list.erb
@@ -1,5 +1,5 @@
-<%= @analysed_module.name.colorize(color) %>:
-  Rating:       <%= @analysed_module.rating.to_s.colorize(color) %>
+<%= Rainbow(@analysed_module.name.to_s).foreground(color) %>:
+  Rating:       <%= Rainbow(@analysed_module.rating.to_s).foreground(color) %>
   Churn:        <%= @analysed_module.churn %>
   Complexity:   <%= @analysed_module.complexity %>
   Duplication:  <%= @analysed_module.duplication %>

--- a/rubycritic.gemspec
+++ b/rubycritic.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'reek', '~> 4.4'
   spec.add_runtime_dependency 'parser', '2.3.1.2'
   spec.add_runtime_dependency 'ruby_parser', '~> 3.8'
-  spec.add_runtime_dependency 'colorize'
+  spec.add_runtime_dependency 'rainbow'
   spec.add_runtime_dependency 'launchy', '2.4.3'
 
   spec.add_development_dependency 'aruba'


### PR DESCRIPTION
Using any GPL-licensed gem in a non-GPL gem, project (or dependency) is often problematic, possibly a GPL license violation but IANAL. Using [license_finder](https://github.com/pivotal/LicenseFinder), the only rubycritic dep. out of license compatibility is [colorize](https://github.com/fazibear/colorize). This PR is ~~a quick hack~~ refactored to use [rainbow](https://github.com/sickill/rainbow) instead, since terminal colorizing is trivial and there are [many options](https://www.ruby-toolbox.com/categories/Terminal_Coloring).

