### PR TITLE
Set required ruby version to 2.1

### DIFF
--- a/rubycritic.gemspec
+++ b/rubycritic.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'RubyCritic is a Ruby code quality reporter'
   spec.homepage      = 'https://github.com/whitesmith/rubycritic'
   spec.license       = 'MIT'
-  spec.required_ruby_version = '>= 2.0.0'
+  spec.required_ruby_version = '>= 2.1.0'
 
   spec.files         = `git ls-files`.split("\n")
   spec.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }


### PR DESCRIPTION
We've removed tests on Ruby 2.0 [some time ago](https://github.com/whitesmith/rubycritic/commit/02d1451e03a54dac95df86a183708eb1fdd42c95)

I think we should also explicitly say we don't support it.