### PR TITLE
Update Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,20 @@
 sudo: false
 language: ruby
-
-rvm:
-  - 2.1.8
-  - 2.2.4
-  - 2.3.0
-  - ruby-head
-  - jruby-9.0.5.0
-  - rbx-3
-
-env:
-  # this doesn't do anything for MRI or RBX, but it doesn't hurt them either
-  # for JRuby, it enables us to get more accurate coverage data
-  - JRUBY_OPTS="--debug"
-
+cache: bundler
+before_install: gem update bundler
 matrix:
+  include:
+    - rvm: 2.1.0
+    - rvm: 2.1.10
+    - rvm: 2.2.5
+    - rvm: 2.3.1
+    - rvm: ruby-head
+    - rvm: jruby-9.1.5.0
+      env: JRUBY_OPTS='--debug' # get more accurate coverage data
+    - rvm: rbx-3
   allow_failures:
     - rvm: ruby-head
-    - rvm: jruby-9.0.5.0
+    - rvm: jruby-9.1.5.0
     - rvm: rbx-3
   fast_finish: true
-
-before_install: gem update bundler
 script: bundle exec rake

--- a/rubycritic.gemspec
+++ b/rubycritic.gemspec
@@ -38,5 +38,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'minitest', '~> 5.3'
   spec.add_development_dependency 'mocha', '~> 1.1'
   spec.add_development_dependency 'rubocop', '>= 0.42.0'
-  spec.add_development_dependency 'pry-byebug'
 end


### PR DESCRIPTION
- Update Travis config to target more recent ruby versions
- Remove pry-byebug as a dev dependency so we can build on jruby