### PR TITLE
Respect Reeks config file search

### DIFF
--- a/.todo.reek
+++ b/.todo.reek
@@ -133,9 +133,10 @@ UncommunicativeParameterName:
   - RubyCritic::Location#to_json
   - RubyCritic::Rating#to_json
   - RubyCritic::Smell#to_json
+  - Theon # This is needed for the tests to pass
 ClassVariable:
   exclude:
   - RubyCritic::SourceControlSystem::Base
-BooleanParameter: 
+BooleanParameter:
   exclude:
   - RubyCritic::Config#self.respond_to_missing?

--- a/lib/rubycritic/analysers/helpers/reek.rb
+++ b/lib/rubycritic/analysers/helpers/reek.rb
@@ -3,5 +3,8 @@ require 'reek'
 
 module RubyCritic
   class Reek < ::Reek::Examiner
+    def initialize(analysed_module)
+      super(analysed_module, configuration: ::Reek::Configuration::AppConfiguration.from_path)
+    end
   end
 end

--- a/test/lib/rubycritic/analysers/smells/reek_test.rb
+++ b/test/lib/rubycritic/analysers/smells/reek_test.rb
@@ -15,6 +15,11 @@ describe RubyCritic::Analyser::ReekSmells do
       @analysed_module.smells.length.must_equal 2
     end
 
+    it 'respects the .reek file' do
+      messages = @analysed_module.smells.map(&:message)
+      messages.wont_include "has the parameter name 'a'"
+    end
+
     it 'creates smells with messages' do
       first_smell = @analysed_module.smells.first
       first_smell.message.must_equal "has boolean parameter 'reek'"

--- a/test/samples/reek/smelly.rb
+++ b/test/samples/reek/smelly.rb
@@ -2,6 +2,10 @@ class Theon
   def reeks?(reek = true)
     reek
   end
+
+  def flayed?(a)
+    a
+  end
 end
 
 # Reek should report
@@ -10,3 +14,4 @@ end
 # This comment is below the module because otherwise Reek will interpret this
 # as a comment describing the module which would thus prevent
 # IrresponsibleModule from being reported.
+# It should ignore the UncommunicativeParameterName as it's on the .todo.reek


### PR DESCRIPTION
Rubycritic was using a subclass of Reek::Examiner. The examiner does not search (or load) the config files by itself, so we need to allow the default behavior used by the `Reek::CLI::Application` which is passing to the examiner a `Reek::Configuration::AppConfiguration.from_path`  with either a `path` to a .reek file or a `nil` (which will trigger the searching for .reek files).

I'm not that all happy with the way I got to make a test for this, but it works and should prevent regressions.