### PR TITLE
Spec: Fix copy-pasted titles of "it" cases

### DIFF
--- a/test/lib/rubycritic/generators/console_report_test.rb
+++ b/test/lib/rubycritic/generators/console_report_test.rb
@@ -28,15 +28,15 @@ describe RubyCritic::Generator::ConsoleReport do
       assert output_contains?('Rating', @mock_analysed_module.rating)
     end
 
-    it "includes the module's rating in the report" do
+    it "includes the module's churn metric in the report" do
       assert output_contains?('Churn', @mock_analysed_module.churn)
     end
 
-    it "includes the module's rating in the report" do
+    it "includes the module's complexity in the report" do
       assert output_contains?('Complexity', @mock_analysed_module.complexity)
     end
 
-    it "includes the module's rating in the report" do
+    it "includes the module's duplication metric in the report" do
       assert output_contains?('Duplication', @mock_analysed_module.duplication)
     end
 


### PR DESCRIPTION
In order to keep the test readable, this PR changes the names of the test cases in ConsoleReport's spec.

It seems some of them were copy-paste oopsies.

Great to have specs, though!