### PR TITLE
README: Complete Usage section

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,12 +113,14 @@ $ rubycritic --help
 
 | Command flag             | Description                                           |
 |--------------------------|-------------------------------------------------------|
-| `-v/--version`           | Displays the current version and exits                |
-| `-p/--path`              | Sets the output directory (tmp/rubycritic by default) |
-| `-s/--minimum-score`     | Set a minimum score                                   |
-| `--mode-ci`              | Uses CI mode (faster, but only analyses last commit)  |
+| `-v` / `--version`       | Displays the current version and exits                |
+| `-p` / `--path`          | Set path where report will be saved (tmp/rubycritic by default) |
+| `-f` / `--format`        | Report smells in the given format: `html` (default; will open in a browser), `json`, `console`. |
+| `-s` / `--minimum-score` | Set a minimum score                                   |
+| `--mode-ci`              | Use CI mode (faster, but only analyses last commit)   |
 | `--deduplicate-symlinks` | De-duplicate symlinks based on their final target     |
 | `--suppress-ratings`     | Suppress letter ratings                               |
+| `--no-browser`           | Do not open html report with browser                  |
 
 
 ### Analyzer Configuration

--- a/features/command_line_interface/options.feature
+++ b/features/command_line_interface/options.feature
@@ -22,7 +22,7 @@ Feature: RubyCritic can be controlled using command-line options
       Usage: rubycritic [options] [paths]
           -p, --path [PATH]                Set path where report will be saved (tmp/rubycritic by default)
           -f, --format [FORMAT]            Report smells in the given format:
-                                             html (default)
+                                             html (default; will open in a browser)
                                              json
                                              console
           -s, --minimum-score [MIN_SCORE]  Set a minimum score

--- a/lib/rubycritic/cli/options.rb
+++ b/lib/rubycritic/cli/options.rb
@@ -23,7 +23,7 @@ module RubyCritic
             '-f', '--format [FORMAT]',
             [:html, :json, :console],
             'Report smells in the given format:',
-            '  html (default)',
+            '  html (default; will open in a browser)',
             '  json',
             '  console'
           ) do |format|


### PR DESCRIPTION
This PR makes the README _Usage_ section match what's currently in the `--help` output.