### PR TITLE
Fix some ruby warnings thrown on rake test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * [CHANGE] Set required ruby version to 2.1 (by Onumis)
 * [BUGFIX] Respect the .reek configuration file (by mereghost)
+* [CHANGE] Fix test warnings and upgrade 'parser' to '2.3.1.4' (by tejasbubane)
 
 # 2.9.4 / 2016-09-16
 

--- a/lib/rubycritic/source_control_systems/perforce.rb
+++ b/lib/rubycritic/source_control_systems/perforce.rb
@@ -1,6 +1,6 @@
+# frozen_string_literal: true
 require 'date'
 
-# frozen_string_literal: true
 module RubyCritic
   module SourceControlSystem
     PerforceStats = Struct.new(:filename, :revision, :last_commit, :opened?)

--- a/rubycritic.gemspec
+++ b/rubycritic.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'flay', '~> 2.8'
   spec.add_runtime_dependency 'flog', '~> 4.4'
   spec.add_runtime_dependency 'reek', '~> 4.4'
-  spec.add_runtime_dependency 'parser', '2.3.1.2'
+  spec.add_runtime_dependency 'parser', '2.3.1.4'
   spec.add_runtime_dependency 'ruby_parser', '~> 3.8'
   spec.add_runtime_dependency 'rainbow'
   spec.add_runtime_dependency 'launchy', '2.4.3'


### PR DESCRIPTION
Running `rake` gives following warnings: https://travis-ci.org/whitesmith/rubycritic/jobs/174016330#L237-L239

Upgrade `parser` to `2.3.1.4`.
One warning (the last one) still left which comes from `parser`. Hopefully that is fixed in later versions.
One way is to disable warnings completely on `rake test`, but I don't think that will be appropriate.

