### PR TITLE
Compare only the modified files between two branches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ tmp
 .ruby-gemset
 .ruby-version
 .DS_Store
+*.DS_Store

--- a/.todo.reek
+++ b/.todo.reek
@@ -67,6 +67,16 @@ Attribute:
   - RubyCritic::Configuration#open_with
   - RubyCritic::Configuration#source_control_system
   - RubyCritic::Configuration#suppress_ratings
+  - RubyCritic::Configuration#base_branch
+  - RubyCritic::Configuration#base_branch_score
+  - RubyCritic::Configuration#base_root_directory
+  - RubyCritic::Configuration#build_root_directory
+  - RubyCritic::Configuration#feature_branch
+  - RubyCritic::Configuration#feature_branch_score
+  - RubyCritic::Configuration#feature_root_directory
+  - RubyCritic::Configuration#threshold_score
+  - RubyCritic::Configuration#base_branch_collection
+  - RubyCritic::Configuration#feature_branch_collection
   - RubyCritic::RakeTask#name
   - RubyCritic::RakeTask#options
   - RubyCritic::RakeTask#paths
@@ -88,6 +98,7 @@ TooManyStatements:
   - RubyCritic::Generator::Html::CodeFile#render
   - RubyCritic::Reporter#self.report_generator_class
   - RubyCritic::SourceLocator#deduplicate_symlinks
+  - RubyCritic::Command::Compare#compare_branches
 FeatureEnvy:
   exclude:
   - Parser::AST::Node#module_name
@@ -104,6 +115,7 @@ NestedIterators:
   - RubyCritic::Analyser::FlaySmells#run
   - RubyCritic::Cli::Options#parse
   - RubyCritic::Generator::HtmlReport#create_directories_and_files
+  - RubyCritic::AnalysedModulesCollection#initialize
 UtilityFunction:
   exclude:
   - RubyCritic::Analyser::FlaySmells#cost
@@ -121,9 +133,18 @@ UtilityFunction:
   - RubyCritic::SourceControlSystem::Git#stashes_count
   - RubyCritic::SourceControlSystem::Mercurial#date_of_last_commit
   - RubyCritic::SourceControlSystem::Mercurial#revisions_count
+  - RubyCritic::ViewHelpers#code_index_path
+  - RubyCritic::AnalysedModulesCollection#build_analysed_module
+  - RubyCritic::Command::Compare#branch_directory
+  - RubyCritic::Command::Compare#build_details
+  - RubyCritic::Command::Compare#threshold_reached?
+  - RubyCritic::Command::Compare#threshold_values_set?
 TooManyInstanceVariables:
   exclude:
   - RubyCritic::Cli::Options
+  - RubyCritic::Generator::Html::CodeFile
+  - RubyCritic::Generator::Html::Overview
+  - RubyCritic::Generator::Html::SmellsIndex
 ControlParameter:
   exclude:
   - RubyCritic::CommandFactory#self.command_class

--- a/features/command_line_interface/options.feature
+++ b/features/command_line_interface/options.feature
@@ -21,12 +21,15 @@ Feature: RubyCritic can be controlled using command-line options
       """
       Usage: rubycritic [options] [paths]
           -p, --path [PATH]                Set path where report will be saved (tmp/rubycritic by default)
+          -b, --branch BRANCH              Set branch to compare
+          -t [MAX_DECREASE],               Set a threshold for score difference between two branches (works only with -b)
+              --maximum-decrease
           -f, --format [FORMAT]            Report smells in the given format:
                                              html (default; will open in a browser)
                                              json
                                              console
           -s, --minimum-score [MIN_SCORE]  Set a minimum score
-          -m, --mode-ci                    Use CI mode (faster, but only analyses last commit)
+          -m, --mode-ci [BASE_BRANCH]      Use CI mode (faster, analyses diffs w.r.t base_branch (default: master))
               --deduplicate-symlinks       De-duplicate symlinks based on their final target
               --suppress-ratings           Suppress letter ratings
               --no-browser                 Do not open html report with browser

--- a/lib/rubycritic/cli/options.rb
+++ b/lib/rubycritic/cli/options.rb
@@ -19,6 +19,17 @@ module RubyCritic
             @root = path
           end
 
+          opts.on('-b', '--branch BRANCH', 'Set branch to compare') do |branch|
+            self.base_branch = String(branch)
+            set_current_branch
+            self.mode = :compare_branches
+          end
+
+          opts.on('-t', '--maximum-decrease [MAX_DECREASE]',
+                  'Set a threshold for score difference between two branches (works only with -b)') do |threshold_score|
+            self.threshold_score = Integer(threshold_score)
+          end
+
           opts.on(
             '-f', '--format [FORMAT]',
             [:html, :json, :console],
@@ -34,7 +45,10 @@ module RubyCritic
             self.minimum_score = Integer(min_score)
           end
 
-          opts.on('-m', '--mode-ci', 'Use CI mode (faster, but only analyses last commit)') do
+          opts.on('-m', '--mode-ci [BASE_BRANCH]',
+                  'Use CI mode (faster, analyses diffs w.r.t base_branch (default: master))') do |branch|
+            self.base_branch = branch || 'master'
+            set_current_branch
             self.mode = :ci
           end
 
@@ -71,20 +85,28 @@ module RubyCritic
           suppress_ratings: suppress_ratings,
           help_text: parser.help,
           minimum_score: minimum_score || 0,
-          no_browser: no_browser
+          no_browser: no_browser,
+          base_branch: base_branch,
+          feature_branch: feature_branch,
+          threshold_score: threshold_score || 0
         }
       end
 
       private
 
       attr_accessor :mode, :root, :format, :deduplicate_symlinks,
-                    :suppress_ratings, :minimum_score, :no_browser, :parser
+                    :suppress_ratings, :minimum_score, :no_browser,
+                    :parser, :base_branch, :feature_branch, :threshold_score
       def paths
         if @argv.empty?
           ['.']
         else
           @argv
         end
+      end
+
+      def set_current_branch
+        self.feature_branch = SourceControlSystem::Git.current_branch
       end
     end
   end

--- a/lib/rubycritic/command_factory.rb
+++ b/lib/rubycritic/command_factory.rb
@@ -19,6 +19,9 @@ module RubyCritic
       when :ci
         require 'rubycritic/commands/ci'
         Command::Ci
+      when :compare_branches
+        require 'rubycritic/commands/compare'
+        Command::Compare
       else
         require 'rubycritic/commands/default'
         Command::Default

--- a/lib/rubycritic/commands/ci.rb
+++ b/lib/rubycritic/commands/ci.rb
@@ -3,13 +3,14 @@ require 'rubycritic/source_control_systems/base'
 require 'rubycritic/analysers_runner'
 require 'rubycritic/reporter'
 require 'rubycritic/commands/default'
+require 'rubycritic/commands/compare'
 
 module RubyCritic
   module Command
-    class Ci < Default
-      def critique
-        AnalysersRunner.new(paths).run
-      end
+    class Ci < Compare
+      # def critique
+      #   AnalysersRunner.new(paths).run
+      # end
 
       private
 

--- a/lib/rubycritic/commands/compare.rb
+++ b/lib/rubycritic/commands/compare.rb
@@ -39,6 +39,7 @@ module RubyCritic
       # keep track of the number of builds and
       # use this build number to create separate directory for each build
       def update_build_number
+        FileUtils.mkdir_p(Config.root) unless File.directory?(Config.root)
         build_file_location = "#{Config.root}/build_count.txt"
         File.new(build_file_location, 'a') unless File.exist?(build_file_location)
         @build_number = File.open(build_file_location).readlines.first.to_i + 1

--- a/lib/rubycritic/commands/compare.rb
+++ b/lib/rubycritic/commands/compare.rb
@@ -37,7 +37,7 @@ module RubyCritic
       end
 
       # keep track of the number of builds and
-      # use this build number to create seperate directory for each build
+      # use this build number to create separate directory for each build
       def update_build_number
         build_file_location = "#{Config.root}/build_count.txt"
         File.new(build_file_location, 'a') unless File.exist?(build_file_location)

--- a/lib/rubycritic/commands/compare.rb
+++ b/lib/rubycritic/commands/compare.rb
@@ -27,10 +27,11 @@ module RubyCritic
       def compare_branches
         update_build_number
         set_root_paths
+        original_no_browser_config = Config.no_browser
         Config.no_browser = true
         analyse_branch(:base_branch)
         analyse_branch(:feature_branch)
-        Config.no_browser = false
+        Config.no_browser = original_no_browser_config
         analyse_modified_files
         compare_code_quality
       end
@@ -38,7 +39,7 @@ module RubyCritic
       # keep track of the number of builds and
       # use this build number to create seperate directory for each build
       def update_build_number
-        build_file_location = '/tmp/build_count.txt'
+        build_file_location = "#{Config.root}/build_count.txt"
         File.new(build_file_location, 'a') unless File.exist?(build_file_location)
         @build_number = File.open(build_file_location).readlines.first.to_i + 1
         File.write(build_file_location, @build_number)
@@ -90,11 +91,11 @@ module RubyCritic
       end
 
       def branch_directory(branch)
-        "tmp/rubycritic/compare/#{Config.send(branch)}"
+        "#{Config.root}/compare/#{Config.send(branch)}"
       end
 
       def build_directory
-        "tmp/rubycritic/compare/builds/build_#{@build_number}"
+        "#{Config.root}/compare/builds/build_#{@build_number}"
       end
 
       # create a txt file with the branch score details

--- a/lib/rubycritic/commands/compare.rb
+++ b/lib/rubycritic/commands/compare.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+require 'rubycritic/source_control_systems/base'
+require 'rubycritic/analysers_runner'
+require 'rubycritic/revision_comparator'
+require 'rubycritic/reporter'
+require 'rubycritic/commands/base'
+require 'rubycritic/commands/default'
+
+module RubyCritic
+  module Command
+    class Compare < Default
+      def initialize(options)
+        super
+        @build_number = 0
+      end
+
+      def execute
+        compare_branches
+        status_reporter.score = Config.feature_branch_score
+        status_reporter
+      end
+
+      private
+
+      attr_reader :paths, :status_reporter
+
+      def compare_branches
+        update_build_number
+        set_root_paths
+        Config.no_browser = true
+        analyse_branch(:base_branch)
+        analyse_branch(:feature_branch)
+        Config.no_browser = false
+        analyse_modified_files
+        compare_code_quality
+      end
+
+      # keep track of the number of builds and
+      # use this build number to create seperate directory for each build
+      def update_build_number
+        build_file_location = '/tmp/build_count.txt'
+        File.new(build_file_location, 'a') unless File.exist?(build_file_location)
+        @build_number = File.open(build_file_location).readlines.first.to_i + 1
+        File.write(build_file_location, @build_number)
+      end
+
+      def set_root_paths
+        Config.base_root_directory = Pathname.new(branch_directory(:base_branch))
+        Config.feature_root_directory = Pathname.new(branch_directory(:feature_branch))
+        Config.build_root_directory = Pathname.new(build_directory)
+      end
+
+      # switch branch and analyse files
+      def analyse_branch(branch)
+        SourceControlSystem::Git.switch_branch(Config.send(branch))
+        critic = critique(branch)
+        Config.send(:"#{branch}_score=", critic.score)
+        Config.root = branch_directory(branch)
+        report(critic)
+      end
+
+      # generate report only for modified files
+      def analyse_modified_files
+        modified_files = Config.feature_branch_collection.where(SourceControlSystem::Git.modified_files)
+        analysed_modules = AnalysedModulesCollection.new(modified_files.map(&:path), modified_files)
+        Config.root = build_directory
+        report(analysed_modules)
+      end
+
+      def compare_code_quality
+        build_details
+        compare_threshold
+      end
+
+      # mark build as failed if the diff b/w the score of
+      # two branches is greater than threshold value
+      def compare_threshold
+        return unless mark_build_fail?
+        print("Threshold: #{Config.threshold_score}\n")
+        print("Difference: #{(Config.base_branch_score - Config.feature_branch_score).abs}\n")
+        abort('The score difference between the two branches is over the threshold.')
+      end
+
+      def mark_build_fail?
+        Config.threshold_score > 0 && threshold_reached?
+      end
+
+      def threshold_reached?
+        (Config.base_branch_score - Config.feature_branch_score) > Config.threshold_score
+      end
+
+      def branch_directory(branch)
+        "tmp/rubycritic/compare/#{Config.send(branch)}"
+      end
+
+      def build_directory
+        "tmp/rubycritic/compare/builds/build_#{@build_number}"
+      end
+
+      # create a txt file with the branch score details
+      def build_details
+        details = "Base branch (#{Config.base_branch}) score: #{Config.base_branch_score} \n"\
+                  "Feature branch (#{Config.feature_branch}) score: #{Config.feature_branch_score} \n"
+        File.open("#{Config.build_root_directory}/build_details.txt", 'w') { |file| file.write(details) }
+      end
+
+      # store the analysed moduled collection based on the branch
+      def critique(branch)
+        module_collection = AnalysersRunner.new(paths).run
+        Config.send(:"#{branch}_collection=", module_collection)
+        RevisionComparator.new(paths).set_statuses(module_collection)
+      end
+    end
+  end
+end

--- a/lib/rubycritic/configuration.rb
+++ b/lib/rubycritic/configuration.rb
@@ -5,7 +5,11 @@ module RubyCritic
   class Configuration
     attr_reader :root
     attr_accessor :source_control_system, :mode, :format, :deduplicate_symlinks,
-                  :suppress_ratings, :open_with, :no_browser
+                  :suppress_ratings, :open_with, :no_browser, :base_branch,
+                  :feature_branch, :base_branch_score, :feature_branch_score,
+                  :base_root_directory, :feature_root_directory,
+                  :build_root_directory, :threshold_score, :base_branch_collection,
+                  :feature_branch_collection
 
     def set(options)
       self.mode = options[:mode] || :default
@@ -15,6 +19,9 @@ module RubyCritic
       self.suppress_ratings = options[:suppress_ratings] || false
       self.open_with = options[:open_with]
       self.no_browser = options[:no_browser]
+      self.base_branch = options[:base_branch]
+      self.feature_branch = options[:feature_branch]
+      self.threshold_score = options[:threshold_score]
     end
 
     def root=(path)
@@ -34,6 +41,16 @@ module RubyCritic
 
     def self.set(options = {})
       configuration.set(options)
+    end
+
+    def self.compare_branches_mode?
+      mode = Config.mode
+      mode == :compare_branches || mode == :ci
+    end
+
+    def self.build_mode?
+      mode = Config.mode
+      (mode == :compare_branches || mode == :ci) && !Config.no_browser
     end
 
     def self.method_missing(method, *args, &block)

--- a/lib/rubycritic/core/analysed_modules_collection.rb
+++ b/lib/rubycritic/core/analysed_modules_collection.rb
@@ -16,14 +16,27 @@ module RubyCritic
     ZERO_SCORE_COST = 16
     COST_MULTIPLIER = MAX_SCORE.to_f / ZERO_SCORE_COST
 
-    def initialize(paths)
+    def initialize(paths, modules = nil)
       @modules = SourceLocator.new(paths).pathnames.map do |pathname|
-        AnalysedModule.new(pathname: pathname)
+        if modules
+          analysed_module = modules.find { |mod| mod.pathname == pathname }
+          build_analysed_module(analysed_module)
+        else
+          AnalysedModule.new(pathname: pathname)
+        end
       end
     end
 
     def each(&block)
       @modules.each(&block)
+    end
+
+    def where(module_paths)
+      @modules.find_all { |mod| module_paths.include? mod.path }
+    end
+
+    def find(module_path)
+      @modules.find { |mod| mod.pathname == module_path }
     end
 
     def to_json(*options)
@@ -53,6 +66,13 @@ module RubyCritic
 
     def limited_cost_for(mod)
       [mod.cost, COST_LIMIT].min
+    end
+
+    def build_analysed_module(analysed_module)
+      AnalysedModule.new(pathname: analysed_module.pathname, name: analysed_module.name,
+                         smells: analysed_module.smells, churn: analysed_module.churn,
+                         committed_at: analysed_module.committed_at, complexity: analysed_module.complexity,
+                         duplication: analysed_module.duplication, methods_count: analysed_module.methods_count)
     end
   end
 end

--- a/lib/rubycritic/generators/html/assets/stylesheets/application.css
+++ b/lib/rubycritic/generators/html/assets/stylesheets/application.css
@@ -527,6 +527,7 @@ span.metric {
   margin-left: 20px;
 }
 
+
 .filter-table {
   text-align: right;
 }
@@ -543,4 +544,23 @@ span.metric {
   background-image: none;
   border: 1px solid #ccc;
   border-radius: 4px;
+}
+
+.branch{
+  font-size: 15px;
+  color: #9b111d;
+  font-weight: bold;
+  display: inline-block;
+  padding: 13px;
+}
+
+.green-color {
+  color: #00A900;
+}
+.red-color {
+  color: #ED0000;
+}
+.empty-span{
+  height: 17px;
+  width: 17px;
 }

--- a/lib/rubycritic/generators/html/code_file.rb
+++ b/lib/rubycritic/generators/html/code_file.rb
@@ -12,6 +12,13 @@ module RubyCritic
         def initialize(analysed_module)
           @analysed_module = analysed_module
           @pathname = @analysed_module.pathname
+          set_header_links if Config.compare_branches_mode?
+        end
+
+        def set_header_links
+          @base_path = code_index_path(Config.base_root_directory, file_location)
+          @feature_path = code_index_path(Config.feature_root_directory, file_location)
+          @build_path = code_index_path(Config.build_root_directory, file_location)
         end
 
         def file_directory
@@ -20,6 +27,10 @@ module RubyCritic
 
         def file_name
           @pathname.basename.sub_ext('.html')
+        end
+
+        def file_location
+          @pathname.sub_ext('.html')
         end
 
         def render

--- a/lib/rubycritic/generators/html/code_index.rb
+++ b/lib/rubycritic/generators/html/code_index.rb
@@ -9,6 +9,13 @@ module RubyCritic
 
         def initialize(analysed_modules)
           @analysed_modules = analysed_modules
+          set_header_links if Config.compare_branches_mode?
+        end
+
+        def set_header_links
+          @base_path = code_index_path(Config.base_root_directory, file_name)
+          @feature_path = code_index_path(Config.feature_root_directory, file_name)
+          @build_path = code_index_path(Config.build_root_directory, file_name)
         end
 
         def file_name

--- a/lib/rubycritic/generators/html/overview.rb
+++ b/lib/rubycritic/generators/html/overview.rb
@@ -14,6 +14,13 @@ module RubyCritic
           @score = analysed_modules.score
           @max_score = AnalysedModulesCollection::MAX_SCORE
           @summary = analysed_modules.summary
+          set_header_links if Config.compare_branches_mode?
+        end
+
+        def set_header_links
+          @base_path = code_index_path(Config.base_root_directory, file_name)
+          @feature_path = code_index_path(Config.feature_root_directory, file_name)
+          @build_path = code_index_path(Config.build_root_directory, file_name)
         end
 
         def file_name

--- a/lib/rubycritic/generators/html/smells_index.rb
+++ b/lib/rubycritic/generators/html/smells_index.rb
@@ -11,6 +11,13 @@ module RubyCritic
           @smells = analysed_modules.flat_map(&:smells).uniq
           @analysed_module_names = analysed_module_names(analysed_modules)
           @show_status = (Config.mode == :default)
+          set_header_links if Config.compare_branches_mode?
+        end
+
+        def set_header_links
+          @base_path = code_index_path(Config.base_root_directory, file_name)
+          @feature_path = code_index_path(Config.feature_root_directory, file_name)
+          @build_path = code_index_path(Config.build_root_directory, file_name)
         end
 
         def file_name

--- a/lib/rubycritic/generators/html/templates/code_index.html.erb
+++ b/lib/rubycritic/generators/html/templates/code_index.html.erb
@@ -23,6 +23,16 @@
             <tr>
               <td>
                 <% unless Config.suppress_ratings %>
+                  <% if Config.build_mode? %>
+                    <% master_analysed_module = Config.base_branch_collection.find(analysed_module.pathname) %>
+                    <% if master_analysed_module.cost > analysed_module.cost %>
+                      <span class="glyphicon glyphicon-arrow-up green-color"></span>
+                    <% elsif master_analysed_module.cost < analysed_module.cost %>
+                      <span class="glyphicon glyphicon-arrow-down red-color"></span>
+                    <% else %>
+                      <span class="empty-span glyphicon"></span>
+                    <% end %>
+                  <% end %>
                   <div class="rating <%= analysed_module.rating.to_s.downcase %>"><%= analysed_module.rating %></div>
                 <% end %>
               </td>

--- a/lib/rubycritic/generators/html/templates/layouts/application.html.erb
+++ b/lib/rubycritic/generators/html/templates/layouts/application.html.erb
@@ -19,6 +19,13 @@
     <header class="navbar navbar-default navbar-fixed-top">
       <a href="#menu-toggle" class="btn btn-default hidden-lg visible-sm-* hidden-md visible-xs-* pull-left" id="menu-toggle"><i class="fa fa-bars" aria-hidden="true"></i></a>
       <a href="<%= file_path('overview.html') %>"><img src="<%= image_path('logo.png') %>" title="Ruby Critic Logo" width="55"><span class="logo">RUBYCRITIC</span></a>
+      <% if Config.compare_branches_mode? %>
+        <ul class="nav navbar-nav navbar-right">
+          <a href="<%= @base_path %>"><span class="branch"><%= Config.base_branch %></span></a>
+          <a href="<%= @feature_path %>"><span class="branch"><%= Config.feature_branch %></span></a>
+          <a href="<%= @build_path %>"><span class="branch">Build</span></a>
+        </ul>
+      <% end %>
     </header>
     <div id="wrapper">
       <!-- Sidebar -->

--- a/lib/rubycritic/generators/html/view_helpers.rb
+++ b/lib/rubycritic/generators/html/view_helpers.rb
@@ -26,7 +26,16 @@ module RubyCritic
     end
 
     def smell_location_path(location)
-      file_path("#{location.pathname.sub_ext('.html')}#L#{location.line}")
+      smell_location = "#{location.pathname.sub_ext('.html')}#L#{location.line}"
+      if Config.compare_branches_mode?
+        file_path("#{File.expand_path(Config.feature_root_directory)}/#{smell_location}")
+      else
+        file_path(smell_location)
+      end
+    end
+
+    def code_index_path(root_directory, file_name)
+      file_path("#{File.expand_path(root_directory)}/#{file_name}")
     end
 
     private

--- a/lib/rubycritic/source_control_systems/git.rb
+++ b/lib/rubycritic/source_control_systems/git.rb
@@ -35,6 +35,28 @@ module RubyCritic
         travel_to_original_state if stash_successful
       end
 
+      def self.switch_branch(branch)
+        uncommitted_changes? ? `git checkout #{branch}` : abort('Uncommitted changes are present.')
+      end
+
+      def self.uncommitted_changes?
+        `git ls-files --other --exclude-standard --directory`.empty? && `git status --porcelain`.empty?
+      end
+
+      def self.modified_files
+        modified_files = `git diff --name-status #{Config.base_branch} #{Config.feature_branch}`
+        modified_files.split("\n").map do |line|
+          next if line.start_with?('D')
+          file_name = line.split("\t")[1]
+          file_name
+        end.compact
+      end
+
+      def self.current_branch
+        branch_list = `git branch`
+        branch_list.match(/\* \w*/)[0].gsub('* ', '')
+      end
+
       private
 
       def stash_changes

--- a/test/lib/rubycritic/commands/compare_test.rb
+++ b/test/lib/rubycritic/commands/compare_test.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+require 'test_helper'
+require 'rubycritic/commands/compare'
+require 'rubycritic/cli/options'
+require 'rubycritic/configuration'
+require 'rubycritic/source_control_systems/git'
+
+module RubyCritic
+  module SourceControlSystem
+    class Git < Base
+      def self.switch_branch(branch)
+        FileUtils.cp "test/samples/#{branch}_file.rb", 'test/samples/compare_file.rb'
+      end
+
+      def self.current_branch
+        'feature_branch'
+      end
+    end
+  end
+end
+
+describe RubyCritic::Command::Compare do
+  before do
+    RubyCritic::Browser.any_instance.stubs(:open).returns(nil)
+    RubyCritic::Reporter.stubs(:generate_report).returns(nil)
+    RubyCritic::Command::Compare.any_instance.stubs(:build_details).returns(nil)
+    RubyCritic::SourceControlSystem::Git.stubs(:modified_files).returns('test/samples/compare_file.rb')
+  end
+
+  describe 'compare' do
+    it 'should compare a file of different branch' do
+      options = ['-b', 'base_branch', '-t', '10', 'test/samples/compare_file.rb']
+      options = RubyCritic::Cli::Options.new(options).parse.to_h
+      RubyCritic::Config.set(options)
+      status_reporter = RubyCritic::Command::Compare.new(options).execute
+      status_reporter.score.must_equal RubyCritic::Config.feature_branch_score
+      status_reporter.status_message.must_equal "Score: #{RubyCritic::Config.feature_branch_score}"
+    end
+
+    after do
+      File.open('test/samples/compare_file.rb', 'w') { |file| file.truncate(0) }
+    end
+  end
+
+  describe 'with default options passing two branches' do
+    before do
+      options = ['-b', 'base_branch', '-t', '10', 'test/samples/compare_file.rb']
+      @options = RubyCritic::Cli::Options.new(options).parse.to_h
+    end
+
+    it 'with -b option withour pull request id' do
+      @options[:base_branch].must_equal 'base_branch'
+      @options[:feature_branch].must_equal 'feature_branch'
+      @options[:mode].must_equal :compare_branches
+      @options[:threshold_score].must_equal 10
+    end
+  end
+end

--- a/test/lib/rubycritic/core/analysed_modules_collection_test.rb
+++ b/test/lib/rubycritic/core/analysed_modules_collection_test.rb
@@ -38,6 +38,44 @@ describe RubyCritic::AnalysedModulesCollection do
         subject.count.must_equal 3
       end
     end
+
+    context 'with a list of files and initializing analysed modules with pre existing values' do
+      let(:paths) { %w(test/samples/empty.rb) }
+      let(:analysed_modules) do
+        [RubyCritic::AnalysedModule.new(pathname: Pathname.new('test/samples/empty.rb'), name: 'Name', smells: [],
+                                        churn: 2, committed_at: Time.now, complexity: 2, duplication: 0,
+                                        methods_count: 2)]
+      end
+
+      it 'registers one AnalysedModule element per existent file' do
+        analysed_modules_collection = RubyCritic::AnalysedModulesCollection.new(paths, analysed_modules)
+        analysed_modules_collection.count.must_equal 1
+        analysed_module = analysed_modules_collection.first
+        analysed_module.name.must_equal 'Name'
+        analysed_module.churn.must_equal 2
+        analysed_module.complexity.must_equal 2
+        analysed_module.duplication.must_equal 0
+        analysed_module.methods_count.must_equal 2
+      end
+    end
+  end
+
+  describe 'querying analysed_modules_collection' do
+    subject { RubyCritic::AnalysedModulesCollection.new(paths, analysed_modules) }
+
+    context 'with a list of files and initializing analysed modules with pre existing values' do
+      let(:paths) { %w(test/samples/empty.rb test/samples/unparsable.rb) }
+      let(:analysed_modules) do
+        [RubyCritic::AnalysedModule.new(pathname: Pathname.new('test/samples/empty.rb'), name: 'Empty'),
+         RubyCritic::AnalysedModule.new(pathname: Pathname.new('test/samples/unparsable.rb'), name: 'Unparsable')]
+      end
+
+      it 'registers one AnalysedModule element per existent file' do
+        subject.count.must_equal 2
+        subject.where(['test/samples/empty.rb']).count.must_equal 1
+        subject.where(['test/samples/unparsable.rb']).count.must_equal 1
+      end
+    end
   end
 
   describe '#score' do

--- a/test/samples/base_branch_file.rb
+++ b/test/samples/base_branch_file.rb
@@ -1,0 +1,2 @@
+class Signup
+end

--- a/test/samples/feature_branch_file.rb
+++ b/test/samples/feature_branch_file.rb
@@ -1,0 +1,34 @@
+class Signup 
+  def flay(parts)
+    parts -= 1
+    parts -= 2
+    parts -= 3
+    parts -= 4
+  end
+
+  def method_missing(method, *args, &block)
+    message = "I"
+    eval "message = ' did not'"
+    eval "message << ' exist,'"
+    eval "message << ' but now'"
+    eval "message << ' I do.'"
+    self.class.send(:define_method, method) { "I did not exist, but now I do." }
+    self.send(method)
+  end
+
+  def allow_nesting_iterators_two_levels_deep
+    loop do
+      loop do
+      end
+    end
+  end
+
+  def allow_many_statements
+    do_something
+    do_something
+    do_something
+    do_something
+    do_something
+    do_something
+  end
+end


### PR DESCRIPTION
Trying to solve [https://github.com/whitesmith/rubycritic/issues/161](https://github.com/whitesmith/rubycritic/issues/161)

Introducing -b option to compare files between two branches and another -t option is to set threshold for score difference between two branches.

Creating a separate build view which will have only the modified files in the code_index page, and links to two compared branches.
![screen shot 2016-12-15 at 4 49 38 pm](https://cloud.githubusercontent.com/assets/4988973/21222154/8365a026-c2e6-11e6-8d21-d48cc950b875.png)

