### PR TITLE
[Fixes #189] Use Ruby's File instead of `wc` system command

### DIFF
--- a/lib/rubycritic/core/analysed_module.rb
+++ b/lib/rubycritic/core/analysed_module.rb
@@ -32,7 +32,7 @@ module RubyCritic
     end
 
     def line_count
-      `wc -l "#{path}"`.strip.split(' ')[0].to_i
+      File.read(path).each_line.count
     end
 
     def cost


### PR DESCRIPTION
As indicated by @guilhermesimoes https://github.com/whitesmith/rubycritic/pull/184#discussion_r88904547