### PR TITLE
Running "rake rubycritic" in rails project does not display gpa-chart(in RubyCritic version 3.1.0)

### DIFF
--- a/lib/rubycritic/generators/html/turbulence.rb
+++ b/lib/rubycritic/generators/html/turbulence.rb
@@ -8,7 +8,7 @@ module RubyCritic
           name: analysed_module.name,
           x: analysed_module.churn,
           y: analysed_module.complexity,
-          rating: analysed_module.rating
+          rating: analysed_module.rating.to_s
         }
       end.to_json
     end


### PR DESCRIPTION

Hi guys,

New UI/UX of rubycritic(version 3.1.0) is awesome!! :tada: thx!

When I was going to upgrade "rubycritic" to version 3.1.0 in my rails project, I found that running `rake rubycritic` did not display gpa-chart.

I think that there is an interference problem between ActiveSupport's `Object#to_json` extension and `RubyCritic::Rating#to_json`.

### Reproducing

Versions:

* rails 5.0.0
* rubycritic 3.1.0

I use `lib/tasks/rubycritic.rake` like below:

```
require 'rubycritic/rake_task'
RubyCritic::RakeTask.new
```

I run:

```
$ bin/rake rubycritic
```

Results in:

**bad**
![bad](https://cloud.githubusercontent.com/assets/1394049/20860220/52167402-b9b6-11e6-9342-ec7aad56c6e5.png)

There are 2 bad points:

* Not displaying gpa-chart
* Colorless plots

But of course

```
$ bundle exec rubycritic .
```

will work well :). This outputs good html.

**good**
![good](https://cloud.githubusercontent.com/assets/1394049/20860222/598ad4b2-b9b6-11e6-909d-cf9ec8aa8a3f.png)

### overview.html source difference

Running `bin/rake rubycritic`(bad) v.s. Running `bundle exec rubycritic .`(good)

```diff
...(snip)....
 <script type="text/javascript">
   var turbulenceData = [
-    {"name":"ApplicationController","x":3,"y":0,"rating":{"letter":"A"}},
-    {"name":"BucketsController","x":12,"y":7,"rating":{"letter":"A"}}
+    {"name":"ApplicationController","x":3,"y":0,"rating":"A"},
+    {"name":"BucketsController","x":12,"y":7,"rating":"A"}
     ...(snip)....
   ];
   var score = 98.95833333333333;
 </script>
...(snip)....
```

So it seems that rendering `{"letter":"A"}` is bad.

### To fix it

Enforcing `rating` value to be a string value in `RubyCritic::Turbulence.data` solves this problem.
