### PR TITLE
Add ruby 2.3.3 to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ matrix:
     - rvm: 2.1.0
     - rvm: 2.1.10
     - rvm: 2.2.5
-    - rvm: 2.3.1
+    - rvm: 2.3.3
     - rvm: ruby-head
     - rvm: jruby-9.1.5.0
       env: JRUBY_OPTS='--debug' # get more accurate coverage data


### PR DESCRIPTION
We upgraded parser to version 2.3.3 but we need to make sure the build
passes for that version.