### PR TITLE
Drop the minor version from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ before_install: gem update bundler
 matrix:
   include:
     - rvm: 2.1.0
-    - rvm: 2.1.10
-    - rvm: 2.2.5
+    - rvm: 2.1
+    - rvm: 2.2
     - rvm: 2.3.3
     - rvm: ruby-head
     - rvm: jruby-9.1.5.0


### PR DESCRIPTION
Follow up from #199.

This way Travis will always test with the latest minor version, but sadly, `rvm: 2.3` is not working :\

@tejasbubane 