### PR TITLE
Fix errors when no source-control is found

### DIFF
--- a/lib/rubycritic/configuration.rb
+++ b/lib/rubycritic/configuration.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
+require 'rubycritic/source_control_systems/base'
+
 module RubyCritic
   class Configuration
     attr_reader :root
@@ -17,6 +19,11 @@ module RubyCritic
 
     def root=(path)
       @root = File.expand_path(path)
+    end
+
+    def source_control_present?
+      source_control_system &&
+        !source_control_system.is_a?(SourceControlSystem::Double)
     end
   end
 

--- a/lib/rubycritic/generators/html/templates/overview.html.erb
+++ b/lib/rubycritic/generators/html/templates/overview.html.erb
@@ -20,12 +20,16 @@
         <!--Churn vs Complexity graph-->
         <div class="col-xs-7 col-sm-7 col-md-6 col-lg-8">
           <div class="Graph_Cards fadeIn">
+            <% if Config.source_control_present? %>
+              <div id="churn-vs-complexity-graph-container" class="chart-container"></div>
+            <% else %>
+              <div id="churn-error">We can't show you Churn-vs-Complexity graph because this project does not seem to be under a source code management system like git or perforce at the moment. This doesn't mean that anything is wrong, it just means certain features like this one are not avaiable.</div>
+            <% end %>
 
-          <div id="churn-vs-complexity-graph-container" class="chart-container"></div>
-          <script type="text/javascript">
-            var turbulenceData = <%= @turbulence_data %>;
-            var score = <%= @score %>;
-          </script>
+            <script type="text/javascript">
+             var turbulenceData = <%= @turbulence_data %>;
+             var score = <%= @score %>;
+            </script>
           </div>
         </div>
         <!--End Churn vs Complexity graph-->

--- a/lib/rubycritic/source_control_systems/base.rb
+++ b/lib/rubycritic/source_control_systems/base.rb
@@ -19,7 +19,9 @@ module RubyCritic
         if supported_system
           supported_system.new
         else
-          puts "RubyCritic can provide more feedback if you use a #{connected_system_names} repository."
+          puts 'RubyCritic can provide more feedback if you use '\
+               "a #{connected_system_names} repository. "\
+               'Churn will not be calculated.'
           Double.new
         end
       end

--- a/lib/rubycritic/source_control_systems/double.rb
+++ b/lib/rubycritic/source_control_systems/double.rb
@@ -3,7 +3,7 @@ module RubyCritic
   module SourceControlSystem
     class Double < Base
       def revisions_count(_)
-        'N/A'
+        0
       end
 
       def date_of_last_commit(_)


### PR DESCRIPTION
Fixes #188 

Churn calculation requires source-control.
Do not show the churn-complexity graph when source control is not found.

![screen shot 2016-12-16 at 1 12 33 am](https://cloud.githubusercontent.com/assets/980783/21239403/c5ddc38e-c32c-11e6-8378-0c931fbc22ac.png)




