### PR TITLE
[ci skip] Use GitHub links in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,88 +1,92 @@
+# master (unreleased)
+
+
 # 3.1.2 / 2016-12-17
 
-* [BUGFIX] Fix lack of the GPA chart when used with rake/rails (by hoshinotsuyoshi)
-* [BUGFIX] Fix code navigation links in the new UI (by rohitcy)
+* [BUGFIX] Fix errors when no source-control is found (by [@tejasbubane][])
+* [BUGFIX] Fix lack of the GPA chart when used with rake/rails (by [@hoshinotsuyoshi][])
+* [BUGFIX] Fix code navigation links in the new UI (by [@rohitcy][])
 
 # 3.1.1 / 2016-12-02
 
-* [FEATURE] Implement search and filter on code and smells view (rohitcy)
-* [CHANGE] Use Ruby's File instead of `wc` system command (by tejasbubane)
-* [CHANGE] Add MRI 2.3.3 compatibility by updating `parser` to v2.3.3.1 (by josephpage)
-* [BUGFIX] Fix code navigation links in the new UI (by rohitcy)
-* [BUGFIX] Add missing method 'head_reference' for Perforce source control (Rataah)
+* [FEATURE] Implement search and filter on code and smells view (by [@rohitcy][])
+* [CHANGE] Use Ruby's File instead of `wc` system command (by [@tejasbubane][])
+* [CHANGE] Add MRI 2.3.3 compatibility by updating `parser` to v2.3.3.1 (by [@josephpage][])
+* [BUGFIX] Fix code navigation links in the new UI (by [@rohitcy][])
+* [BUGFIX] Add missing method 'head_reference' for Perforce source control (by [@Rataah][])
 
 # 3.1.0 / 2016-11-23
 
-* [FEATURE] Support for Perforce source control system (by Loic Gudet)
-* [CHANGE] New Web UI (by tejasbubane)
-* [CHANGE] Significant improvements to documentation (by olleolleolle)
-* [CHANGE] Typo / consistency updates to features and tests (by olleolleolle)
-* [CHANGE] Fix test warnings and upgrade 'parser' to '2.3.1.4' (by tejasbubane)
-* [BUGFIX] Increase the turboThreshold of Highcharts so that it renders nicely even with lots of data (by Victor Martins)
+* [FEATURE] Support for Perforce source control system (by [@Rataah][])
+* [CHANGE] New Web UI (by [@tejasbubane][])
+* [CHANGE] Significant improvements to documentation (by [@olleolleolle][])
+* [CHANGE] Typo / consistency updates to features and tests (by [@olleolleolle][])
+* [CHANGE] Fix test warnings and upgrade 'parser' to '2.3.1.4' (by [@tejasbubane][])
+* [BUGFIX] Increase the turboThreshold of Highcharts so that it renders nicely even with lots of data (by [@victormartins][])
 
 # 3.0.0 / 2016-11-01
 
-* [CHANGE] Set required ruby version to 2.1 (by Onumis)
-* [BUGFIX] Respect the .reek configuration file (by mereghost)
+* [CHANGE] Set required ruby version to 2.1 (by [@Onumis][])
+* [BUGFIX] Respect the .reek configuration file (by [@mereghost][])
 
 # 2.9.4 / 2016-09-16
 
-* [CHANGE] Update Reek, flog, flay (by bglusman)
+* [CHANGE] Update Reek, flog, flay (by [@bglusman][])
 
 # 2.9.3 / 2016-08-17
 
-* [FEATURE] Save json report to file  (by NickTroy)
-* [CHANGE] Rename Rubycritic to RubyCritic (by troessner)
+* [FEATURE] Save json report to file  (by [@NickTroy][])
+* [CHANGE] Rename Rubycritic to RubyCritic (by [@troessner][])
 
 # 2.9.2 / 2016-07-01
 
-* [CHANGE] Upgrade rubocop to 0.41.1 (by nijikon)
-* [CHANGE] Upgrade flog to 4.4.0 (by nijikon)
-* [CHANGE] Upgrade flay to 2.8.0 (by nijikon)
-* [CHANGE] Upgrade Reek to 4.1.0 and Parser to 2.3.1.2 (by y-yagi)
+* [CHANGE] Upgrade rubocop to 0.41.1 (by [@nijikon][])
+* [CHANGE] Upgrade flog to 4.4.0 (by [@nijikon][])
+* [CHANGE] Upgrade flay to 2.8.0 (by [@nijikon][])
+* [CHANGE] Upgrade Reek to 4.1.0 and Parser to 2.3.1.2 (by [@y-yagi][])
 
 # 2.9.1 / 2016-05-16
 
-* [CHANGE] Upgrade 'parser' to 2.3.1.0 (by y-yagi)
-* [CHANGE] Upgrade 'reek' to 4.0.2 (by onumis)
-* [CHANGE] Upgrade 'rubocop' to 0.40.0 (by onumis)
+* [CHANGE] Upgrade 'parser' to 2.3.1.0 (by [@y-yagi][])
+* [CHANGE] Upgrade 'reek' to 4.0.2 (by [@onumis][])
+* [CHANGE] Upgrade 'rubocop' to 0.40.0 (by [@onumis][])
 
 # 2.9.0 / 2016-04-12
 
-* [FEATURE] Add links to Flay and Flog code smells documentation (by ragesoss)
-* [FEATURE] Documentation updates (by troessner)
-* [CHANGE] Bump Rubocop to 0.39.0 (by nijikon)
-* [CHANGE] Bump Reek to 4.0.1 (by nijikon)
-* [CHANGE] Drop support for Ruby 2.0 (by nijikon)
+* [FEATURE] Add links to Flay and Flog code smells documentation (by [@ragesoss][])
+* [FEATURE] Documentation updates (by [@troessner][])
+* [CHANGE] Bump Rubocop to 0.39.0 (by [@nijikon][])
+* [CHANGE] Bump Reek to 4.0.1 (by [@nijikon][])
+* [CHANGE] Drop support for Ruby 2.0 (by [@nijikon][])
 
 # 2.8.0 / 2016-02-29
 
-* [FEATURE] Add link to Reek's code smells documentation (by danielmbarlow)
-* [FEATURE] Make RubyCritic usable as Rake Task (by Timo Rößner)
-* [CHANGE] Bump Rubocop to 0.37.2 (by Tomasz Pajor)
-* [CHANGE] Bump Flay to 2.7.0 (by Tomasz Pajor)
-* [CHANGE] Bump Reek to 3.11 (by Tomasz Pajor)
-* [CHANGE] Add explicit runtime dependency on ruby_parser ('~> 3.8') (by Nuno Silva)
+* [FEATURE] Add link to Reek's code smells documentation (by [@danielmbarlow][])
+* [FEATURE] Make RubyCritic usable as Rake Task (by [@troessner][])
+* [CHANGE] Bump Rubocop to 0.37.2 (by [@nijikon][])
+* [CHANGE] Bump Flay to 2.7.0 (by [@nijikon][])
+* [CHANGE] Bump Reek to 3.11 (by [@nijikon][])
+* [CHANGE] Add explicit runtime dependency on ruby_parser ('~> 3.8') (by [@Onumis][])
 
 # 2.7.1 / 2016-02-09
 
-* [CHANGE] Bump Reek to 3.10.1 (by Tomasz Pajor)
-* [BUGFIX] Analyse only the files whose paths are specified in the CLI (by Nuno Silva)
+* [CHANGE] Bump Reek to 3.10.1 (by [@nijikon][])
+* [BUGFIX] Analyse only the files whose paths are specified in the CLI (by [@Onumis][])
 
 # 2.7.0 / 2016-01-23
 
-* [FEATURE] Open html report with browser (by YingRui Lu)
+* [FEATURE] Open html report with browser (by [@superiorlu][])
 * [CHANGE] Bump Reek to 3.9.1
 * [CHANGE] Bump Rubocop to 0.36 and internal cleanup (preparing for Ruby 2.3)
 
 # 2.6.0 / 2016-01-21
 
-* [FEATURE] Add a minimum score option to the command line interface (by Roberto Schneider)
+* [FEATURE] Add a minimum score option to the command line interface (by [@RobertoSchneiders][])
 * [CHANGE] Display the class and module names when the file has no methods
 
 # 2.5.0 / 2016-01-16
 
-* [FEATURE] Add a ConsoleReport format (by Josh Bodah)
+* [FEATURE] Add a ConsoleReport format (by [@jbodah][])
 
 # 2.4.1 / 2015-12-27
 
@@ -90,11 +94,11 @@
 
 # 2.4.0 / 2015-12-26
 
-* [FEATURE] Add progress bar functionality (by Nate Holland)
+* [FEATURE] Add progress bar functionality (by [@natesholland][])
 
 # 2.3.0 / 2015-11-30
 
-* [FEATURE] Added global score calculation (by Ancor Gonzalez Sosa)
+* [FEATURE] Added global score calculation (by [@ancorgs][])
 * [CHANGE] Bump Reek dependency to 3.7.1.
 
 # 2.2.0 / 2015-11-20
@@ -114,12 +118,12 @@
 # 1.4.0 / 2015-03-14
 
 * [FEATURE] New report in JSON format. Available by using the new CLI option `-f`
-* [FEATURE] New CLI option `--suppress-ratings` to suppress ratings (by halostatue)
-* [CHANGE] Improve UI, particularly the sortable tables (by crackofdusk)
+* [FEATURE] New CLI option `--suppress-ratings` to suppress ratings (by [@halostatue][])
+* [CHANGE] Improve UI, particularly the sortable tables (by [@crackofdusk][])
 
 # 1.3.0 / 2015-02-16
 
-* [FEATURE] New CLI option `--deduplicate-symlinks` to deduplicate symlinks (by LeeXGreen)
+* [FEATURE] New CLI option `--deduplicate-symlinks` to deduplicate symlinks (by [@LeeXGreen][])
 * [CHANGE] Update to Reek 1.6.5 (from 1.6.3)
 * [CHANGE] Remove ruby2ruby dependency
 
@@ -156,3 +160,29 @@
 # 1.0.0 / 2014-07-13
 
 * Official Release
+
+
+[@LeeXGreen]: https://github.com/LeeXGreen
+[@crackofdusk]: https://github.com/crackofdusk
+[@halostatue]: https://github.com/halostatue
+[@ancorgs]: https://github.com/ancorgs
+[@natesholland]: https://github.com/natesholland
+[@jbodah]: https://github.com/jbodah
+[@RobertoSchneiders]: https://github.com/RobertoSchneiders
+[@superiorlu]: https://github.com/superiorlu
+[@Onumis]: https://github.com/Onumis
+[@nijikon]: https://github.com/nijikon
+[@troessner]: https://github.com/troessner
+[@danielmbarlow]: https://github.com/danielmbarlow
+[@ragesoss]: https://github.com/ragesoss
+[@y-yagi]: https://github.com/y-yagi
+[@NickTroy]: https://github.com/NickTroy
+[@bglusman]: https://github.com/bglusman
+[@mereghost]: https://github.com/mereghost
+[@victormartins]: https://github.com/victormartins
+[@tejasbubane]: https://github.com/tejasbubane
+[@olleolleolle]: https://github.com/olleolleolle
+[@Rataah]: https://github.com/Rataah
+[@rohitcy]: https://github.com/rohitcy
+[@josephpage]: https://github.com/josephpage
+[@hoshinotsuyoshi]: https://github.com/hoshinotsuyoshi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,19 +20,21 @@ If you want to squash a bug or add a new feature, please:
 
 4. Run the tests with the `rake` command. Make sure that they are still passing.
 
-5. [Stage partial-file changesets] \(`git add -p`).
+5. Add a Changelog entry. Refer [Changelog entry format](#changelog-entry-format).
 
-6. Commit your changes (`git commit`).
+6. [Stage partial-file changesets] \(`git add -p`).
+
+7. Commit your changes (`git commit`).
 Make exactly as many commits as you need.
 Each commit should do one thing and one thing only. For example, all whitespace fixes should be relegated to a single commit.
 
-7. Write [descriptive commit messages].
+8. Write [descriptive commit messages].
 
-8. Push the branch to GitHub (`git push origin my-new-feature`).
+9. Push the branch to GitHub (`git push origin my-new-feature`).
 
-9. [Create a Pull Request] and send it to be merged with the master branch.
+10. [Create a Pull Request] and send it to be merged with the master branch.
 
-10. After your code is reviewed, [hide the sausage making]. We follow the "one commit per pull request" [principle](http://ndlib.github.io/practices/one-commit-per-pull-request/) since this allows for a clean git history, easy handling of features and convenient rollbacks when things go wrong. Or in one sentence: You can have as many commits as you want in your pull request, but after the final review and before the merge you need to squash all of those in one single commit.
+11. After your code is reviewed, [hide the sausage making]. We follow the "one commit per pull request" [principle](http://ndlib.github.io/practices/one-commit-per-pull-request/) since this allows for a clean git history, easy handling of features and convenient rollbacks when things go wrong. Or in one sentence: You can have as many commits as you want in your pull request, but after the final review and before the merge you need to squash all of those in one single commit.
 For a more in-depth look at interactive rebasing, be sure to check [how to rewrite history] as well.
 
 Improving the Documentation
@@ -70,3 +72,21 @@ If you are experiencing unexpected behavior and, after having read the documenta
 [issues tracker]: https://github.com/whitesmith/rubycritic/issues
 [Create a new issue]: https://github.com/whitesmith/rubycritic/issues/new
 [How to Report Bugs Effectively]: http://www.chiark.greenend.org.uk/~sgtatham/bugs.html
+
+Changelog entry format
+------------------------
+Here are a few examples:
+
+```
+* [BUGFIX] Fix errors when no source-control is found (by [@tejasbubane][])
+* [BUGFIX] Fix lack of the GPA chart when used with rake/rails (by [@hoshinotsuyoshi][])
+* [BUGFIX] Fix code navigation links in the new UI (by [@rohitcy][])
+```
+
+* Mark it up in [Markdown syntax](http://daringfireball.net/projects/markdown/syntax).
+* Add your entry in the `master (unreleased)` section.
+* The entry line should start with `* ` (an asterisk and a space).
+* Start with the change type BUGFIX / CHANGE / FEATURE.
+* Describe the brief of the change.
+* At the end of the entry, add an implicit link to your GitHub user page as `([@username][])`.
+* If this is your first contribution to RuboCop project, add a link definition for the implicit link to the bottom of the changelog as `[@username]: https://github.com/username`.


### PR DESCRIPTION
* Use markdown reference-style links - inspired by [Rubocop's CHANGELOG](https://github.com/bbatsov/rubocop/blob/master/CHANGELOG.md).
* Add corresponding section in CONTRIBUTING.md