### PR TITLE
Accept a float as the minimum score

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ $ rubycritic --help
 | `-v` / `--version`       | Displays the current version and exits                |
 | `-p` / `--path`          | Set path where report will be saved (tmp/rubycritic by default) |
 | `-f` / `--format`        | Report smells in the given format: `html` (default; will open in a browser), `json`, `console`. |
-| `-s` / `--minimum-score` | Set a minimum score                                   |
+| `-s` / `--minimum-score` | Set a minimum score (FLOAT: ex: 96.28)                |
 | `--mode-ci`              | Use CI mode (faster, but only analyses last commit)   |
 | `--deduplicate-symlinks` | De-duplicate symlinks based on their final target     |
 | `--suppress-ratings`     | Suppress letter ratings                               |

--- a/lib/rubycritic/cli/options.rb
+++ b/lib/rubycritic/cli/options.rb
@@ -31,7 +31,7 @@ module RubyCritic
           end
 
           opts.on('-s', '--minimum-score [MIN_SCORE]', 'Set a minimum score') do |min_score|
-            self.minimum_score = Integer(min_score)
+            self.minimum_score = Float(min_score)
           end
 
           opts.on('-m', '--mode-ci', 'Use CI mode (faster, but only analyses last commit)') do

--- a/test/lib/rubycritic/commands/status_reporter_test.rb
+++ b/test/lib/rubycritic/commands/status_reporter_test.rb
@@ -49,13 +49,13 @@ describe RubyCritic::Command::StatusReporter do
       it 'should return the correct status' do
         @reporter.score = score
         @reporter.status.must_equal score_below_minimum
-        @reporter.status_message.must_equal 'Score (98.0) is below the minimum 99'
+        @reporter.status_message.must_equal 'Score (98.0) is below the minimum 99.0'
       end
 
       it 'should format the score' do
         @reporter.score = 98.95258620689656
         @reporter.status.must_equal score_below_minimum
-        @reporter.status_message.must_equal 'Score (98.95) is below the minimum 99'
+        @reporter.status_message.must_equal 'Score (98.95) is below the minimum 99.0'
       end
     end
 


### PR DESCRIPTION
Changed the CLI option for minimum score to a `Float` instead of an `Integer` and updated the tests.

This allows us to take the result of our previous scan (97.72) and set that as the minimum score.