### PR TITLE
Update RuboCop to 0.47.1 from 0.42.0.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,4 +18,9 @@ Metrics/LineLength:
 Style/Documentation:
   Enabled: false
 
+Security/MarshalLoad:
+  Enabled: false
+  Include:
+    - 'lib/rubycritic/serializer.rb'
+
 inherit_from: .rubocop_todo.yml

--- a/rubycritic.gemspec
+++ b/rubycritic.gemspec
@@ -37,5 +37,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'minitest', '~> 5.3'
   spec.add_development_dependency 'mocha', '~> 1.1'
-  spec.add_development_dependency 'rubocop', '>= 0.42.0'
+  spec.add_development_dependency 'rubocop', '>= 0.47.1'
 end


### PR DESCRIPTION
Obvious change to `rubycritic.gemspec`. This commit also changes the
`.rubocop.yml` file to disable a `Security/MarshalLoad` cop (introduced
in RuboCop 0.47.0) from flagging the `RubyCritic::Serializer.load`
method. Interestingly, wrapping that method in RuboCop disable/enable
comments for that cop simply flags a `Lint/UnneededDisable` violation.
Go figure. Adding the one file to a disable-Security/MarshalLoad entry
in `.rubocop.yml` solves the problem, even if it does feel like shooting
a fly with an RPG.