### PR TITLE
Update for Ruby 2.4 compatibility; update parser Gem. [Closes #218]

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,4 +23,14 @@ Security/MarshalLoad:
   Include:
     - 'lib/rubycritic/serializer.rb'
 
+Style/RedundantFreeze:
+  Enabled: false
+  Include:
+    - 'lib/rubycritic/core/smell.rb'
+    - 'lib/rubycritic/generators/json/simple.rb'
+    - 'lib/rubycritic/revision_comparator.rb'
+    - 'lib/rubycritic/source_control_systems/perforce.rb'
+    - 'lib/rubycritic/source_locator.rb'
+    - 'lib/rubycritic/version.rb'
+
 inherit_from: .rubocop_todo.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 # 3.1.3 / 2016-12-19
 
 * [BUGFIX] Fix crash with the usage of an unavailable color in "rainbow" gem  (by [@thedrow][])
+* [CHANGE] Update `rubocop` to 0.47.1 from 0.42.0 (by [@jdickey][])
+* [CHANGE] Update for Ruby 2.4.0 compatibility; update `parser` gem to 2.4.0 (by [@jdickey][])
 
 # 3.1.2 / 2016-12-17
 
@@ -190,3 +192,4 @@
 [@josephpage]: https://github.com/josephpage
 [@hoshinotsuyoshi]: https://github.com/hoshinotsuyoshi
 [@thedrow]: https://github.com/thedrow
+[@jdickey]: https://github.com/jdickey

--- a/rubycritic.gemspec
+++ b/rubycritic.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'flay', '~> 2.8'
   spec.add_runtime_dependency 'flog', '~> 4.4'
   spec.add_runtime_dependency 'reek', '~> 4.4'
-  spec.add_runtime_dependency 'parser', '2.3.3.1'
+  spec.add_runtime_dependency 'parser', '2.4.0'
   spec.add_runtime_dependency 'ruby_parser', '~> 3.8'
   spec.add_runtime_dependency 'rainbow', '~> 2.1'
   spec.add_runtime_dependency 'launchy', '2.4.3'


### PR DESCRIPTION
The only change needed to support Ruby 2.4 was to specify Version 2.4.0 of the `parser` Gem rather than the previous Version 2.3.3.1. However, with the updated `parser` Gem, RuboCop reported several offences that it had not done previously. These were all involving explicit calls to `#freeze` on string literals already frozen using the pragma comment `# frozen_string_literal: true`. The previous version of the parser clearly did not honour the comment pragma, which led RuboCop to assume that the strings had not previously been frozen.

[Closes #218]