### PR TITLE
Add YARD options file, render images in generated docs

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -1,0 +1,5 @@
+--no-private
+--use-cache
+--asset images
+lib/**/*.rb -
+README.md LICENSE.txt CHANGELOG.md

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ RubyCritic
 [![Build Status](https://travis-ci.org/whitesmith/rubycritic.svg?branch=master)](https://travis-ci.org/whitesmith/rubycritic)
 [![Code Climate](https://codeclimate.com/github/whitesmith/rubycritic/badges/gpa.svg)](https://codeclimate.com/github/whitesmith/rubycritic)
 
-<img src="/images/logo.png" alt="RubyCritic Icon" align="right" />
+<img src="./images/logo.png" alt="RubyCritic Icon" align="right" />
 RubyCritic is a gem that wraps around static analysis gems such as [Reek][1], [Flay][2] and [Flog][3] to provide a quality report of your Ruby code.
 
 **Table of Contents**
@@ -28,15 +28,15 @@ This gem provides features such as:
 
 1. An overview of your project:
 
-  ![RubyCritic overview screenshot](/images/overview.png)
+  ![RubyCritic overview screenshot](./images/overview.png)
 
 2. An index of the project files with their respective number of smells:
 
-  ![RubyCritic code index screenshot](/images/code.png)
+  ![RubyCritic code index screenshot](./images/code.png)
 
 3. An index of the smells detected:
 
-  ![RubyCritic smells index screenshot](/images/smells.png)
+  ![RubyCritic smells index screenshot](./images/smells.png)
 
 4. When analysing code like the following:
 
@@ -52,11 +52,11 @@ This gem provides features such as:
 
   It basically turns something like this:
 
-  ![Reek output screenshot](/images/reek.png)
+  ![Reek output screenshot](./images/reek.png)
 
   Into something like this:
 
-  ![RubyCritic file code screenshot](/images/smell-details.png)
+  ![RubyCritic file code screenshot](./images/smell-details.png)
 
 5. It uses your source control system (only Git, Mercurial and Perforce
   are currently supported) to compare your currently uncommitted
@@ -215,7 +215,7 @@ The current core team consists of:
 
 ## Credits
 
-![Whitesmith](/images/whitesmith.png)
+![Whitesmith](./images/whitesmith.png)
 
 RubyCritic is maintained and funded by [Whitesmith][9]. Tweet your questions or suggestions to [@Whitesmithco][10].
 


### PR DESCRIPTION
This PR adds a configuration file for YARD, the API docs generator.

To make the documentation pretty:

  - README: image tags with relative links, so that it can render elsewhere, too.
  - Generated docs: copy `images/` directory as "assets" to the output folder (`doc/`)