### PR TITLE
Tweak CHANGELOG.md since v3.1.3 doesn't support Ruby 2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # master (unreleased)
 
+* [CHANGE] Update `rubocop` to 0.47.1 from 0.42.0 (by [@jdickey][])
+* [CHANGE] Update for Ruby 2.4.0 compatibility; update `parser` gem to 2.4.0 (by [@jdickey][])
+
 # 3.1.3 / 2016-12-19
 
 * [BUGFIX] Fix crash with the usage of an unavailable color in "rainbow" gem  (by [@thedrow][])
-* [CHANGE] Update `rubocop` to 0.47.1 from 0.42.0 (by [@jdickey][])
-* [CHANGE] Update for Ruby 2.4.0 compatibility; update `parser` gem to 2.4.0 (by [@jdickey][])
 
 # 3.1.2 / 2016-12-17
 


### PR DESCRIPTION
It seems that master supports Ruby 2.4.0 (thanks for @jdickey 👏 👏 ) but v3.1.3 doesn't.

And, you know, three months has already passed since Ruby 2.4.0 was out. Could you release the next version? 