### PR TITLE
Update the "Getting Started"

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ If you'd rather install RubyCritic using Bundler, add this line to your
 application's Gemfile:
 
 ```ruby
-gem "rubycritic", :require => false
+gem "rubycritic", require: false
 ```
 
 And then execute:


### PR DESCRIPTION
RubyCritic supports Ruby 2.1 or higher. I think that Ruby 1.9's hash syntax is good for sample on how to write to Gemfile.