### PR TITLE
Fix a RuboCop offenses

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -40,3 +40,6 @@ Style/MethodMissing:
   Exclude: 
     - 'lib/rubycritic/configuration.rb'
 
+# Offense count: 3
+Style/IndentHeredoc:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 # Specify your gem's dependencies in rubycritic.gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'bundler/gem_tasks'
 require 'rake/testtask'
 require 'rubocop/rake_task'
@@ -24,4 +25,4 @@ RubyCritic::RakeTask.new do |task|
   task.paths = FileList['lib/**/*.rb']
 end
 
-task default: [:test, :features, :reek, :rubocop]
+task default: %i[test features reek rubocop]

--- a/features/step_definitions/rake_task_steps.rb
+++ b/features/step_definitions/rake_task_steps.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 When(/^I run rake (\w*) with:$/) do |name, task_def|
   rake(name, task_def)
 end

--- a/features/step_definitions/rubycritic_steps.rb
+++ b/features/step_definitions/rubycritic_steps.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 When(/^I run rubycritic (.*)$/) do |args|
   rubycritic(args)
 end

--- a/features/step_definitions/sample_file_steps.rb
+++ b/features/step_definitions/sample_file_steps.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 Given(/^the smelly file 'smelly.rb'/) do
   contents = <<-EOS.strip_heredoc
     class AllTheMethods

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_relative '../../lib/rubycritic'
 require_relative '../../lib/rubycritic/cli/application'
 require_relative '../../lib/rubycritic/commands/status_reporter'

--- a/lib/rubycritic.rb
+++ b/lib/rubycritic.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rubycritic/command_factory'
 
 module RubyCritic

--- a/lib/rubycritic/analysers/attributes.rb
+++ b/lib/rubycritic/analysers/attributes.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rubycritic/analysers/helpers/methods_counter'
 require 'rubycritic/analysers/helpers/modules_locator'
 require 'rubycritic/colorize'

--- a/lib/rubycritic/analysers/churn.rb
+++ b/lib/rubycritic/analysers/churn.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rubycritic/colorize'
 
 module RubyCritic

--- a/lib/rubycritic/analysers/complexity.rb
+++ b/lib/rubycritic/analysers/complexity.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rubycritic/analysers/helpers/flog'
 require 'rubycritic/colorize'
 

--- a/lib/rubycritic/analysers/helpers/ast_node.rb
+++ b/lib/rubycritic/analysers/helpers/ast_node.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
+
 module Parser
   module AST
     class Node
-      MODULE_TYPES = [:module, :class].freeze
+      MODULE_TYPES = %i[module class].freeze
 
       def count_nodes_of_type(*types)
         count = 0

--- a/lib/rubycritic/analysers/helpers/flay.rb
+++ b/lib/rubycritic/analysers/helpers/flay.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'flay'
 
 module RubyCritic

--- a/lib/rubycritic/analysers/helpers/flog.rb
+++ b/lib/rubycritic/analysers/helpers/flog.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'flog'
 
 module RubyCritic

--- a/lib/rubycritic/analysers/helpers/methods_counter.rb
+++ b/lib/rubycritic/analysers/helpers/methods_counter.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rubycritic/analysers/helpers/parser'
 
 module RubyCritic

--- a/lib/rubycritic/analysers/helpers/modules_locator.rb
+++ b/lib/rubycritic/analysers/helpers/modules_locator.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rubycritic/analysers/helpers/parser'
 
 module RubyCritic

--- a/lib/rubycritic/analysers/helpers/parser.rb
+++ b/lib/rubycritic/analysers/helpers/parser.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'parser/current'
 require 'rubycritic/analysers/helpers/ast_node'
 

--- a/lib/rubycritic/analysers/helpers/reek.rb
+++ b/lib/rubycritic/analysers/helpers/reek.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'reek'
 
 module RubyCritic

--- a/lib/rubycritic/analysers/smells/flay.rb
+++ b/lib/rubycritic/analysers/smells/flay.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rubycritic/analysers/helpers/flay'
 require 'rubycritic/core/smell'
 require 'rubycritic/colorize'

--- a/lib/rubycritic/analysers/smells/flog.rb
+++ b/lib/rubycritic/analysers/smells/flog.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rubycritic/analysers/helpers/flog'
 require 'rubycritic/core/smell'
 require 'rubycritic/colorize'

--- a/lib/rubycritic/analysers/smells/reek.rb
+++ b/lib/rubycritic/analysers/smells/reek.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rubycritic/analysers/helpers/reek'
 require 'rubycritic/core/smell'
 require 'rubycritic/colorize'

--- a/lib/rubycritic/analysers_runner.rb
+++ b/lib/rubycritic/analysers_runner.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rubycritic/core/analysed_modules_collection'
 require 'rubycritic/analysers/smells/flay'
 require 'rubycritic/analysers/smells/flog'

--- a/lib/rubycritic/analysis_summary.rb
+++ b/lib/rubycritic/analysis_summary.rb
@@ -11,7 +11,7 @@ module RubyCritic
     end
 
     def generate
-      %w(A B C D F).each_with_object({}) do |rating, summary|
+      %w[A B C D F].each_with_object({}) do |rating, summary|
         summary[rating] = generate_for(rating)
       end
     end

--- a/lib/rubycritic/browser.rb
+++ b/lib/rubycritic/browser.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'launchy'
 
 module RubyCritic

--- a/lib/rubycritic/cli/application.rb
+++ b/lib/rubycritic/cli/application.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rubycritic'
 require 'rubycritic/cli/options'
 require 'rubycritic/command_factory'

--- a/lib/rubycritic/cli/options.rb
+++ b/lib/rubycritic/cli/options.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'optparse'
 require 'rubycritic/browser'
 
@@ -21,7 +22,7 @@ module RubyCritic
 
           opts.on(
             '-f', '--format [FORMAT]',
-            [:html, :json, :console],
+            %i[html json console],
             'Report smells in the given format:',
             '  html (default; will open in a browser)',
             '  json',

--- a/lib/rubycritic/colorize.rb
+++ b/lib/rubycritic/colorize.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module RubyCritic
   module Colorize
     def colorize(text, color_code)

--- a/lib/rubycritic/command_factory.rb
+++ b/lib/rubycritic/command_factory.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rubycritic/configuration'
 
 module RubyCritic

--- a/lib/rubycritic/commands/base.rb
+++ b/lib/rubycritic/commands/base.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rubycritic/commands/status_reporter'
 
 module RubyCritic

--- a/lib/rubycritic/commands/ci.rb
+++ b/lib/rubycritic/commands/ci.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rubycritic/source_control_systems/base'
 require 'rubycritic/analysers_runner'
 require 'rubycritic/reporter'

--- a/lib/rubycritic/commands/default.rb
+++ b/lib/rubycritic/commands/default.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rubycritic/source_control_systems/base'
 require 'rubycritic/analysers_runner'
 require 'rubycritic/revision_comparator'

--- a/lib/rubycritic/commands/help.rb
+++ b/lib/rubycritic/commands/help.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rubycritic/commands/base'
 
 module RubyCritic

--- a/lib/rubycritic/commands/status_reporter.rb
+++ b/lib/rubycritic/commands/status_reporter.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module RubyCritic
   module Command
     class StatusReporter

--- a/lib/rubycritic/commands/version.rb
+++ b/lib/rubycritic/commands/version.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rubycritic/version'
 require 'rubycritic/commands/base'
 

--- a/lib/rubycritic/configuration.rb
+++ b/lib/rubycritic/configuration.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rubycritic/source_control_systems/base'
 
 module RubyCritic

--- a/lib/rubycritic/core/analysed_module.rb
+++ b/lib/rubycritic/core/analysed_module.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'virtus'
 require 'rubycritic/core/rating'
 

--- a/lib/rubycritic/core/analysed_modules_collection.rb
+++ b/lib/rubycritic/core/analysed_modules_collection.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rubycritic/source_locator'
 require 'rubycritic/core/analysed_module'
 

--- a/lib/rubycritic/core/location.rb
+++ b/lib/rubycritic/core/location.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'pathname'
 
 module RubyCritic

--- a/lib/rubycritic/core/rating.rb
+++ b/lib/rubycritic/core/rating.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module RubyCritic
   class Rating
     def self.from_cost(cost)

--- a/lib/rubycritic/core/smell.rb
+++ b/lib/rubycritic/core/smell.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'virtus'
 require 'rubycritic/core/location'
 

--- a/lib/rubycritic/generators/console_report.rb
+++ b/lib/rubycritic/generators/console_report.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rubycritic/generators/text/list'
 
 module RubyCritic

--- a/lib/rubycritic/generators/html/base.rb
+++ b/lib/rubycritic/generators/html/base.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'erb'
 require 'pathname'
 require 'rubycritic/generators/html/view_helpers'

--- a/lib/rubycritic/generators/html/code_file.rb
+++ b/lib/rubycritic/generators/html/code_file.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rubycritic/generators/html/base'
 require 'rubycritic/generators/html/line'
 

--- a/lib/rubycritic/generators/html/code_index.rb
+++ b/lib/rubycritic/generators/html/code_index.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rubycritic/generators/html/base'
 
 module RubyCritic

--- a/lib/rubycritic/generators/html/line.rb
+++ b/lib/rubycritic/generators/html/line.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'cgi'
 require 'rubycritic/generators/html/base'
 

--- a/lib/rubycritic/generators/html/overview.rb
+++ b/lib/rubycritic/generators/html/overview.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rubycritic/generators/html/base'
 require 'rubycritic/generators/html/turbulence'
 require 'rubycritic/analysis_summary'

--- a/lib/rubycritic/generators/html/smells_index.rb
+++ b/lib/rubycritic/generators/html/smells_index.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rubycritic/generators/html/base'
 
 module RubyCritic

--- a/lib/rubycritic/generators/html/turbulence.rb
+++ b/lib/rubycritic/generators/html/turbulence.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'json'
 module RubyCritic
   module Turbulence

--- a/lib/rubycritic/generators/html/view_helpers.rb
+++ b/lib/rubycritic/generators/html/view_helpers.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module RubyCritic
   module ViewHelpers
     def timeago_tag(time)

--- a/lib/rubycritic/generators/html_report.rb
+++ b/lib/rubycritic/generators/html_report.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'fileutils'
 require 'rubycritic/configuration'
 require 'rubycritic/generators/html/overview'

--- a/lib/rubycritic/generators/json/simple.rb
+++ b/lib/rubycritic/generators/json/simple.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'json'
 require 'rubycritic/version'
 require 'pathname'

--- a/lib/rubycritic/generators/json_report.rb
+++ b/lib/rubycritic/generators/json_report.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rubycritic/generators/json/simple'
 
 module RubyCritic

--- a/lib/rubycritic/generators/text/list.rb
+++ b/lib/rubycritic/generators/text/list.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rainbow'
 
 module RubyCritic

--- a/lib/rubycritic/rake_task.rb
+++ b/lib/rubycritic/rake_task.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rake'
 require 'rake/tasklib'
 require 'English'

--- a/lib/rubycritic/reporter.rb
+++ b/lib/rubycritic/reporter.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module RubyCritic
   module Reporter
     def self.generate_report(analysed_modules)

--- a/lib/rubycritic/serializer.rb
+++ b/lib/rubycritic/serializer.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'fileutils'
 
 module RubyCritic

--- a/lib/rubycritic/smells_status_setter.rb
+++ b/lib/rubycritic/smells_status_setter.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module RubyCritic
   module SmellsStatusSetter
     def self.set(smells_before, smells_now)

--- a/lib/rubycritic/source_control_systems/base.rb
+++ b/lib/rubycritic/source_control_systems/base.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'shellwords'
 
 module RubyCritic

--- a/lib/rubycritic/source_control_systems/double.rb
+++ b/lib/rubycritic/source_control_systems/double.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module RubyCritic
   module SourceControlSystem
     class Double < Base

--- a/lib/rubycritic/source_control_systems/git.rb
+++ b/lib/rubycritic/source_control_systems/git.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module RubyCritic
   module SourceControlSystem
     class Git < Base

--- a/lib/rubycritic/source_control_systems/mercurial.rb
+++ b/lib/rubycritic/source_control_systems/mercurial.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module RubyCritic
   module SourceControlSystem
     class Mercurial < Base

--- a/lib/rubycritic/source_control_systems/perforce.rb
+++ b/lib/rubycritic/source_control_systems/perforce.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'date'
 
 module RubyCritic

--- a/rubycritic.gemspec
+++ b/rubycritic.gemspec
@@ -1,5 +1,6 @@
 # coding: utf-8
 # frozen_string_literal: true
+
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'rubycritic/version'

--- a/test/analysers_test_helper.rb
+++ b/test/analysers_test_helper.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'test_helper'
 
 class AnalysedModuleDouble < OpenStruct; end

--- a/test/lib/rubycritic/analysers/churn_test.rb
+++ b/test/lib/rubycritic/analysers/churn_test.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'analysers_test_helper'
 require 'rubycritic/analysers/churn'
 require 'rubycritic/source_control_systems/base'

--- a/test/lib/rubycritic/analysers/complexity_test.rb
+++ b/test/lib/rubycritic/analysers/complexity_test.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'analysers_test_helper'
 require 'rubycritic/analysers/complexity'
 

--- a/test/lib/rubycritic/analysers/helpers/methods_counter_test.rb
+++ b/test/lib/rubycritic/analysers/helpers/methods_counter_test.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'analysers_test_helper'
 require 'rubycritic/analysers/helpers/methods_counter'
 

--- a/test/lib/rubycritic/analysers/helpers/modules_locator_test.rb
+++ b/test/lib/rubycritic/analysers/helpers/modules_locator_test.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'test_helper'
 require 'rubycritic/analysers/helpers/modules_locator'
 require 'rubycritic/core/analysed_module'

--- a/test/lib/rubycritic/analysers/smells/flay_test.rb
+++ b/test/lib/rubycritic/analysers/smells/flay_test.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'test_helper'
 require 'rubycritic/analysers/smells/flay'
 require 'rubycritic/core/analysed_module'

--- a/test/lib/rubycritic/analysers/smells/flog_test.rb
+++ b/test/lib/rubycritic/analysers/smells/flog_test.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'analysers_test_helper'
 require 'rubycritic/analysers/smells/flog'
 

--- a/test/lib/rubycritic/analysers/smells/reek_test.rb
+++ b/test/lib/rubycritic/analysers/smells/reek_test.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'analysers_test_helper'
 require 'rubycritic/analysers/smells/reek'
 

--- a/test/lib/rubycritic/analysis_summary_test.rb
+++ b/test/lib/rubycritic/analysis_summary_test.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'test_helper'
 require 'rubycritic/analysis_summary'
 
@@ -7,10 +8,10 @@ module RubyCritic
     before do
       analysed_modules = AnalysedModulesCollectionDouble.new(
         [
-          AnalysedModuleDouble.new(rating: 'A', churn: 2, smells: [:a, :b, :c]),
+          AnalysedModuleDouble.new(rating: 'A', churn: 2, smells: %i[a b c]),
           AnalysedModuleDouble.new(rating: 'A', churn: 3, smells: [:b]),
-          AnalysedModuleDouble.new(rating: 'A', churn: 4, smells: [:x, :y]),
-          AnalysedModuleDouble.new(rating: 'B', churn: 5, smells: [:a, :z])
+          AnalysedModuleDouble.new(rating: 'A', churn: 4, smells: %i[x y]),
+          AnalysedModuleDouble.new(rating: 'B', churn: 5, smells: %i[a z])
         ]
       )
       @summary = RubyCritic::AnalysisSummary.generate(analysed_modules)

--- a/test/lib/rubycritic/browser_test.rb
+++ b/test/lib/rubycritic/browser_test.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'test_helper'
 require 'rubycritic/browser'
 

--- a/test/lib/rubycritic/commands/status_reporter_test.rb
+++ b/test/lib/rubycritic/commands/status_reporter_test.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'test_helper'
 require 'rubycritic/commands/status_reporter'
 require 'rubycritic/cli/options'

--- a/test/lib/rubycritic/configuration_test.rb
+++ b/test/lib/rubycritic/configuration_test.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'test_helper'
 require 'rubycritic/configuration'
 

--- a/test/lib/rubycritic/core/analysed_module_test.rb
+++ b/test/lib/rubycritic/core/analysed_module_test.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'test_helper'
 require 'rubycritic/core/analysed_module'
 require 'rubycritic/core/smell'

--- a/test/lib/rubycritic/core/analysed_modules_collection_test.rb
+++ b/test/lib/rubycritic/core/analysed_modules_collection_test.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'test_helper'
 require 'rubycritic/core/analysed_modules_collection'
 
@@ -15,7 +16,7 @@ describe RubyCritic::AnalysedModulesCollection do
     end
 
     context 'with a list of files' do
-      let(:paths) { %w(test/samples/doesnt_exist.rb test/samples/unparsable.rb test/samples/empty.rb) }
+      let(:paths) { %w[test/samples/doesnt_exist.rb test/samples/unparsable.rb test/samples/empty.rb] }
 
       it 'registers one AnalysedModule element per existent file' do
         subject.count.must_equal 2
@@ -32,7 +33,7 @@ describe RubyCritic::AnalysedModulesCollection do
     end
 
     context 'with redundant paths' do
-      let(:paths) { %w(test/samples/flog test/samples/flog/complex.rb) }
+      let(:paths) { %w[test/samples/flog test/samples/flog/complex.rb] }
 
       it 'returns a redundant collection' do
         subject.count.must_equal 3
@@ -64,7 +65,7 @@ describe RubyCritic::AnalysedModulesCollection do
         end
       end
 
-      let(:paths) { %w(test/samples/flog test/samples/flay) }
+      let(:paths) { %w[test/samples/flog test/samples/flay] }
 
       context 'with perfect modules' do
         let(:costs) { [0.0, 0.0, 0.0, 0.0] }

--- a/test/lib/rubycritic/core/location_test.rb
+++ b/test/lib/rubycritic/core/location_test.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'test_helper'
 require 'rubycritic/core/location'
 

--- a/test/lib/rubycritic/core/smell_test.rb
+++ b/test/lib/rubycritic/core/smell_test.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'test_helper'
 require 'rubycritic/core/smell'
 

--- a/test/lib/rubycritic/core/smells_array_test.rb
+++ b/test/lib/rubycritic/core/smells_array_test.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'test_helper'
 require 'rubycritic/core/smell'
 

--- a/test/lib/rubycritic/generators/console_report_test.rb
+++ b/test/lib/rubycritic/generators/console_report_test.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'test_helper'
 require 'rubycritic/generators/console_report'
 require 'rubycritic/core/rating'

--- a/test/lib/rubycritic/generators/json_report_test.rb
+++ b/test/lib/rubycritic/generators/json_report_test.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'test_helper'
 require 'rubycritic/core/analysed_modules_collection'
 require 'rubycritic/generators/json_report'

--- a/test/lib/rubycritic/generators/turbulence_test.rb
+++ b/test/lib/rubycritic/generators/turbulence_test.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'test_helper'
 require 'rubycritic/generators/html/turbulence'
 

--- a/test/lib/rubycritic/generators/view_helpers_test.rb
+++ b/test/lib/rubycritic/generators/view_helpers_test.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'test_helper'
 require 'rubycritic/generators/html/view_helpers'
 require 'pathname'

--- a/test/lib/rubycritic/revision_comparator_test.rb
+++ b/test/lib/rubycritic/revision_comparator_test.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'test_helper'
 require 'rubycritic/revision_comparator'
 

--- a/test/lib/rubycritic/smells_status_setter_test.rb
+++ b/test/lib/rubycritic/smells_status_setter_test.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'test_helper'
 require 'rubycritic/core/smell'
 require 'rubycritic/smells_status_setter'

--- a/test/lib/rubycritic/source_control_systems/base_test.rb
+++ b/test/lib/rubycritic/source_control_systems/base_test.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'test_helper'
 require 'rubycritic/source_control_systems/base'
 

--- a/test/lib/rubycritic/source_control_systems/double_test.rb
+++ b/test/lib/rubycritic/source_control_systems/double_test.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'test_helper'
 require 'rubycritic/source_control_systems/base'
 require_relative 'interfaces/basic'

--- a/test/lib/rubycritic/source_control_systems/git_test.rb
+++ b/test/lib/rubycritic/source_control_systems/git_test.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'test_helper'
 require 'rubycritic/source_control_systems/base'
 require_relative 'interfaces/basic'

--- a/test/lib/rubycritic/source_control_systems/interfaces/basic.rb
+++ b/test/lib/rubycritic/source_control_systems/interfaces/basic.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module BasicInterface
   def test_implements_basic_interface
     assert_respond_to @system, :revisions_count

--- a/test/lib/rubycritic/source_control_systems/interfaces/time_travel.rb
+++ b/test/lib/rubycritic/source_control_systems/interfaces/time_travel.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # This interface is only used if `@system.revision?` returns `true`.
 module TimeTravelInterface
   def test_implements_time_travel_interface

--- a/test/lib/rubycritic/source_control_systems/mercurial_test.rb
+++ b/test/lib/rubycritic/source_control_systems/mercurial_test.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'test_helper'
 require 'rubycritic/source_control_systems/base'
 require_relative 'interfaces/basic'

--- a/test/lib/rubycritic/source_control_systems/perforce_test.rb
+++ b/test/lib/rubycritic/source_control_systems/perforce_test.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'test_helper'
 require 'rubycritic/source_control_systems/base'
 

--- a/test/lib/rubycritic/source_locator_test.rb
+++ b/test/lib/rubycritic/source_locator_test.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'test_helper'
 require 'rubycritic/source_locator'
 

--- a/test/lib/rubycritic/version_test.rb
+++ b/test/lib/rubycritic/version_test.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'test_helper'
 require 'rubycritic/version'
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'minitest/autorun'
 require 'minitest/pride'
 require 'mocha/mini_test'


### PR DESCRIPTION
This PR fixes the following offenses.

```sh
% rubocop
Inspecting 99 files
CCC.CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC.CCCCCCC..CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC

Offenses:

(snip)

99 files inspected, 107 offenses detected
```

cf. https://travis-ci.org/whitesmith/rubycritic/jobs/221954186

This is what I did with PR. First, I fixed it using autocorrect (`rubocop -a`) . Next, it disable Style/IndentHeredoc cop. It is disabling Style/IndentHeredoc cop for the following reasons.

- RubyCritic does not depend on Active Support, then it can not use `String#strip_heredoc`.
- RubyCritic has support of Ruby 2.2 or lower, then it can not use squiggly heredoc (`<<~`) .

Thank you.