### PR TITLE
Nest ordered list so we don't render errors as line numbers

### DIFF
--- a/lib/rubycritic/generators/html/assets/stylesheets/application.css
+++ b/lib/rubycritic/generators/html/assets/stylesheets/application.css
@@ -417,6 +417,10 @@ header {
   color: #197b30;
 }
 
+ol.errors {
+  list-style: none;
+  padding-left: 0px;
+}
 .errors {
   background-position: 10px 25px;
   background-repeat: no-repeat;

--- a/lib/rubycritic/generators/html/templates/smelly_line.html.erb
+++ b/lib/rubycritic/generators/html/templates/smelly_line.html.erb
@@ -1,6 +1,6 @@
 <%= @text %>
 
-<div class="nocode errors smells">
+<ol class="nocode errors smells">
 <% @smells.each do |smell| %>
   <li>
     <div class="description">
@@ -20,4 +20,4 @@
     </div>
   </li>
 <% end %>
-</div>
+</ol>


### PR DESCRIPTION
Fixes https://github.com/whitesmith/rubycritic/issues/216