### PR TITLE
Only scroll Y axis when visiting page with anchor tag

### DIFF
--- a/lib/rubycritic/generators/html/assets/javascripts/application.js
+++ b/lib/rubycritic/generators/html/assets/javascripts/application.js
@@ -197,7 +197,8 @@ function scrollToTarget(lineReference) {
   $.scrollTo(lineReference, {
     duration: 300,
     easing: "linear",
-    offset: {top: -87}
+    offset: {top: -87},
+    axis: 'y'
   });
 }
 


### PR DESCRIPTION
### Problem

`$.scrollTo` was using [default setting](https://github.com/flesler/jquery.scrollTo#settings) of scrolling to `xy` axis to scroll to line number. On my 13 inch screen this would cause a weird rendering issue where the page score would be partially overlapped. 

### Solution

Only `$.scrollTo` in the `y` axis.

### Example

<img width="619" alt="ruby_critic_-_home" src="https://cloud.githubusercontent.com/assets/34163/26029228/482d53cc-37fe-11e7-9ea6-09152dd85667.png">
