### PR TITLE
Relax dependency version of parser gem

### DIFF
--- a/rubycritic.gemspec
+++ b/rubycritic.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'flay', '~> 2.8'
   spec.add_runtime_dependency 'flog', '~> 4.4'
   spec.add_runtime_dependency 'launchy', '2.4.3'
-  spec.add_runtime_dependency 'parser', '2.4.0'
+  spec.add_runtime_dependency 'parser', '~> 2.4.0'
   spec.add_runtime_dependency 'rainbow', '~> 2.1'
   spec.add_runtime_dependency 'reek', '~> 4.4'
   spec.add_runtime_dependency 'ruby_parser', '~> 3.8'


### PR DESCRIPTION
My Rails project uses Ruby 2.4.1 so that parser v2.4.0 warns as follows:

![image](https://cloud.githubusercontent.com/assets/96157/26187002/ff83ddf4-3bd0-11e7-965e-f286c59f9db6.png)

This patch fixes it.