### PR TITLE
Traverse git history only once

### DIFF
--- a/.todo.reek
+++ b/.todo.reek
@@ -137,6 +137,7 @@ UncommunicativeParameterName:
 ClassVariable:
   exclude:
   - RubyCritic::SourceControlSystem::Base
+  - RubyCritic::SourceControlSystem::Git::Revision
 BooleanParameter:
   exclude:
   - RubyCritic::Config#self.respond_to_missing?

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # master (unreleased)
 
+* [CHANGE] Cache git revision count ([@joneshf][])
+
 # 3.2.2 / 2017-05-18 [(commits)](https://github.com/whitesmith/rubycritic/compare/v3.2.1...v3.2.2)
 
 * [CHANGE] Relax dependency of parser gem (by [@yuku-t][])
@@ -210,3 +212,4 @@
 [@koic]: https://github.com/koic
 [@georgedrummond]: https://github.com/georgedrummond
 [@yuku-t]: https://github.com/yuku-t
+[@joneshf]: https://github.com/joneshf

--- a/lib/rubycritic/source_control_systems/git.rb
+++ b/lib/rubycritic/source_control_systems/git.rb
@@ -14,7 +14,7 @@ module RubyCritic
       end
 
       def revisions_count(path)
-        `git log --follow --format=%h #{path.shellescape}`.count("\n")
+        path_revisions_count.fetch(path.shellescape, 0)
       end
 
       def date_of_last_commit(path)
@@ -51,6 +51,18 @@ module RubyCritic
 
       def travel_to_original_state
         `git stash pop`
+      end
+
+      def path_revisions_counts
+        `git log --name-only --format='' | sort | uniq -c`
+      end
+
+      def path_revisions_count
+        @path_revisions_count ||=
+          path_revisions_counts.split("\n").map do |string|
+            count, path = string.split
+            [path, count.to_i]
+          end.to_h
       end
     end
   end

--- a/lib/rubycritic/source_control_systems/git/revision.rb
+++ b/lib/rubycritic/source_control_systems/git/revision.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+module RubyCritic
+  module SourceControlSystem
+    class Git < Base
+      class Revision
+        def initialize(path, new_path)
+          @path = path
+          @new_path = new_path
+        end
+
+        def self.matches?(status)
+          match =~ status
+        end
+
+        def self.parse(revisions, string)
+          status, path, new_path = string.split("\t").map(&:shellescape)
+          revisions
+            .find { |revision| revision.matches?(status) }
+            .new(path, new_path)
+        end
+
+        private
+
+        attr_reader :path, :new_path
+      end
+
+      class Double < Revision
+        def evaluate(_) end
+
+        def self.match
+          //
+        end
+      end
+
+      class Add < Revision
+        def evaluate(hash)
+          hash[path] = 1
+        end
+
+        def self.match
+          /A/
+        end
+      end
+
+      class Copy < Revision
+        def evaluate(hash)
+          hash[new_path] = 1
+        end
+
+        def self.match
+          /C/
+        end
+      end
+
+      class Delete < Revision
+        def evaluate(hash)
+          hash.delete(path)
+        end
+
+        def self.match
+          /D/
+        end
+      end
+
+      class Modify < Revision
+        def evaluate(hash)
+          hash[path] = hash.fetch(path, 0) + 1
+        end
+
+        def self.match
+          /M|T/
+        end
+      end
+
+      class Rename < Revision
+        def evaluate(hash)
+          value = hash.delete(path) || 0
+          hash[new_path] = value + 1
+        end
+
+        def self.match
+          /R/
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Why this PR?

This is specific to my problem, but it probably applies to repos of other shapes and sizes along with different version control systems.

We've got a five year old repo (to the day 🎂), with 46k commits over 9k files. I mention these numbers only to provide context. When churn is run over the whole repo, it takes about 30 minutes to complete. I think this is because it traverses the entire history for each file path given. Unfortunately if that's the performance of churn, we can't start using RubyCritic in CI.

I've started experimenting with traversing the history once, caching the results and using the cache for quicker lookup. Using this method, churn takes about 2 minutes to complete. That's something we can deal with on CI.

# What's the change?

Before, we were traversing the history for each path.
That behavior gets costly with a long history.

Now, we are traversing the history once initially,
creating a cache from paths to revision counts,
and referencing the cache for each path.

# Further ideas

We might be able to do similar for the other source control systems.
However, I personally don't have enough experience with them,
nor do I have an actual project to test on.

I welcome any critiques or other ideas.