### PR TITLE
Make json_report_test test on actual files

### DIFF
--- a/lib/rubycritic/source_control_systems/git.rb
+++ b/lib/rubycritic/source_control_systems/git.rb
@@ -1,12 +1,23 @@
 # frozen_string_literal: true
 
+require 'tty/which'
+
 module RubyCritic
   module SourceControlSystem
     class Git < Base
       register_system
+      GIT_EXECUTABLE = TTY::Which.which('git')
+
+      def self.git(arg)
+        `#{GIT_EXECUTABLE} #{arg}`
+      end
+
+      def git(arg)
+        self.class.git(arg)
+      end
 
       def self.supported?
-        `git branch 2>&1` && $?.success?
+        git('branch 2>&1') && $?.success?
       end
 
       def self.to_s
@@ -14,11 +25,11 @@ module RubyCritic
       end
 
       def revisions_count(path)
-        `git log --follow --format=%h #{path.shellescape}`.count("\n")
+        git("log --follow --format=%h #{path.shellescape}").count("\n")
       end
 
       def date_of_last_commit(path)
-        `git log -1 --date=iso --format=%ad #{path.shellescape}`.chomp!
+        git("log -1 --date=iso --format=%ad #{path.shellescape}").chomp!
       end
 
       def revision?
@@ -26,7 +37,7 @@ module RubyCritic
       end
 
       def head_reference
-        `git rev-parse --verify HEAD`.chomp!
+        git('rev-parse --verify HEAD').chomp!
       end
 
       def travel_to_head
@@ -40,17 +51,17 @@ module RubyCritic
 
       def stash_changes
         stashes_count_before = stashes_count
-        `git stash`
+        git('stash')
         stashes_count_after = stashes_count
         stashes_count_after > stashes_count_before
       end
 
       def stashes_count
-        `git stash list --format=%h`.count("\n")
+        git('stash list --format=%h').count("\n")
       end
 
       def travel_to_original_state
-        `git stash pop`
+        git('stash pop')
       end
     end
   end

--- a/lib/rubycritic/source_locator.rb
+++ b/lib/rubycritic/source_locator.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'pathname'
+require 'rubycritic/configuration'
 
 module RubyCritic
   class SourceLocator

--- a/rubycritic.gemspec
+++ b/rubycritic.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'flay', '~> 2.8'
   spec.add_runtime_dependency 'flog', '~> 4.4'
   spec.add_runtime_dependency 'launchy', '2.4.3'
+  spec.add_runtime_dependency 'tty-which', '~> 0.3.0'
   spec.add_runtime_dependency 'parser', '~> 2.4.0'
   spec.add_runtime_dependency 'rainbow', '~> 2.1'
   spec.add_runtime_dependency 'reek', '~> 4.4'

--- a/rubycritic.gemspec
+++ b/rubycritic.gemspec
@@ -37,6 +37,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'cucumber', '~> 2.2', '>= 2.2.0'
   spec.add_development_dependency 'fakefs', '~> 0.10', '>= 0.10.0'
   spec.add_development_dependency 'minitest', '~> 5.3', '>= 5.3.0'
+  spec.add_development_dependency 'minitest-around', '~> 0.4.0'
+  spec.add_development_dependency 'diff-lcs', '~> 1.3'
   spec.add_development_dependency 'mocha', '~> 1.1', '>= 1.1.0'
   spec.add_development_dependency 'rake', '~> 11.0', '>= 11.0.0'
   spec.add_development_dependency 'rubocop', '~> 0.48.0'


### PR DESCRIPTION
We're currently creating a new reporter and along the way noticed that `json_report_test.rb` does not test anything semantically.
This test makes `json_report_test.rb` an integration test that actually runs analyzers on the FakeFS and checks that all sample files appear in the report.