### PR TITLE
Lint report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # master [(unreleased)](https://github.com/whitesmith/rubycritic/compare/v3.2.3...master)
+* [FEATURE] Add lint format similar to Golint (by [@nightscape][])
 
 # 3.2.3 / 2017-05-31 [(commits)](https://github.com/whitesmith/rubycritic/compare/v3.2.2...v3.2.3)
 
@@ -215,3 +216,4 @@
 [@georgedrummond]: https://github.com/georgedrummond
 [@yuku-t]: https://github.com/yuku-t
 [@ochagata]: https://github.com/ochagata
+[@nightscape]: https://github.com/nightscape

--- a/docs/jenkins-pr-reviews.md
+++ b/docs/jenkins-pr-reviews.md
@@ -1,0 +1,64 @@
+# Making Jenkins review Pull Requests
+
+## Installing Jenkins and setting up RubyCritic
+
+There is a step-by-step tutorial on how to set up Jenkins in [`building-own-code-climate.md`](./building-own-code-climate.md).
+
+### Installing required plugins
+
+Installing a Jenkins Plugin is extremely easy. All you have to do is proceed to `Manage Jenkins`, go to `Manage Plugins`, select the `Available` tab and then check the desired plugin.
+
+For creating comments on PRs we are going to use the [Violation Comments to GitHub Jenkins Plugin](https://github.com/jenkinsci/violation-comments-to-github-plugin).
+
+## Configuring the project
+
+The Violation plugin has parsers for many different formats, and the GoLint one is compatible with the `lint` format created by RubyCritic.
+We're assuming that you use a `Jenkinsfile` for creating a pipeline, but the approach can be adapted to other scenarios.
+
+
+```groovy
+pipeline {
+  agent any
+
+  stages {
+    stage('Build') {
+      steps {
+        // Install gems etc.
+      }
+    }
+    stage('Test') {
+      steps {
+        parallel tests: { // We are running tests and code_checks in parallel to shorten build times
+          sh 'bundle exec rspec'
+        },
+        code_checks: {
+          sh 'bundle exec rubycritic -f lint'
+        }
+      }
+    }
+    stage('Package / Deploy') {
+      steps {
+        parallel deploy: {
+          // Create Docker image / deploy via Capistrano / ...
+        },
+        publish_code_review: {
+          step([
+            $class: 'ViolationsToGitHubRecorder',
+            config: [
+              repositoryName: 'your_project_name',
+              pullRequestId: env.CHANGE_ID, // The CHANGE_ID env variable will be set to the PR ID by Jenkins
+              createSingleFileComments: true, // Create one comment per violation
+              commentOnlyChangedContent: true, // Only comment on lines that have changed
+              keepOldComments: false,
+              violationConfigs: [
+                [ pattern: '.*/lint\\.txt$', parser: 'GOLINT', reporter: 'RubyCritic' ], // RubyCritic will output a lint.txt file in GoLint compatible format
+              ]
+            ]])
+        }
+      }
+    }
+  }
+}
+```
+
+For further information, check out the documentation of the [Violation Comments to GitHub Jenkins Plugin](https://github.com/jenkinsci/violation-comments-to-github-plugin).

--- a/features/command_line_interface/options.feature
+++ b/features/command_line_interface/options.feature
@@ -25,6 +25,7 @@ Feature: RubyCritic can be controlled using command-line options
                                              html (default; will open in a browser)
                                              json
                                              console
+                                             lint
           -s, --minimum-score [MIN_SCORE]  Set a minimum score
           -m, --mode-ci                    Use CI mode (faster, but only analyses last commit)
               --deduplicate-symlinks       De-duplicate symlinks based on their final target

--- a/lib/rubycritic/cli/options.rb
+++ b/lib/rubycritic/cli/options.rb
@@ -22,11 +22,12 @@ module RubyCritic
 
           opts.on(
             '-f', '--format [FORMAT]',
-            %i[html json console],
+            %i[html json console lint],
             'Report smells in the given format:',
             '  html (default; will open in a browser)',
             '  json',
-            '  console'
+            '  console',
+            '  lint'
           ) do |format|
             self.format = format
           end

--- a/lib/rubycritic/generators/lint_report.rb
+++ b/lib/rubycritic/generators/lint_report.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'rubycritic/generators/text/lint'
+
+module RubyCritic
+  module Generator
+    class LintReport
+      def initialize(analysed_modules)
+        @analysed_modules = analysed_modules
+      end
+
+      def generate_report
+        FileUtils.mkdir_p(generator.file_directory)
+        File.open(generator.file_pathname, 'w+') do |file|
+          file.write(reports.join("\n"))
+        end
+      end
+
+      def generator
+        Text::Lint
+      end
+
+      def reports
+        @analysed_modules.sort.map do |mod|
+          generator.new(mod).render
+        end
+      end
+    end
+  end
+end

--- a/lib/rubycritic/generators/text/lint.rb
+++ b/lib/rubycritic/generators/text/lint.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'erb'
+module RubyCritic
+  module Generator
+    module Text
+      class Lint
+        class << self
+          TEMPLATE_PATH = File.expand_path('../templates/lint.erb', __FILE__)
+          FILE_NAME = 'lint.txt'.freeze
+
+          def file_directory
+            @file_directory ||= Pathname.new(Config.root)
+          end
+
+          def file_pathname
+            Pathname.new(file_directory).join FILE_NAME
+          end
+
+          def erb_template
+            @erb_template ||= ERB.new(File.read(TEMPLATE_PATH), nil, '-')
+          end
+        end
+
+        def initialize(analysed_module)
+          @analysed_module = analysed_module
+        end
+
+        def render
+          erb_template.result(binding)
+        end
+
+        private
+
+        def erb_template
+          self.class.erb_template
+        end
+      end
+    end
+  end
+end

--- a/lib/rubycritic/generators/text/templates/lint.erb
+++ b/lib/rubycritic/generators/text/templates/lint.erb
@@ -1,0 +1,3 @@
+<%- @analysed_module.smells.each do |smell| -%>
+<%= smell.locations.first.to_s %>: <%= smell.to_s %>
+<%- end -%>

--- a/lib/rubycritic/reporter.rb
+++ b/lib/rubycritic/reporter.rb
@@ -14,6 +14,9 @@ module RubyCritic
       when :console
         require 'rubycritic/generators/console_report'
         Generator::ConsoleReport
+      when :lint
+        require 'rubycritic/generators/lint_report'
+        Generator::LintReport
       else
         require 'rubycritic/generators/html_report'
         Generator::HtmlReport

--- a/test/lib/rubycritic/generators/lint_report_test.rb
+++ b/test/lib/rubycritic/generators/lint_report_test.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'rubycritic/analysers_runner'
+require 'rubycritic/generators/lint_report'
+require 'fakefs/safe'
+
+describe RubyCritic::Generator::LintReport do
+  describe '#generate_report' do
+    around do |example|
+      capture_output_streams do
+        with_cloned_fs(&example)
+      end
+    end
+
+    it 'report file has data inside' do
+      sample_files = Dir['test/samples/**/*.rb'].reject { |f| File.zero?(f) }
+      create_analysed_modules_collection
+      generate_report
+      lines = File.readlines('test/samples/lint.txt').map(&:strip).reject(&:empty?)
+      analysed_files = lines.map { |line| line.split(':').first }.uniq
+      assert_matched_arrays analysed_files, sample_files
+    end
+  end
+
+  def create_analysed_modules_collection
+    RubyCritic::Config.root = 'test/samples'
+    RubyCritic::Config.source_control_system = RubyCritic::SourceControlSystem::Git.new
+    analyser_runner = RubyCritic::AnalysersRunner.new('test/samples/')
+    @analysed_modules_collection = analyser_runner.run
+  end
+
+  def generate_report
+    report = RubyCritic::Generator::LintReport.new(@analysed_modules_collection)
+    report.generate_report
+  end
+end


### PR DESCRIPTION
This PR is based on https://github.com/whitesmith/rubycritic/pull/247 and adds a reporter which writes files in a format that many other linters (like e.g. Golint) use.
We are using it in combination with https://github.com/jenkinsci/violation-comments-to-github-plugin to create Github PR comments with rubycritic's output.