### PR TITLE
Update tests for ruby 2.5

### DIFF
--- a/lib/rubycritic/core/analysed_modules_collection.rb
+++ b/lib/rubycritic/core/analysed_modules_collection.rb
@@ -9,13 +9,13 @@ module RubyCritic
 
     # Limit used to prevent very bad modules to have excessive impact in the
     # overall result. See #limited_cost_for
-    COST_LIMIT = 32
+    COST_LIMIT = 32.0
     # Score goes from 0 (worst) to 100 (perfect)
-    MAX_SCORE = 100
+    MAX_SCORE = 100.0
     # Projects with an average cost of 16 (or above) will score 0, since 16
     # is where the worst possible rating (F) starts
-    ZERO_SCORE_COST = 16
-    COST_MULTIPLIER = MAX_SCORE.to_f / ZERO_SCORE_COST
+    ZERO_SCORE_COST = 16.0
+    COST_MULTIPLIER = MAX_SCORE / ZERO_SCORE_COST
 
     def initialize(paths)
       @modules = SourceLocator.new(paths).pathnames.map do |pathname|

--- a/test/lib/rubycritic/commands/status_reporter_test.rb
+++ b/test/lib/rubycritic/commands/status_reporter_test.rb
@@ -21,7 +21,7 @@ describe RubyCritic::Command::StatusReporter do
     end
 
     it 'accept a score' do
-      @reporter.score = 50
+      @reporter.score = 50.0
       @reporter.status.must_equal success_status
       @reporter.status_message.must_equal 'Score: 50.0'
     end
@@ -46,7 +46,7 @@ describe RubyCritic::Command::StatusReporter do
     end
 
     describe 'when score is below minimum' do
-      let(:score) { 98 }
+      let(:score) { 98.0 }
       it 'should return the correct status' do
         @reporter.score = score
         @reporter.status.must_equal score_below_minimum
@@ -61,7 +61,7 @@ describe RubyCritic::Command::StatusReporter do
     end
 
     describe 'when score is equal the minimum' do
-      let(:score) { 99 }
+      let(:score) { 99.0 }
       it 'should return the correct status' do
         @reporter.score = score
         @reporter.status.must_equal success_status
@@ -70,7 +70,7 @@ describe RubyCritic::Command::StatusReporter do
     end
 
     describe 'when score is above the minimum' do
-      let(:score) { 100 }
+      let(:score) { 100.0 }
       it 'should return the correct status' do
         @reporter.score = score
         @reporter.status.must_equal success_status


### PR DESCRIPTION
Should partially address #251 which looks to be caused by:

> Integer#{round,floor,ceil,truncate} now always return an Integer.

from https://docs.ruby-lang.org/en/trunk/NEWS.html.

I don't think rubocop supports Ruby 2.5 yet (https://github.com/bbatsov/rubocop/blob/master/lib/rubocop/config.rb#L20) so there will still be more work to do on this issue.