### PR TITLE
Clarify README

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ end
 
 ## Compatibility
 
-RubyCritic is supporting:
+RubyCritic is supporting Ruby versions:
 
 * 2.1
 * 2.2


### PR DESCRIPTION
This is really minor, but I thought it might be good to clarify that the compatibility section of the README refers to Ruby.