### PR TITLE
perforce_test: Make test pass also in GMT+2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,5 +24,5 @@ matrix:
 script:
   - bundle exec rake test
   - bundle exec cucumber features --format progress --color
-  - bundle exec reek
+  - bundle exec rake reek
   - bundle exec rubocop

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,3 +21,8 @@ matrix:
     - rvm: rbx-3
   fast_finish: true
 
+script:
+  - bundle exec rake test
+  - bundle exec cucumber features --format progress --color
+  - bundle exec reek
+  - bundle exec rubocop

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 sudo: false
 language: ruby
 cache: bundler
-before_install: gem update bundler
+before_install:
+  - gem install bundler
 matrix:
   include:
     - rvm: 2.1.0
@@ -18,4 +19,4 @@ matrix:
     - rvm: jruby-9.1.8.0
     - rvm: rbx-3
   fast_finish: true
-script: bundle exec rake
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: false
 language: ruby
-cache: bundler
+cache:
+  bundler: true
 before_install:
   - gem install bundler
 matrix:

--- a/rubycritic.gemspec
+++ b/rubycritic.gemspec
@@ -41,5 +41,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'minitest-around', '~> 0.4.0'
   spec.add_development_dependency 'mocha', '~> 1.1', '>= 1.1.0'
   spec.add_development_dependency 'rake', '~> 12.0', '>= 11.0.0'
-  spec.add_development_dependency 'rubocop', '~> 0.51'
+  spec.add_development_dependency 'rubocop', '~> 0.51', '< 0.52.0'
 end

--- a/test/lib/rubycritic/source_control_systems/perforce_test.rb
+++ b/test/lib/rubycritic/source_control_systems/perforce_test.rb
@@ -151,10 +151,13 @@ Server address: the.server.address.com
       end
 
       it 'retrieves the date of the last commit of the ruby files' do
+        oldtz = ENV['TZ']
+        ENV['TZ'] = 'utc'
         Dir.stubs(:getwd).returns('/path/to/client')
         RubyCritic::SourceControlSystem::Perforce.stubs(:`).once.returns(p4_stats)
         @system.date_of_last_commit('a_ruby_file.rb').must_equal '2016-09-05 11:39:11 +0000'
         @system.date_of_last_commit('second_ruby_file.rb').must_equal '2016-05-30 09:47:48 +0000'
+        ENV['TZ'] = oldtz
       end
 
       it 'retrieves the information if the ruby file is opened (in the changelist and ready to commit)' do


### PR DESCRIPTION
This PR makes a test pass also when the `TZ` isn't set to UTC.

See https://github.com/whitesmith/rubycritic/issues/258

It's my kludge workaround: make the `TZ=utc` while running the test.

---

Then, also: to make the build pass on Travis:

- `gem install bundler`, to have a working gem-based Bundler
- Pin RuboCop to 0.51.0, which has no current defects
- unroll rake tasks which want to `ruby bundle exec` themselves.