### PR TITLE
Fix wrong label for churn in the code file template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # master [(unreleased)](https://github.com/whitesmith/rubycritic/compare/v3.3.0...master)
 
 * [CHANGE] Update `rubocop` to 0.51.0 (by [@olleolleolle][]) 
+* [BUGFIX] Fix wrong label for churn in the code file template
 
 # 3.3.0 / 2017-10-10 [(commits)](https://github.com/whitesmith/rubycritic/compare/v3.2.3...v3.3.0)
 
@@ -226,3 +227,4 @@
 [@yuku-t]: https://github.com/yuku-t
 [@ochagata]: https://github.com/ochagata
 [@nightscape]: https://github.com/nightscape
+[@nbekirov]: https://github.com/nbekirov

--- a/lib/rubycritic/generators/html/templates/code_file.html.erb
+++ b/lib/rubycritic/generators/html/templates/code_file.html.erb
@@ -32,7 +32,7 @@
             </div>
             <div class="col-md-3">
               <div><span class="metric"><%= @analysed_module.complexity_per_method %></span><small> complexity/method</small></div>
-              <div><span class="metric"><%= @analysed_module.churn %></span><small> loc/method</small></div>
+              <div><span class="metric"><%= @analysed_module.churn %></span><small> churn</small></div>
             </div>
             <div class="col-md-3">
               <div><span class="metric"><%= @analysed_module.complexity %></span><small> complexity</small></div>


### PR DESCRIPTION
This was changed during the New Web UI in PR #184.

Actually, I like the idea of "loc/method" metric but I'm unsure if and where to put it. For now I've just fixed the label.