### PR TITLE
[CHANGE] Update parser, rainbow, rubocop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,14 @@
 # master [(unreleased)](https://github.com/whitesmith/rubycritic/compare/v3.3.0...master)
 
-* [CHANGE] Update `rubocop` to 0.51.0 (by [@olleolleolle][]) 
+* [CHANGE] Update `rubocop` to 0.51.0 (by [@olleolleolle][])
+* [CHANGE] Update `parser` to 2.5.0 (by [@joshrpowell][])
+* [CHANGE] Update `rainbow` to 3.0 (by [@joshrpowell][])
+* [CHANGE] Update `rubocop` to 0.53.0 (by [@joshrpowell][])
 
 # 3.3.0 / 2017-10-10 [(commits)](https://github.com/whitesmith/rubycritic/compare/v3.2.3...v3.3.0)
 
 * [FEATURE] Add lint format similar to Golint (by [@nightscape][])
-* [CHANGE] Update `cucumber` to 3.0 (by [@onumis][]) 
+* [CHANGE] Update `cucumber` to 3.0 (by [@onumis][])
 * [CHANGE] Update `rake` to 12.0 (by [@onumis][])
 * [CHANGE] Update `rubocop` to 0.50.0 (by [@onumis][])
 * [CHANGE] Accepting floating point values from Flog (by [@onumis][])
@@ -226,3 +229,4 @@
 [@yuku-t]: https://github.com/yuku-t
 [@ochagata]: https://github.com/ochagata
 [@nightscape]: https://github.com/nightscape
+[@joshrpowell]: https://github.com/joshrpowell

--- a/bin/rubycritic
+++ b/bin/rubycritic
@@ -3,7 +3,7 @@
 
 # Always look in the lib directory of this gem
 # first when searching the load path
-$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+$LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 
 require 'rubycritic/cli/application'
 

--- a/lib/rubycritic/analysers/smells/flog.rb
+++ b/lib/rubycritic/analysers/smells/flog.rb
@@ -35,9 +35,7 @@ module RubyCritic
         @flog.flog(analysed_module.path)
         @flog.each_by_score do |class_method, original_score|
           score = original_score.round
-          if score >= HIGH_COMPLEXITY_SCORE_THRESHOLD
-            analysed_module.smells << create_smell(class_method, score)
-          end
+          analysed_module.smells << create_smell(class_method, score) if score >= HIGH_COMPLEXITY_SCORE_THRESHOLD
         end
       end
 

--- a/lib/rubycritic/cli/options.rb
+++ b/lib/rubycritic/cli/options.rb
@@ -76,6 +76,7 @@ module RubyCritic
           no_browser: no_browser
         }
       end
+      # rubocop:enable Metrics/MethodLength
 
       private
 

--- a/lib/rubycritic/core/analysed_module.rb
+++ b/lib/rubycritic/core/analysed_module.rb
@@ -87,8 +87,8 @@ module RubyCritic
       }
     end
 
-    def to_json(*a)
-      to_h.to_json(*a)
+    def to_json(*options)
+      to_h.to_json(*options)
     end
   end
 end

--- a/lib/rubycritic/core/location.rb
+++ b/lib/rubycritic/core/location.rb
@@ -26,8 +26,8 @@ module RubyCritic
       }
     end
 
-    def to_json(*a)
-      to_h.to_json(*a)
+    def to_json(*options)
+      to_h.to_json(*options)
     end
 
     def ==(other)

--- a/lib/rubycritic/core/rating.rb
+++ b/lib/rubycritic/core/rating.rb
@@ -23,8 +23,8 @@ module RubyCritic
       @letter
     end
 
-    def to_json(*a)
-      to_h.to_json(*a)
+    def to_json(*options)
+      to_h.to_json(*options)
     end
   end
 end

--- a/lib/rubycritic/core/smell.rb
+++ b/lib/rubycritic/core/smell.rb
@@ -48,8 +48,8 @@ module RubyCritic
       }
     end
 
-    def to_json(*a)
-      to_h.to_json(*a)
+    def to_json(*options)
+      to_h.to_json(*options)
     end
 
     def doc_url

--- a/lib/rubycritic/generators/html/base.rb
+++ b/lib/rubycritic/generators/html/base.rb
@@ -12,7 +12,7 @@ module RubyCritic
           ERB.new(File.read(File.join(TEMPLATES_DIR, template_path)))
         end
 
-        TEMPLATES_DIR = File.expand_path('../templates', __FILE__)
+        TEMPLATES_DIR = File.expand_path('templates', __dir__)
         LAYOUT_TEMPLATE = erb_template(File.join('layouts', 'application.html.erb'))
 
         include ViewHelpers

--- a/lib/rubycritic/generators/html_report.rb
+++ b/lib/rubycritic/generators/html_report.rb
@@ -10,7 +10,7 @@ require 'rubycritic/generators/html/code_file'
 module RubyCritic
   module Generator
     class HtmlReport
-      ASSETS_DIR = File.expand_path('../html/assets', __FILE__)
+      ASSETS_DIR = File.expand_path('html/assets', __dir__)
 
       def initialize(analysed_modules)
         @analysed_modules = analysed_modules

--- a/lib/rubycritic/generators/text/lint.rb
+++ b/lib/rubycritic/generators/text/lint.rb
@@ -6,7 +6,7 @@ module RubyCritic
     module Text
       class Lint
         class << self
-          TEMPLATE_PATH = File.expand_path('../templates/lint.erb', __FILE__)
+          TEMPLATE_PATH = File.expand_path('templates/lint.erb', __dir__)
           FILE_NAME = 'lint.txt'.freeze
 
           def file_directory

--- a/lib/rubycritic/generators/text/list.rb
+++ b/lib/rubycritic/generators/text/list.rb
@@ -7,7 +7,7 @@ module RubyCritic
     module Text
       class List
         class << self
-          TEMPLATE_PATH = File.expand_path('../templates/list.erb', __FILE__)
+          TEMPLATE_PATH = File.expand_path('templates/list.erb', __dir__)
 
           def erb_template
             @erb_template ||= ERB.new(File.read(TEMPLATE_PATH), nil, '-')

--- a/lib/rubycritic/source_control_systems/double.rb
+++ b/lib/rubycritic/source_control_systems/double.rb
@@ -3,11 +3,11 @@
 module RubyCritic
   module SourceControlSystem
     class Double < Base
-      def revisions_count(_)
+      def revisions_count(_path)
         0
       end
 
-      def date_of_last_commit(_)
+      def date_of_last_commit(_path)
         nil
       end
 

--- a/rubycritic.gemspec
+++ b/rubycritic.gemspec
@@ -24,8 +24,8 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'flay', '~> 2.8'
   spec.add_runtime_dependency 'flog', '~> 4.4'
   spec.add_runtime_dependency 'launchy', '2.4.3'
-  spec.add_runtime_dependency 'parser', '~> 2.4.0'
-  spec.add_runtime_dependency 'rainbow', '~> 2.1'
+  spec.add_runtime_dependency 'parser', '~> 2.5.0'
+  spec.add_runtime_dependency 'rainbow', '~> 3.0'
   spec.add_runtime_dependency 'reek', '~> 4.4'
   spec.add_runtime_dependency 'ruby_parser', '~> 3.8'
   spec.add_runtime_dependency 'tty-which', '~> 0.3.0'
@@ -41,5 +41,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'minitest-around', '~> 0.4.0'
   spec.add_development_dependency 'mocha', '~> 1.1', '>= 1.1.0'
   spec.add_development_dependency 'rake', '~> 12.0', '>= 11.0.0'
-  spec.add_development_dependency 'rubocop', '~> 0.51', '< 0.52.0'
+  spec.add_development_dependency 'rubocop', '~> 0.53'
 end

--- a/rubycritic.gemspec
+++ b/rubycritic.gemspec
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'rubycritic/version'
 


### PR DESCRIPTION
Given the recent addition of Ruby 2.5 to the tests [1c242dd](https://github.com/whitesmith/rubycritic/commit/1c242dda783573e9680e4724af171e87e74a97c4) I bumped to `rubocop 0.53.0` and ran into the following:

```ruby
Resolving dependencies..........
Bundler could not find compatible versions for gem "parser":
  In Gemfile:
    rubocop (~> 0.53.0) was resolved to 0.53.0, which depends on
      parser (>= 2.5)

    rubycritic was resolved to 3.3.0, which depends on
      parser (~> 2.4.0)
```

Which required the following changes: 

- [Parser CHANGELOG](https://github.com/whitequark/parser/blob/master/CHANGELOG.md)
- [Rainbow CHANGELOG](https://github.com/sickill/rainbow/blob/master/Changelog.md)
- [Rubocop CHANGELOG](https://github.com/bbatsov/rubocop/blob/master/CHANGELOG.md)