### PR TITLE
Branch comparison feature fix

### DIFF
--- a/lib/rubycritic/commands/compare.rb
+++ b/lib/rubycritic/commands/compare.rb
@@ -76,7 +76,7 @@ module RubyCritic
       end
 
       def mark_build_fail?
-        Config.threshold_score > 0 && threshold_reached?
+        Config.threshold_score >= 0 && threshold_reached?
       end
 
       def threshold_reached?

--- a/lib/rubycritic/source_control_systems/git.rb
+++ b/lib/rubycritic/source_control_systems/git.rb
@@ -52,11 +52,11 @@ module RubyCritic
       end
 
       def self.switch_branch(branch)
-        uncommitted_changes? ? `git checkout #{branch}` : abort('Uncommitted changes are present.')
+        uncommitted_changes? ? abort('Uncommitted changes are present.') : `git checkout #{branch}`
       end
 
       def self.uncommitted_changes?
-        `git ls-files --other --exclude-standard --directory`.empty? && `git status --porcelain`.empty?
+        !`git ls-files --other --exclude-standard --directory`.empty? || !`git status --porcelain`.empty?
       end
 
       def self.modified_files


### PR DESCRIPTION
Hi, this is a fix for the branch comparison feature. As of now, `-t`/`--maximum-decrease` does not behave as expected: it will not abort the process, aka exit the process with a code of 1, when the threshold is set to 0, even though the difference between the two branches' score is > 0.

I also tried to run rubocop before pushing and had to fix some issues in order to make it run. Please refer to commit message for more details.