### PR TITLE
Update Readme to support 2.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ RubyCritic is supporting Ruby versions:
 * 2.2
 * 2.3
 * 2.4
+* 2.5
 
 
 ## Improving RubyCritic


### PR DESCRIPTION
Looking on [Travis matrix](https://github.com/whitesmith/rubycritic/blob/master/.travis.yml#L14) `Ruby 2.5` is supported.