### PR TITLE
Remove some cops form .rubocop_todo.yml

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -1,20 +1,13 @@
 # Offense count: 1
 Metrics/AbcSize:
   Exclude:
-    - 'lib/rubycritic/analysers/smells/flay.rb'
     - 'lib/rubycritic/cli/options.rb'
 
 # Offense count: 2
 # Configuration parameters: CountComments.
 Metrics/MethodLength:
   Exclude:
-    - 'lib/rubycritic/analysers/smells/flay.rb'
     - 'lib/rubycritic/core/analysed_module.rb'
-
-# Offense count: 1
-Naming/AccessorMethodName:
-  Exclude:
-    - 'lib/rubycritic/generators/html/base.rb'
 
 # Offense count: 1
 Style/ClassVars:

--- a/lib/rubycritic/analysers/smells/flay.rb
+++ b/lib/rubycritic/analysers/smells/flay.rb
@@ -15,8 +15,7 @@ module RubyCritic
 
       def run
         @flay.hashes.each do |structural_hash, nodes|
-          add_smells(structural_hash, nodes)
-          add_duplication(nodes)
+          analyze_modules(structural_hash, nodes)
           print green '.'
         end
         puts ''
@@ -67,13 +66,10 @@ module RubyCritic
         mass / 25
       end
 
-      def add_smells(structural_hash, nodes)
+      def analyze_modules(structural_hash, nodes)
         nodes.map(&:file).uniq.each do |file|
           @analysed_modules[file].smells << create_smell(structural_hash, nodes)
         end
-      end
-
-      def add_duplication(nodes)
         nodes.each do |node|
           @analysed_modules[node.file].duplication += node.mass
         end

--- a/lib/rubycritic/analysers/smells/flay.rb
+++ b/lib/rubycritic/analysers/smells/flay.rb
@@ -15,14 +15,8 @@ module RubyCritic
 
       def run
         @flay.hashes.each do |structural_hash, nodes|
-          smell = create_smell(structural_hash, nodes)
-          nodes.map(&:file).uniq.each do |file|
-            @analysed_modules[file].smells << smell
-          end
-
-          nodes.each do |node|
-            @analysed_modules[node.file].duplication += node.mass
-          end
+          add_smells(structural_hash, nodes)
+          add_duplication(nodes)
           print green '.'
         end
         puts ''
@@ -71,6 +65,18 @@ module RubyCritic
 
       def cost(mass)
         mass / 25
+      end
+
+      def add_smells(structural_hash, nodes)
+        nodes.map(&:file).uniq.each do |file|
+          @analysed_modules[file].smells << create_smell(structural_hash, nodes)
+        end
+      end
+
+      def add_duplication(nodes)
+        nodes.each do |node|
+          @analysed_modules[node.file].duplication += node.mass
+        end
       end
     end
   end

--- a/lib/rubycritic/generators/html/base.rb
+++ b/lib/rubycritic/generators/html/base.rb
@@ -44,6 +44,10 @@ module RubyCritic
         def root_directory
           @root_directory ||= Pathname.new(Config.root)
         end
+
+        def base_binding
+          binding
+        end
       end
     end
   end

--- a/lib/rubycritic/generators/html/base.rb
+++ b/lib/rubycritic/generators/html/base.rb
@@ -44,10 +44,6 @@ module RubyCritic
         def root_directory
           @root_directory ||= Pathname.new(Config.root)
         end
-
-        def get_binding
-          binding
-        end
       end
     end
   end

--- a/lib/rubycritic/generators/html/code_file.rb
+++ b/lib/rubycritic/generators/html/code_file.rb
@@ -42,8 +42,8 @@ module RubyCritic
             file_code << Line.new(file_directory, line_text, line_smells).render
           end
 
-          file_body = TEMPLATE.result(get_binding { file_code.join })
-          LAYOUT_TEMPLATE.result(get_binding { file_body })
+          file_body = TEMPLATE.result(base_binding { file_code.join })
+          LAYOUT_TEMPLATE.result(base_binding { file_body })
         end
       end
     end

--- a/lib/rubycritic/generators/html/code_index.rb
+++ b/lib/rubycritic/generators/html/code_index.rb
@@ -24,8 +24,8 @@ module RubyCritic
         end
 
         def render
-          index_body = TEMPLATE.result(get_binding)
-          LAYOUT_TEMPLATE.result(get_binding { index_body })
+          index_body = TEMPLATE.result(base_binding)
+          LAYOUT_TEMPLATE.result(base_binding { index_body })
         end
       end
     end

--- a/lib/rubycritic/generators/html/overview.rb
+++ b/lib/rubycritic/generators/html/overview.rb
@@ -29,8 +29,8 @@ module RubyCritic
         end
 
         def render
-          index_body = TEMPLATE.result(get_binding)
-          LAYOUT_TEMPLATE.result(get_binding { index_body })
+          index_body = TEMPLATE.result(base_binding)
+          LAYOUT_TEMPLATE.result(base_binding { index_body })
         end
       end
     end

--- a/lib/rubycritic/generators/html/smells_index.rb
+++ b/lib/rubycritic/generators/html/smells_index.rb
@@ -26,8 +26,8 @@ module RubyCritic
         end
 
         def render
-          index_body = TEMPLATE.result(get_binding)
-          LAYOUT_TEMPLATE.result(get_binding { index_body })
+          index_body = TEMPLATE.result(base_binding)
+          LAYOUT_TEMPLATE.result(base_binding { index_body })
         end
 
         private


### PR DESCRIPTION
- Removed some cops on `.rubocop_todo.yml`

Don't see the method `get_binding` being used, so I removed it, if it being used somewhere else I think we can use another approach.

If it needs some revision, I will be happy to help :)