### PR TITLE
Allow Rubycritic to accept config files

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -93,7 +93,7 @@ detectors:
     - Parser::AST::Node#module_names
     - RubyCritic::Analyser::FlaySmells#run
     - RubyCritic::Cli::Application#execute
-    - RubyCritic::Cli::Options#parse
+    - RubyCritic::Cli::Options::Argv#parse
     - RubyCritic::CommandFactory#self.command_class
     - RubyCritic::Configuration#set
     - RubyCritic::Generator::Html::CodeFile#render
@@ -114,7 +114,7 @@ detectors:
     exclude:
     - Parser::AST::Node#recursive_children
     - RubyCritic::Analyser::FlaySmells#run
-    - RubyCritic::Cli::Options#parse
+    - RubyCritic::Cli::Options::Argv#parse
     - RubyCritic::Generator::HtmlReport#create_directories_and_files
     - RubyCritic::AnalysedModulesCollection#initialize
   UtilityFunction:
@@ -125,6 +125,7 @@ detectors:
     - RubyCritic::Analyser::FlogSmells#type
     - RubyCritic::Analyser::ReekSmells#smell_locations
     - RubyCritic::Cli::Application#print
+    - RubyCritic::Cli::Options::File#value_for
     - RubyCritic::AnalysedModulesCollection#limited_cost_for
     - RubyCritic::Generator::Html::SmellsIndex#analysed_module_names
     - RubyCritic::Generator::HtmlReport#copy_assets_to_report_directory
@@ -142,7 +143,6 @@ detectors:
     - RubyCritic::Command::Compare#threshold_values_set?
   TooManyInstanceVariables:
     exclude:
-    - RubyCritic::Cli::Options
     - RubyCritic::Generator::Html::CodeFile
     - RubyCritic::Generator::Html::Overview
     - RubyCritic::Generator::Html::SmellsIndex

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -1,7 +1,12 @@
 # Offense count: 1
 Metrics/AbcSize:
   Exclude:
-    - 'lib/rubycritic/cli/options.rb'
+    - 'lib/rubycritic/cli/options/argv.rb'
+
+# Offense count: 1
+Metrics/LineLength:
+  Exclude:
+    - 'lib/rubycritic/cli/options/argv.rb'
 
 # Offense count: 2
 # Configuration parameters: CountComments.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -2,6 +2,7 @@
 Metrics/AbcSize:
   Exclude:
     - 'lib/rubycritic/cli/options/argv.rb'
+    - 'lib/rubycritic/configuration.rb'
 
 # Offense count: 1
 Metrics/LineLength:

--- a/README.md
+++ b/README.md
@@ -125,6 +125,25 @@ $ rubycritic --help
 | `--suppress-ratings`        | Suppress letter ratings                                                                        |
 | `--no-browser`              | Do not open html report with browser                                                           |
 
+You also can use a config file. Just create a `.rubycritic.yml` on your project root path.
+
+Here are one example:
+```
+mode_ci:
+  enabled: true # default is false
+  branch: 'production' # default is master
+branch: 'production' # default is master
+path: '/tmp/mycustompath' # Set path where report will be saved (tmp/rubycritic by default)
+threshhold_score: 10 # default is 0
+deduplicate_symlinks: true # default is false
+suppress_ratings: true # default is false
+no_browser: true # default is false
+format: console # Available values are: html, json, console, lint. Default value is html.
+minimum_score: 95 # default is 0
+paths: # Files to analyse.
+  - 'app/controllers/'
+  - 'app/models/'
+```
 
 ### Analyzer Configuration
 

--- a/lib/rubycritic/cli/application.rb
+++ b/lib/rubycritic/cli/application.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rubycritic'
+require 'rubycritic/browser'
 require 'rubycritic/cli/options'
 require 'rubycritic/command_factory'
 

--- a/lib/rubycritic/cli/application.rb
+++ b/lib/rubycritic/cli/application.rb
@@ -16,9 +16,9 @@ module RubyCritic
       end
 
       def execute
-        parsed_options = @options.parse
+        parsed_options = @options.parse.to_h
 
-        reporter = RubyCritic::CommandFactory.create(parsed_options.to_h).execute
+        reporter = RubyCritic::CommandFactory.create(parsed_options).execute
         print(reporter.status_message)
         reporter.status
       rescue OptionParser::InvalidOption => error

--- a/lib/rubycritic/cli/options.rb
+++ b/lib/rubycritic/cli/options.rb
@@ -1,22 +1,27 @@
 # frozen_string_literal: true
 
 require 'rubycritic/cli/options/argv'
+require 'rubycritic/cli/options/file'
 
 module RubyCritic
   module Cli
     class Options
-      attr_reader :options
+      attr_reader :argv_options, :file_options
 
       def initialize(argv)
-        @options = Argv.new(argv)
+        @argv_options = Argv.new(argv)
+        @file_options = File.new
       end
 
       def parse
-        options.parse
+        argv_options.parse
+        file_options.parse
+
+        self
       end
 
       def to_h
-        options.to_h
+        file_options.to_h.merge(argv_options.to_h)
       end
     end
   end

--- a/lib/rubycritic/cli/options.rb
+++ b/lib/rubycritic/cli/options.rb
@@ -1,116 +1,22 @@
 # frozen_string_literal: true
 
-require 'optparse'
+require 'rubycritic/cli/options/argv'
 
 module RubyCritic
   module Cli
     class Options
+      attr_reader :options
+
       def initialize(argv)
-        @argv = argv
-        self.parser = OptionParser.new
+        @options = Argv.new(argv)
       end
 
-      # rubocop:disable Metrics/MethodLength
       def parse
-        parser.new do |opts|
-          opts.banner = 'Usage: rubycritic [options] [paths]'
-
-          opts.on('-p', '--path [PATH]', 'Set path where report will be saved (tmp/rubycritic by default)') do |path|
-            @root = path
-          end
-
-          opts.on('-b', '--branch BRANCH', 'Set branch to compare') do |branch|
-            self.base_branch = String(branch)
-            set_current_branch
-            self.mode = :compare_branches
-          end
-
-          opts.on('-t', '--maximum-decrease [MAX_DECREASE]',
-                  'Set a threshold for score difference between two branches (works only with -b)') do |threshold_score|
-            self.threshold_score = Integer(threshold_score)
-          end
-
-          formats = []
-          self.formats = formats
-          opts.on(
-            '-f', '--format [FORMAT]',
-            %i[html json console lint],
-            'Report smells in the given format:',
-            '  html (default; will open in a browser)',
-            '  json',
-            '  console',
-            '  lint'
-          ) do |format|
-            formats << format
-          end
-
-          opts.on('-s', '--minimum-score [MIN_SCORE]', 'Set a minimum score') do |min_score|
-            self.minimum_score = Float(min_score)
-          end
-
-          opts.on('-m', '--mode-ci [BASE_BRANCH]',
-                  'Use CI mode (faster, analyses diffs w.r.t base_branch (default: master))') do |branch|
-            self.base_branch = branch || 'master'
-            set_current_branch
-            self.mode = :ci
-          end
-
-          opts.on('--deduplicate-symlinks', 'De-duplicate symlinks based on their final target') do
-            self.deduplicate_symlinks = true
-          end
-
-          opts.on('--suppress-ratings', 'Suppress letter ratings') do
-            self.suppress_ratings = true
-          end
-
-          opts.on('--no-browser', 'Do not open html report with browser') do
-            self.no_browser = true
-          end
-
-          opts.on_tail('-v', '--version', "Show gem's version") do
-            self.mode = :version
-          end
-
-          opts.on_tail('-h', '--help', 'Show this message') do
-            self.mode = :help
-          end
-        end.parse!(@argv)
-        self
+        options.parse
       end
 
       def to_h
-        {
-          mode: mode,
-          root: root,
-          formats: formats,
-          deduplicate_symlinks: deduplicate_symlinks,
-          paths: paths,
-          suppress_ratings: suppress_ratings,
-          help_text: parser.help,
-          minimum_score: minimum_score || 0,
-          no_browser: no_browser,
-          base_branch: base_branch,
-          feature_branch: feature_branch,
-          threshold_score: threshold_score || 0
-        }
-      end
-      # rubocop:enable Metrics/MethodLength
-
-      private
-
-      attr_accessor :mode, :root, :formats, :deduplicate_symlinks,
-                    :suppress_ratings, :minimum_score, :no_browser,
-                    :parser, :base_branch, :feature_branch, :threshold_score
-      def paths
-        if @argv.empty?
-          ['.']
-        else
-          @argv
-        end
-      end
-
-      def set_current_branch
-        self.feature_branch = SourceControlSystem::Git.current_branch
+        options.to_h
       end
     end
   end

--- a/lib/rubycritic/cli/options.rb
+++ b/lib/rubycritic/cli/options.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'optparse'
-require 'rubycritic/browser'
 
 module RubyCritic
   module Cli

--- a/lib/rubycritic/cli/options/argv.rb
+++ b/lib/rubycritic/cli/options/argv.rb
@@ -91,7 +91,11 @@ module RubyCritic
             base_branch: base_branch,
             feature_branch: feature_branch,
             threshold_score: threshold_score
+<<<<<<< HEAD
           }
+=======
+          }.compact
+>>>>>>> Add parsing config file
         end
         # rubocop:enable Metrics/MethodLength
 

--- a/lib/rubycritic/cli/options/argv.rb
+++ b/lib/rubycritic/cli/options/argv.rb
@@ -92,10 +92,14 @@ module RubyCritic
             feature_branch: feature_branch,
             threshold_score: threshold_score
 <<<<<<< HEAD
+<<<<<<< HEAD
           }
 =======
           }.compact
 >>>>>>> Add parsing config file
+=======
+          }
+>>>>>>> Remove .compact because it is not supported by previous Ruby versions
         end
         # rubocop:enable Metrics/MethodLength
 

--- a/lib/rubycritic/cli/options/argv.rb
+++ b/lib/rubycritic/cli/options/argv.rb
@@ -91,15 +91,7 @@ module RubyCritic
             base_branch: base_branch,
             feature_branch: feature_branch,
             threshold_score: threshold_score
-<<<<<<< HEAD
-<<<<<<< HEAD
           }
-=======
-          }.compact
->>>>>>> Add parsing config file
-=======
-          }
->>>>>>> Remove .compact because it is not supported by previous Ruby versions
         end
         # rubocop:enable Metrics/MethodLength
 

--- a/lib/rubycritic/cli/options/argv.rb
+++ b/lib/rubycritic/cli/options/argv.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require 'optparse'
+
+module RubyCritic
+  module Cli
+    class Options
+      class Argv
+        def initialize(argv)
+          @argv = argv
+          self.parser = OptionParser.new
+        end
+
+        # rubocop:disable Metrics/MethodLength
+        def parse
+          parser.new do |opts|
+            opts.banner = 'Usage: rubycritic [options] [paths]'
+
+            opts.on('-p', '--path [PATH]', 'Set path where report will be saved (tmp/rubycritic by default)') do |path|
+              @root = path
+            end
+
+            opts.on('-b', '--branch BRANCH', 'Set branch to compare') do |branch|
+              self.base_branch = String(branch)
+              set_current_branch
+              self.mode = :compare_branches
+            end
+
+            opts.on('-t', '--maximum-decrease [MAX_DECREASE]', 'Set a threshold for score difference between two branches (works only with -b)') do |threshold_score|
+              self.threshold_score = Integer(threshold_score)
+            end
+
+            formats = []
+            self.formats = formats
+            opts.on(
+              '-f', '--format [FORMAT]',
+              %i[html json console lint],
+              'Report smells in the given format:',
+              '  html (default; will open in a browser)',
+              '  json',
+              '  console',
+              '  lint'
+            ) do |format|
+              formats << format
+            end
+
+            opts.on('-s', '--minimum-score [MIN_SCORE]', 'Set a minimum score') do |min_score|
+              self.minimum_score = Float(min_score)
+            end
+
+            opts.on('-m', '--mode-ci [BASE_BRANCH]',
+                    'Use CI mode (faster, analyses diffs w.r.t base_branch (default: master))') do |branch|
+              self.base_branch = branch || 'master'
+              set_current_branch
+              self.mode = :ci
+            end
+
+            opts.on('--deduplicate-symlinks', 'De-duplicate symlinks based on their final target') do
+              self.deduplicate_symlinks = true
+            end
+
+            opts.on('--suppress-ratings', 'Suppress letter ratings') do
+              self.suppress_ratings = true
+            end
+
+            opts.on('--no-browser', 'Do not open html report with browser') do
+              self.no_browser = true
+            end
+
+            opts.on_tail('-v', '--version', "Show gem's version") do
+              self.mode = :version
+            end
+
+            opts.on_tail('-h', '--help', 'Show this message') do
+              self.mode = :help
+            end
+          end.parse!(@argv)
+        end
+
+        def to_h
+          {
+            mode: mode,
+            root: root,
+            formats: formats,
+            deduplicate_symlinks: deduplicate_symlinks,
+            paths: paths,
+            suppress_ratings: suppress_ratings,
+            help_text: parser.help,
+            minimum_score: minimum_score,
+            no_browser: no_browser,
+            base_branch: base_branch,
+            feature_branch: feature_branch,
+            threshold_score: threshold_score
+          }
+        end
+        # rubocop:enable Metrics/MethodLength
+
+        private
+
+        attr_accessor :mode, :root, :formats, :deduplicate_symlinks,
+                      :suppress_ratings, :minimum_score, :no_browser,
+                      :parser, :base_branch, :feature_branch, :threshold_score
+        def paths
+          @argv unless @argv.empty?
+        end
+
+        def set_current_branch
+          self.feature_branch = SourceControlSystem::Git.current_branch
+        end
+      end
+    end
+  end
+end

--- a/lib/rubycritic/cli/options/file.rb
+++ b/lib/rubycritic/cli/options/file.rb
@@ -1,0 +1,96 @@
+require 'yaml'
+
+module RubyCritic
+  module Cli
+    class Options
+      class File
+        attr_reader :filename, :options
+
+        def initialize(filename = './.rubycritic.yml')
+          @filename = filename
+          @options = {}
+        end
+
+        def parse
+          @options = YAML.load_file(filename) if ::File.file?(filename)
+        end
+
+        # rubocop:disable Metrics/MethodLength
+        def to_h
+          {
+            mode: mode,
+            root: root,
+            format: format,
+            deduplicate_symlinks: deduplicate_symlinks,
+            paths: paths,
+            suppress_ratings: suppress_ratings,
+            minimum_score: minimum_score,
+            no_browser: no_browser,
+            base_branch: base_branch,
+            feature_branch: feature_branch,
+            threshold_score: threshold_score
+          }.compact
+        end
+        # rubocop:enable Metrics/MethodLength
+
+        private
+
+        def base_branch
+          return options.dig('mode_ci', 'branch') || 'master' if options.dig('mode_ci', 'enabled').to_s == 'true'
+
+          options['branch']
+        end
+
+        def mode
+          if options.dig('mode_ci', 'enabled').to_s == 'true'
+            :ci
+          elsif base_branch
+            :compare_branches
+          end
+        end
+
+        def feature_branch
+          SourceControlSystem::Git.current_branch if base_branch
+        end
+
+        def root
+          options['path']
+        end
+
+        def threshold_score
+          options['threshold_score']
+        end
+
+        def deduplicate_symlinks
+          value_for(options['deduplicate_symlinks'])
+        end
+
+        def suppress_ratings
+          value_for(options['suppress_ratings'])
+        end
+
+        def no_browser
+          value_for(options['no_browser'])
+        end
+
+        def format
+          value = options['format']
+          value if %w[html json console lint].include?(value)
+        end
+
+        def minimum_score
+          options['minimum_score']
+        end
+
+        def paths
+          options['paths']
+        end
+
+        def value_for(value)
+          value = value.to_s
+          value == 'true' unless value.empty?
+        end
+      end
+    end
+  end
+end

--- a/lib/rubycritic/cli/options/file.rb
+++ b/lib/rubycritic/cli/options/file.rb
@@ -31,7 +31,7 @@ module RubyCritic
             base_branch: base_branch,
             feature_branch: feature_branch,
             threshold_score: threshold_score
-          }.compact
+          }
         end
         # rubocop:enable Metrics/MethodLength
 

--- a/lib/rubycritic/cli/options/file.rb
+++ b/lib/rubycritic/cli/options/file.rb
@@ -22,7 +22,7 @@ module RubyCritic
           {
             mode: mode,
             root: root,
-            format: format,
+            formats: formats,
             deduplicate_symlinks: deduplicate_symlinks,
             paths: paths,
             suppress_ratings: suppress_ratings,
@@ -75,9 +75,11 @@ module RubyCritic
           value_for(options['no_browser'])
         end
 
-        def format
-          value = options['format']
-          value if %w[html json console lint].include?(value)
+        def formats
+          formats = options['formats'] || []
+          formats.select do |format|
+            %w[html json console lint].include?(format)
+          end
         end
 
         def minimum_score

--- a/lib/rubycritic/cli/options/file.rb
+++ b/lib/rubycritic/cli/options/file.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'yaml'
 
 module RubyCritic

--- a/lib/rubycritic/commands/default.rb
+++ b/lib/rubycritic/commands/default.rb
@@ -11,7 +11,7 @@ module RubyCritic
     class Default < Base
       def initialize(options)
         super
-        @paths = options[:paths]
+        @paths = options[:paths] || ['.']
         Config.source_control_system = SourceControlSystem::Base.create
       end
 

--- a/lib/rubycritic/commands/status_reporter.rb
+++ b/lib/rubycritic/commands/status_reporter.rb
@@ -29,7 +29,7 @@ module RubyCritic
       end
 
       def satisfy_minimum_score_rule
-        score >= @options[:minimum_score]
+        score >= @options[:minimum_score].to_f
       end
 
       def update_status_message

--- a/lib/rubycritic/configuration.rb
+++ b/lib/rubycritic/configuration.rb
@@ -15,14 +15,14 @@ module RubyCritic
     def set(options)
       self.mode = options[:mode] || :default
       self.root = options[:root] || 'tmp/rubycritic'
-      self.formats = options[:formats] || [:html]
-      self.deduplicate_symlinks = options[:deduplicate_symlinks] || false
-      self.suppress_ratings = options[:suppress_ratings] || false
+      self.format = options[:formats] || [:html]
+      self.deduplicate_symlinks = options[:deduplicate_symlinks]
+      self.suppress_ratings = options[:suppress_ratings]
       self.open_with = options[:open_with]
       self.no_browser = options[:no_browser]
       self.base_branch = options[:base_branch]
       self.feature_branch = options[:feature_branch]
-      self.threshold_score = options[:threshold_score]
+      self.threshold_score = options[:threshold_score].to_i
     end
 
     def root=(path)

--- a/lib/rubycritic/configuration.rb
+++ b/lib/rubycritic/configuration.rb
@@ -15,7 +15,7 @@ module RubyCritic
     def set(options)
       self.mode = options[:mode] || :default
       self.root = options[:root] || 'tmp/rubycritic'
-      self.format = options[:formats] || [:html]
+      self.formats = options[:formats] || [:html]
       self.deduplicate_symlinks = options[:deduplicate_symlinks]
       self.suppress_ratings = options[:suppress_ratings]
       self.open_with = options[:open_with]


### PR DESCRIPTION
Allow Rubycritic to accept a config file instead of building the whole command through the command line.

Other tools do that, for example, Rubocop.

I need help on how I can test these changes.