### PR TITLE
Add support for multiple report formats in one run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,12 @@ spec/reports
 test/tmp
 test/version_tmp
 test/samples/report.json
+test/samples/lint.txt
+test/samples/overview.html   
+test/samples/code_index.html
+test/samples/smells_index.html
+test/samples/test
+test/samples/assets
 tmp
 .idea/
 .ruby-gemset

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # master [(unreleased)](https://github.com/whitesmith/rubycritic/compare/v3.5.2...master)
 
+* [FEATURE] Allow generating reports in multiple formats in one run (by [@katafrakt])
+
 # 3.5.2 / 2018-09-27 [(commits)](https://github.com/whitesmith/rubycritic/compare/v3.5.1...v3.5.2)
 
 * [BUGFIX] Use a better uncommitted changes detection for git (by [@onumis][])

--- a/lib/rubycritic/cli/options.rb
+++ b/lib/rubycritic/cli/options.rb
@@ -31,6 +31,8 @@ module RubyCritic
             self.threshold_score = Integer(threshold_score)
           end
 
+          formats = []
+          self.formats = formats
           opts.on(
             '-f', '--format [FORMAT]',
             %i[html json console lint],
@@ -40,7 +42,7 @@ module RubyCritic
             '  console',
             '  lint'
           ) do |format|
-            self.format = format
+            formats << format
           end
 
           opts.on('-s', '--minimum-score [MIN_SCORE]', 'Set a minimum score') do |min_score|
@@ -81,7 +83,7 @@ module RubyCritic
         {
           mode: mode,
           root: root,
-          format: format,
+          formats: formats,
           deduplicate_symlinks: deduplicate_symlinks,
           paths: paths,
           suppress_ratings: suppress_ratings,
@@ -97,7 +99,7 @@ module RubyCritic
 
       private
 
-      attr_accessor :mode, :root, :format, :deduplicate_symlinks,
+      attr_accessor :mode, :root, :formats, :deduplicate_symlinks,
                     :suppress_ratings, :minimum_score, :no_browser,
                     :parser, :base_branch, :feature_branch, :threshold_score
       def paths

--- a/lib/rubycritic/configuration.rb
+++ b/lib/rubycritic/configuration.rb
@@ -5,7 +5,7 @@ require 'rubycritic/source_control_systems/base'
 module RubyCritic
   class Configuration
     attr_reader :root
-    attr_accessor :source_control_system, :mode, :format, :deduplicate_symlinks,
+    attr_accessor :source_control_system, :mode, :formats, :deduplicate_symlinks,
                   :suppress_ratings, :open_with, :no_browser, :base_branch,
                   :feature_branch, :base_branch_score, :feature_branch_score,
                   :base_root_directory, :feature_root_directory,
@@ -15,7 +15,7 @@ module RubyCritic
     def set(options)
       self.mode = options[:mode] || :default
       self.root = options[:root] || 'tmp/rubycritic'
-      self.format = options[:format] || :html
+      self.formats = options[:formats] || [:html]
       self.deduplicate_symlinks = options[:deduplicate_symlinks] || false
       self.suppress_ratings = options[:suppress_ratings] || false
       self.open_with = options[:open_with]

--- a/lib/rubycritic/reporter.rb
+++ b/lib/rubycritic/reporter.rb
@@ -5,11 +5,12 @@ module RubyCritic
     REPORT_GENERATOR_CLASS_FORMATS = %i[json console lint].freeze
 
     def self.generate_report(analysed_modules)
-      report_generator_class.new(analysed_modules).generate_report
+      Config.formats.uniq.each do |format|
+        report_generator_class(format).new(analysed_modules).generate_report
+      end
     end
 
-    def self.report_generator_class
-      config_format = Config.format
+    def self.report_generator_class(config_format)
       if REPORT_GENERATOR_CLASS_FORMATS.include? config_format
         require "rubycritic/generators/#{config_format}_report"
         Generator.const_get("#{config_format.capitalize}Report")

--- a/test/lib/rubycritic/reporter_test.rb
+++ b/test/lib/rubycritic/reporter_test.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'rubycritic/reporter'
+
+describe RubyCritic::Reporter do
+  it 'creates multiple reports' do
+    RubyCritic::Config.set(formats: %i[json lint html], no_browser: true)
+    create_analysed_modules_collection
+    RubyCritic::Reporter.generate_report(@analysed_modules_collection)
+
+    assert(File.exist?('test/samples/report.json'))
+    assert(File.exist?('test/samples/lint.txt'))
+    assert(File.exist?('test/samples/overview.html'))
+  end
+
+  def create_analysed_modules_collection
+    RubyCritic::Config.root = 'test/samples'
+    RubyCritic::Config.source_control_system = RubyCritic::SourceControlSystem::Git.new
+    analyser_runner = RubyCritic::AnalysersRunner.new('test/samples/')
+    @analysed_modules_collection = analyser_runner.run
+  end
+end


### PR DESCRIPTION
When you pass `--format` option to RubyCritic, it should be possible to use that option more than once and have reports in different formats created without having to run whole analysis twice.

My use case is to run in in CI, then extract some data from JSON report and send it to Slack, but also publish the HTML report, so people can examine it in a friendly way.

I'm not sure if tests I wrote are enough, but it was all that came to mind.