### PR TITLE
Support for multiple formats by the format option.

### DIFF
--- a/lib/rubycritic/cli/options.rb
+++ b/lib/rubycritic/cli/options.rb
@@ -9,10 +9,12 @@ module RubyCritic
       def initialize(argv)
         @argv = argv
         self.parser = OptionParser.new
+        self.formats = []
       end
 
       # rubocop:disable Metrics/MethodLength
       def parse
+        tmp_formats = []
         parser.new do |opts|
           opts.banner = 'Usage: rubycritic [options] [paths]'
 
@@ -40,7 +42,7 @@ module RubyCritic
             '  console',
             '  lint'
           ) do |format|
-            self.format = format
+            tmp_formats << format
           end
 
           opts.on('-s', '--minimum-score [MIN_SCORE]', 'Set a minimum score') do |min_score|
@@ -74,6 +76,7 @@ module RubyCritic
             self.mode = :help
           end
         end.parse!(@argv)
+        self.formats = tmp_formats
         self
       end
 
@@ -81,7 +84,7 @@ module RubyCritic
         {
           mode: mode,
           root: root,
-          format: format,
+          formats: formats,
           deduplicate_symlinks: deduplicate_symlinks,
           paths: paths,
           suppress_ratings: suppress_ratings,
@@ -97,7 +100,7 @@ module RubyCritic
 
       private
 
-      attr_accessor :mode, :root, :format, :deduplicate_symlinks,
+      attr_accessor :mode, :root, :formats, :deduplicate_symlinks,
                     :suppress_ratings, :minimum_score, :no_browser,
                     :parser, :base_branch, :feature_branch, :threshold_score
       def paths

--- a/lib/rubycritic/commands/default.rb
+++ b/lib/rubycritic/commands/default.rb
@@ -26,7 +26,10 @@ module RubyCritic
       end
 
       def report(analysed_modules)
-        Reporter.generate_report(analysed_modules)
+        Config.formats.each do |format|
+          Reporter.generate_report(analysed_modules, format)
+        end
+
         status_reporter.score = analysed_modules.score
       end
 

--- a/lib/rubycritic/configuration.rb
+++ b/lib/rubycritic/configuration.rb
@@ -5,7 +5,7 @@ require 'rubycritic/source_control_systems/base'
 module RubyCritic
   class Configuration
     attr_reader :root
-    attr_accessor :source_control_system, :mode, :format, :deduplicate_symlinks,
+    attr_accessor :source_control_system, :mode, :formats, :deduplicate_symlinks,
                   :suppress_ratings, :open_with, :no_browser, :base_branch,
                   :feature_branch, :base_branch_score, :feature_branch_score,
                   :base_root_directory, :feature_root_directory,
@@ -15,7 +15,7 @@ module RubyCritic
     def set(options)
       self.mode = options[:mode] || :default
       self.root = options[:root] || 'tmp/rubycritic'
-      self.format = options[:format] || :html
+      self.formats = options[:formats] || [:html]
       self.deduplicate_symlinks = options[:deduplicate_symlinks] || false
       self.suppress_ratings = options[:suppress_ratings] || false
       self.open_with = options[:open_with]

--- a/lib/rubycritic/reporter.rb
+++ b/lib/rubycritic/reporter.rb
@@ -4,15 +4,14 @@ module RubyCritic
   module Reporter
     REPORT_GENERATOR_CLASS_FORMATS = %i[json console lint].freeze
 
-    def self.generate_report(analysed_modules)
-      report_generator_class.new(analysed_modules).generate_report
+    def self.generate_report(analysed_modules, format)
+      report_generator_class(format).new(analysed_modules).generate_report
     end
 
-    def self.report_generator_class
-      config_format = Config.format
-      if REPORT_GENERATOR_CLASS_FORMATS.include? config_format
-        require "rubycritic/generators/#{config_format}_report"
-        Generator.const_get("#{config_format.capitalize}Report")
+    def self.report_generator_class(format)
+      if REPORT_GENERATOR_CLASS_FORMATS.include? format
+        require "rubycritic/generators/#{format}_report"
+        Generator.const_get("#{format.capitalize}Report")
       else
         require 'rubycritic/generators/html_report'
         Generator::HtmlReport


### PR DESCRIPTION
This PR would support the following:
```
./bin/rubycritic --minimum-score 90 --format html --format json
warning: parser/current is loading parser/ruby25, which recognizes
warning: 2.5.3-compliant syntax, but you are running 2.5.1.
warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
  test/samples/unparsable.rb:1 :: parse error on value "%" (tOP_ASGN)
  skipping test/samples/unparsable.rb
running flay smells
....
......................................................................................................................
New critique at file:////home/grimme/src/rubycritic/tmp/rubycritic/overview.html
Score (88.99) is below the minimum 90.0

Di Feb 19, 12:03:53
/home/grimme/src/rubycritic feature/support-multiple-formats
$ ls -lhtr tmp/rubycritic/
total 208K
-rw-rw-r-- 1 grimme grimme  16K Feb 19 12:03 overview.html
-rw-rw-r-- 1 grimme grimme  69K Feb 19 12:03 code_index.html
-rw-rw-r-- 1 grimme grimme  55K Feb 19 12:03 smells_index.html
drwxrwxr-x 4 grimme grimme 4,0K Feb 19 12:03 features
drwxrwxr-x 4 grimme grimme 4,0K Feb 19 12:03 test
drwxrwxr-x 3 grimme grimme 4,0K Feb 19 12:03 lib
drwxrwxr-x 6 grimme grimme 4,0K Feb 19 12:03 assets
-rw-rw-r-- 1 grimme grimme  48K Feb 19 12:03 report.json
```
As can be seen it creates both the html and the json formatted report.

Closes #202 