### PR TITLE
New feature to support formatters.

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,18 +112,20 @@ For a full list of the command-line options run:
 $ rubycritic --help
 ```
 
-| Command flag                | Description                                                                                    |
-|-----------------------------|------------------------------------------------------------------------------------------------|
-| `-v` / `--version`          | Displays the current version and exits                                                         |
-| `-p` / `--path`             | Set path where report will be saved (tmp/rubycritic by default)                                |
-| `-f` / `--format`           | Report smells in the given format(s) (see below)                                               |
-| `-s` / `--minimum-score`    | Set a minimum score (FLOAT: ex: 96.28), default: 0                                             |
-| `-m` / `--mode-ci`          | Use CI mode. Faster, analyses diffs w.r.t base_branch (default: master), see -b                |
-| `-b` / `--branch`           | Set branch to compare                                                                          |
-| `-t` / `--maximum-decrease` | Set a threshold for score difference between two branches (works only with -b), default: 0     |
-| `--deduplicate-symlinks`    | De-duplicate symlinks based on their final target                                              |
-| `--suppress-ratings`        | Suppress letter ratings                                                                        |
-| `--no-browser`              | Do not open html report with browser                                                           |
+| Command flag                        | Description                                                                                    |
+|-------------------------------------|------------------------------------------------------------------------------------------------|
+| `-v` / `--version`                  | Displays the current version and exits                                                         |
+| `-p` / `--path`                     | Set path where report will be saved (tmp/rubycritic by default)                                |
+| `-f` / `--format`                   | Report smells in the given format: `html` (default; will open in a browser), `json`, `console` |
+| `--formatter requirepath:classname` | Load and instantiate the formatter (reporter) with the given classname and load the            |
+|                                     | requirepath upfront.                                                                           | 
+| `-s` / `--minimum-score`            | Set a minimum score (FLOAT: ex: 96.28), default: 0                                             |
+| `-m` / `--mode-ci`                  | Use CI mode. Faster, analyses diffs w.r.t base_branch (default: master), see -b                |
+| `-b` / `--branch`                   | Set branch to compare                                                                          |
+| `-t` / `--maximum-decrease`         | Set a threshold for score difference between two branches (works only with -b), default: 0     |
+| `--deduplicate-symlinks`            | De-duplicate symlinks based on their final target                                              |
+| `--suppress-ratings`                | Suppress letter ratings                                                                        |
+| `--no-browser`                      | Do not open html report with browser                                                           |
 
 ### Available output formats:
 - `html` (default; will open in a browser)
@@ -208,6 +210,9 @@ RubyCritic::RakeTask.new do |task|
 end
 ```
 
+## Formatters
+
+See [formatters](docs/formatters.md)
 
 ## Compatibility
 

--- a/docs/formatters.md
+++ b/docs/formatters.md
@@ -1,0 +1,67 @@
+# Concept of formatters
+
+The formatters support is to extract the logic of the representation of each rubycritic run from the gathering of results.
+With delegating to a formatter you can write your own *whitelabeled* report for rubycritic and being indepedent on the logic.
+
+## Formatters interface
+
+The formatters are nothing else then a [report/generator](lib/rubycritic/generators). 
+The report generator has to be implemented as follows
+
+``` ruby
+class MyFormatter
+  def initialize(analysed_modules)
+    ..
+    @analysed_modules = analysed_modules
+    ..
+  end
+
+  def generate_report
+    .. # do whatever you want with the analysed_modules model
+  end
+end
+```
+
+The results will be passed through the [analysed_modules_collection class](lib/rubycritic/core/analysed_modules_collection.rb).
+The ``generate_report`` method is called to actually generate the report.
+
+## Examples
+
+### Badges
+
+See [rubycritic-small-badge](https://github.com/MarcGrimme/rubycritic-small-badge/). This badge could look as follows:
+
+[![RubyCritic](https://marcgrimme.github.io/rubycritic-small-badge/badges/rubycritic_badge_score.svg)](https://marcgrimme.github.io/rubycritic-small-badge/tmp/rubycritic/overview.html)
+
+## Formatter Classloading
+
+### With classname
+
+In order to load the formatter class as part of the Raketask the following approach can be followed. Basically the *require* of the formatter class needs to happen somewhere before the  ``RubyCritic::RakeTask`` is defined.
+
+When *rubycritic* is run the formatter class is automatically loaded if the formatter parameter represents the fully qualified classname of the formatter class.
+Takeing the above example and combining it with the *Rakefile* could look as follows:
+
+``` ruby Rakefile
+...
+require 'my_formatter'
+RubyCritic::RakeTask.new do |task|
+  ..
+  task.options = %(--formatter MyFormatter)
+  ..
+end
+```
+
+See the [Rakefile](https://github.com/MarcGrimme/repo-small-badge/blob/master/Rakefile#L14-L19) for [rubycritic-small-badge](https://github.com/MarcGrimme/rubycritic-small-badge/)
+
+### With classname and classpath
+
+*rubycritic* is called outside of the structure that has to be **criticed** with just calling the command. The path to load as well as the fully qualitfied classname of the formatter have to be passed. This happens with the ``--formater`` option followed by the path to require (*requirepath*) a `:` as a separator and the fully qualified *classname*.
+An example could look as follows:
+
+``` shell
+gem install my_formatter_gem
+rubycritic --formatter my_formatter:MyFormatter
+```
+
+This will do the same as above.

--- a/features/command_line_interface/options.feature
+++ b/features/command_line_interface/options.feature
@@ -29,6 +29,16 @@ Feature: RubyCritic can be controlled using command-line options
                                              json
                                              console
                                              lint
+                                           Multiple formats are supported.
+              --formatter [REQUIREPATH]:[CLASSNAME]|[CLASSNAME]
+                                           Instantiate a given class as formatter and call report for reporting.
+                                           Two ways are possible to load the formatter.
+                                           If the class is not autorequired the REQUIREPATH can be given together
+                                           with the CLASSNAME to be loaded seperated by a :.
+                                           Example: rubycritic/markdown/reporter.rb:RubyCritic::MarkDown::Reporter
+                                           or if the file is already required the CLASSNAME is enough
+                                           Example: RubyCritic::MarkDown::Reporter
+                                           Multiple formatters are supported.
           -s, --minimum-score [MIN_SCORE]  Set a minimum score
           -m, --mode-ci [BASE_BRANCH]      Use CI mode (faster, analyses diffs w.r.t base_branch (default: master))
               --deduplicate-symlinks       De-duplicate symlinks based on their final target

--- a/lib/rubycritic/cli/options.rb
+++ b/lib/rubycritic/cli/options.rb
@@ -16,7 +16,6 @@ module RubyCritic
       def parse
         argv_options.parse
         file_options.parse
-
         self
       end
 

--- a/lib/rubycritic/cli/options/argv.rb
+++ b/lib/rubycritic/cli/options/argv.rb
@@ -5,13 +5,14 @@ require 'optparse'
 module RubyCritic
   module Cli
     class Options
+      # rubocop:disable Metrics/ClassLength
       class Argv
         def initialize(argv)
           @argv = argv
           self.parser = OptionParser.new
         end
 
-        # rubocop:disable Metrics/MethodLength
+        # rubocop:disable Metrics/MethodLength,Metrics/AbcSize
         def parse
           parser.new do |opts|
             opts.banner = 'Usage: rubycritic [options] [paths]'
@@ -43,9 +44,26 @@ module RubyCritic
               '  html (default; will open in a browser)',
               '  json',
               '  console',
-              '  lint'
+              '  lint',
+              'Multiple formats are supported.'
             ) do |format|
               formats << format
+            end
+
+            formatters = []
+            self.formatters = formatters
+            opts.on(
+              '--formatter [REQUIREPATH]:[CLASSNAME]|[CLASSNAME]',
+              'Instantiate a given class as formatter and call report for reporting.',
+              'Two ways are possible to load the formatter.',
+              'If the class is not autorequired the REQUIREPATH can be given together',
+              'with the CLASSNAME to be loaded seperated by a :.',
+              'Example: rubycritic/markdown/reporter.rb:RubyCritic::MarkDown::Reporter',
+              'or if the file is already required the CLASSNAME is enough',
+              'Example: RubyCritic::MarkDown::Reporter',
+              'Multiple formatters are supported.'
+            ) do |formatter|
+              formatters << formatter
             end
 
             opts.on('-s', '--minimum-score [MIN_SCORE]', 'Set a minimum score') do |min_score|
@@ -86,6 +104,7 @@ module RubyCritic
             mode: mode,
             root: root,
             formats: formats,
+            formatters: formatters,
             deduplicate_symlinks: deduplicate_symlinks,
             paths: paths,
             suppress_ratings: suppress_ratings,
@@ -97,11 +116,11 @@ module RubyCritic
             threshold_score: threshold_score
           }
         end
-        # rubocop:enable Metrics/MethodLength
+        # rubocop:enable Metrics/MethodLength,Metrics/AbcSize
 
         private
 
-        attr_accessor :mode, :root, :formats, :deduplicate_symlinks,
+        attr_accessor :mode, :root, :formats, :formatters, :deduplicate_symlinks,
                       :suppress_ratings, :minimum_score, :no_browser,
                       :parser, :base_branch, :feature_branch, :threshold_score
         def paths
@@ -112,6 +131,7 @@ module RubyCritic
           self.feature_branch = SourceControlSystem::Git.current_branch
         end
       end
+      # rubocop:enable Metrics/ClassLength
     end
   end
 end

--- a/lib/rubycritic/configuration.rb
+++ b/lib/rubycritic/configuration.rb
@@ -5,7 +5,7 @@ require 'rubycritic/source_control_systems/base'
 module RubyCritic
   class Configuration
     attr_reader :root
-    attr_accessor :source_control_system, :mode, :formats, :deduplicate_symlinks,
+    attr_accessor :source_control_system, :mode, :formats, :formatters, :deduplicate_symlinks,
                   :suppress_ratings, :open_with, :no_browser, :base_branch,
                   :feature_branch, :base_branch_score, :feature_branch_score,
                   :base_root_directory, :feature_root_directory,
@@ -15,7 +15,6 @@ module RubyCritic
     def set(options)
       self.mode = options[:mode] || :default
       self.root = options[:root] || 'tmp/rubycritic'
-      self.formats = options[:formats] || [:html]
       self.deduplicate_symlinks = options[:deduplicate_symlinks]
       self.suppress_ratings = options[:suppress_ratings]
       self.open_with = options[:open_with]
@@ -23,6 +22,12 @@ module RubyCritic
       self.base_branch = options[:base_branch]
       self.feature_branch = options[:feature_branch]
       self.threshold_score = options[:threshold_score].to_i
+      setup_formats(options)
+    end
+
+    def setup_formats(options)
+      self.formats = options[:formats] || [:html]
+      self.formatters = options[:formatters] || []
     end
 
     def root=(path)

--- a/lib/rubycritic/reporter.rb
+++ b/lib/rubycritic/reporter.rb
@@ -5,8 +5,11 @@ module RubyCritic
     REPORT_GENERATOR_CLASS_FORMATS = %i[json console lint].freeze
 
     def self.generate_report(analysed_modules)
-      Config.formats.uniq.each do |format|
+      RubyCritic::Config.formats.uniq.each do |format|
         report_generator_class(format).new(analysed_modules).generate_report
+      end
+      RubyCritic::Config.formatters.each do |formatter|
+        report_generator_class_from_formatter(formatter).new(analysed_modules).generate_report
       end
     end
 
@@ -18,6 +21,19 @@ module RubyCritic
         require 'rubycritic/generators/html_report'
         Generator::HtmlReport
       end
+    end
+
+    def self.report_generator_class_from_formatter(formatter)
+      require_path, class_name = formatter.sub(/([^:]):([^:])/, '\1\;\2').split('\;', 2)
+      class_name ||= require_path
+      require require_path unless require_path == class_name
+      class_from_path(class_name)
+    end
+
+    def self.class_from_path(path)
+      path.split('::').inject(Object) { |obj, klass| obj.const_get klass }
+    rescue NameError => error
+      raise "Could not create reporter for class #{path}. Error: #{error}!"
     end
   end
 end

--- a/test/lib/rubycritic/reporter_test.rb
+++ b/test/lib/rubycritic/reporter_test.rb
@@ -4,8 +4,13 @@ require 'test_helper'
 require 'rubycritic/reporter'
 
 describe RubyCritic::Reporter do
+  before do
+    RubyCritic::Config.set({})
+    RubyCritic::Config.stubs(:no_browser).returns(true)
+  end
+
   it 'creates multiple reports' do
-    RubyCritic::Config.set(formats: %i[json lint html], no_browser: true)
+    RubyCritic::Config.stubs(:formats).returns(%i[json lint html])
     create_analysed_modules_collection
     RubyCritic::Reporter.generate_report(@analysed_modules_collection)
 
@@ -14,9 +19,37 @@ describe RubyCritic::Reporter do
     assert(File.exist?('test/samples/overview.html'))
   end
 
+  it 'creates a dummy formatter' do
+    RubyCritic::Config.stubs(:formatters).returns(['DummyFormatter'])
+    class DummyFormatter; end
+    formatter = mock
+    formatter.expects(:generate_report).returns(true)
+    DummyFormatter.expects(:new).once.returns(formatter)
+    create_analysed_modules_collection
+    assert RubyCritic::Reporter.generate_report(@analysed_modules_collection)
+  end
+
+  it 'creates a dummy formatter long path' do
+    RubyCritic::Config.stubs(:formatters).returns(['MyTest::DummyFormatter'])
+    module MyTest
+      class DummyFormatter; end
+    end
+    formatter = mock
+    formatter.expects(:generate_report).returns(true)
+    MyTest::DummyFormatter.expects(:new).once.returns(formatter)
+    create_analysed_modules_collection
+    assert RubyCritic::Reporter.generate_report(@analysed_modules_collection)
+  end
+
+  it 'creates and loads a dummy formatter' do
+    RubyCritic::Config.stubs(:formatters).returns(['./test/samples/dummy_formatter.rb:Test::DummyFormatter'])
+    create_analysed_modules_collection
+    assert RubyCritic::Reporter.generate_report(@analysed_modules_collection)
+  end
+
   def create_analysed_modules_collection
-    RubyCritic::Config.root = 'test/samples'
-    RubyCritic::Config.source_control_system = RubyCritic::SourceControlSystem::Git.new
+    RubyCritic::Config.stubs(:root).returns('./test/samples')
+    RubyCritic::Config.stubs(:source_control_system).returns(RubyCritic::SourceControlSystem::Git.new)
     analyser_runner = RubyCritic::AnalysersRunner.new('test/samples/')
     @analysed_modules_collection = analyser_runner.run
   end

--- a/test/samples/dummy_formatter.rb
+++ b/test/samples/dummy_formatter.rb
@@ -1,0 +1,6 @@
+module Test
+  class DummyFormatter
+    def initialize(_analysed_modules); end
+    def generate_report; end
+  end
+end


### PR DESCRIPTION
This feature enables rubycritic to use external reporters chained together. A little bit similar to how simplecov does it.
One use case is a badge to be created from it like to be seen here (look on the badges):
[![ruby-critic-small-badge](https://marcgrimme.github.io/rubycritic-small-badge/badges/rubycritic_badge_score.svg)](https://marcgrimme.github.io/rubycritic-small-badge/tmp/rubycritic/overview.html) see [rubycritic-small-badge](https://github.com/MarcGrimme/rubycritic-small-badge/)
Other use cases could be an Markdown Report but not necessarily as part of the RubyCritic gem.
Let me know what you think.