### PR TITLE
Fix generating the default html report, fixes #297

### DIFF
--- a/lib/rubycritic/configuration.rb
+++ b/lib/rubycritic/configuration.rb
@@ -26,7 +26,8 @@ module RubyCritic
     end
 
     def setup_formats(options)
-      self.formats = options[:formats] || [:html]
+      formats = options[:formats].to_a
+      self.formats = formats.empty? ? [:html] : formats
       self.formatters = options[:formatters] || []
     end
 

--- a/test/lib/rubycritic/configuration_test.rb
+++ b/test/lib/rubycritic/configuration_test.rb
@@ -28,4 +28,14 @@ describe RubyCritic::Configuration do
       RubyCritic::Config.root = @default
     end
   end
+
+  describe '#formats' do
+    before do
+      RubyCritic::Config.set(formats: [])
+    end
+
+    it 'sets html format by default' do
+      RubyCritic::Config.formats.must_equal [:html]
+    end
+  end
 end


### PR DESCRIPTION
The html report was not generated in the new version (#297), cause the parsed options turned `formats` to be an empty array, so the default formats value `[:html]` was not assigned.
- fixed setting default value when `formats` are empty
- added spec for this case