### PR TITLE
Fix HTML5 aria-hidden attribute. Remove default type="text/javascript…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # master [(unreleased)](https://github.com/whitesmith/rubycritic/compare/v4.0.2...master)
 
+* [BUGFIX] Assorted fixes in HTML report (by [@jbampton][])
 * [BUGFIX] Fix duplicate HTML5 DOCTYPE (by [@jbampton][])
 
 # 4.0.2 / 2019-03-14 [(commits)](https://github.com/whitesmith/rubycritic/compare/v4.0.1...v4.0.2)

--- a/lib/rubycritic/generators/html/assets/stylesheets/application.css
+++ b/lib/rubycritic/generators/html/assets/stylesheets/application.css
@@ -124,7 +124,7 @@ header {
 .Summary_Content .list-inline {
   text-align:center;
   margin-top:10px;
-  pading-right:0;
+  padding-right:0;
 }
 .Summary_Content .list-inline span {color:#A4A4A4}
 #wrapper.toggled #page-content-wrapper {

--- a/lib/rubycritic/generators/html/templates/layouts/application.html.erb
+++ b/lib/rubycritic/generators/html/templates/layouts/application.html.erb
@@ -17,7 +17,7 @@
   <body>
     <header class="navbar navbar-default navbar-fixed-top">
       <a href="#menu-toggle" class="btn btn-default hidden-lg visible-sm-* hidden-md visible-xs-* pull-left" id="menu-toggle"><i class="fa fa-bars" aria-hidden="true"></i></a>
-      <a href="<%= file_path('overview.html') %>"><img src="<%= image_path('logo.png') %>" title="Ruby Critic Logo" width="55"><span class="logo">RUBYCRITIC</span></a>
+      <a href="<%= file_path('overview.html') %>"><img src="<%= image_path('logo.png') %>" alt="Ruby Critic Logo" title="Ruby Critic Logo" width="55"><span class="logo">RUBYCRITIC</span></a>
       <% if Config.compare_branches_mode? %>
         <ul class="nav navbar-nav navbar-right">
           <a href="<%= @base_path %>"><span class="branch"><%= Config.base_branch %></span></a>
@@ -49,7 +49,7 @@
       </div>
     </div>
 
-    <!-- Javascripts -->
+    <!-- JavaScripts -->
     <%= javascript_tag(:'jquery.min') %>
     <%= javascript_tag(:'jquery.tablesorter.min') %>
     <%= javascript_tag(:'jquery.scrollTo.min') %>

--- a/lib/rubycritic/generators/html/templates/overview.html.erb
+++ b/lib/rubycritic/generators/html/templates/overview.html.erb
@@ -23,10 +23,10 @@
             <% if Config.source_control_present? %>
               <div id="churn-vs-complexity-graph-container" class="chart-container"></div>
             <% else %>
-              <div id="churn-error">We can't show you Churn-vs-Complexity graph because this project does not seem to be under a source code management system like git or perforce at the moment. This doesn't mean that anything is wrong, it just means certain features like this one are not avaiable.</div>
+              <div id="churn-error">We can't show you Churn-vs-Complexity graph because this project does not seem to be under a source code management system like git or perforce at the moment. This doesn't mean that anything is wrong, it just means certain features like this one are not available.</div>
             <% end %>
 
-            <script type="text/javascript">
+            <script>
              var turbulenceData = <%= @turbulence_data %>;
              var score = <%= @score %>;
             </script>

--- a/lib/rubycritic/generators/html/templates/smelly_line.html.erb
+++ b/lib/rubycritic/generators/html/templates/smelly_line.html.erb
@@ -6,7 +6,7 @@
     <div class="description">
       <div class="heading">
         <span>
-          <i class="fa fa-warning" aria-hidden"true"=""></i>
+          <i class="fa fa-warning" aria-hidden="true"></i>
           <a href="<%= smell.doc_url %>" target="_blank"><b><%= smell.type %></b></a>
         </span>
       </div>


### PR DESCRIPTION
…" from HTML5 script tag. Correct case of JavaScript.

Fix CSS padding-right property spelling.  

Add HTML img alt attribute to logo.  Fix spelling