### PR TITLE
Config options getting overwritten by nil argv options

### DIFF
--- a/lib/rubycritic/cli/options.rb
+++ b/lib/rubycritic/cli/options.rb
@@ -24,9 +24,9 @@ module RubyCritic
         file_hash = file_options.to_h
         argv_hash = argv_options.to_h
 
-        file_hash.merge(argv_hash) { |_, file_option, argv_option|
+        file_hash.merge(argv_hash) do |_, file_option, argv_option|
           argv_option.nil? ? file_option : argv_option
-        }
+        end
       end
     end
   end

--- a/lib/rubycritic/cli/options.rb
+++ b/lib/rubycritic/cli/options.rb
@@ -19,6 +19,7 @@ module RubyCritic
         self
       end
 
+      # :reek:NilCheck
       def to_h
         file_hash = file_options.to_h
         argv_hash = argv_options.to_h

--- a/lib/rubycritic/cli/options.rb
+++ b/lib/rubycritic/cli/options.rb
@@ -20,7 +20,12 @@ module RubyCritic
       end
 
       def to_h
-        file_options.to_h.merge(argv_options.to_h)
+        file_hash = file_options.to_h
+        argv_hash = argv_options.to_h
+
+        file_hash.merge(argv_hash) { |_, file_option, argv_option|
+          argv_option.nil? ? file_option : argv_option
+        }
       end
     end
   end

--- a/lib/rubycritic/cli/options/argv.rb
+++ b/lib/rubycritic/cli/options/argv.rb
@@ -114,7 +114,7 @@ module RubyCritic
             base_branch: base_branch,
             feature_branch: feature_branch,
             threshold_score: threshold_score
-          }.delete_if {|_, value| value.nil? }
+          }
         end
         # rubocop:enable Metrics/MethodLength,Metrics/AbcSize
 

--- a/lib/rubycritic/cli/options/argv.rb
+++ b/lib/rubycritic/cli/options/argv.rb
@@ -114,7 +114,7 @@ module RubyCritic
             base_branch: base_branch,
             feature_branch: feature_branch,
             threshold_score: threshold_score
-          }
+          }.delete_if {|key, value| value.nil? }
         end
         # rubocop:enable Metrics/MethodLength,Metrics/AbcSize
 

--- a/lib/rubycritic/cli/options/argv.rb
+++ b/lib/rubycritic/cli/options/argv.rb
@@ -114,7 +114,7 @@ module RubyCritic
             base_branch: base_branch,
             feature_branch: feature_branch,
             threshold_score: threshold_score
-          }.delete_if {|key, value| value.nil? }
+          }.delete_if {|_, value| value.nil? }
         end
         # rubocop:enable Metrics/MethodLength,Metrics/AbcSize
 


### PR DESCRIPTION
Options that are defined in the config file were getting overwritten by everything defined by the `argv_options` hash because of the way the hashes are getting merged here: https://github.com/whitesmith/rubycritic/blob/master/lib/rubycritic/cli/options.rb#L23

This commit deletes all argv options that are nil which allows any config file options to be applied as expected.

Another option would be to supply a block to the hash merge referenced in the above link. I initially went this route but then realized that you can't simply check for truthy-ness because the argv options could be false...

