### PR TITLE
Add Markdown linting to the Travis build by using the Rubygem mdl.

### DIFF
--- a/.mdlrc
+++ b/.mdlrc
@@ -1,0 +1,2 @@
+git_recurse true
+rules "~MD004,~MD006,~MD013,~MD014,~MD025,~MD029,~MD032,~MD033,~MD038"

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,4 +26,5 @@ script:
   - bundle exec rake test
   - bundle exec cucumber features --format progress --color
   - bundle exec rake reek
+  - bundle exec mdl .
   - bundle exec rubocop

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # master [(unreleased)](https://github.com/whitesmith/rubycritic/compare/v4.1.0...master)
 
-*
+* [FEATURE] Add Markdown linting to the Travis build by using the Rubygem `markdownlint` (by [@jbampton][])
 
 # master [(unreleased)](https://github.com/whitesmith/rubycritic/compare/v4.0.2...v4.1.0)
 
@@ -15,7 +15,7 @@
 
 # 4.0.1 / 2019-03-12 [(commits)](https://github.com/whitesmith/rubycritic/compare/v4.0.0...v4.0.1)
 
-* [FEATUE] Allow passing formatters from the outside (by [@marcgrimme][] and [@onumis][])
+* [FEATURE] Allow passing formatters from the outside (by [@marcgrimme][] and [@onumis][])
 * [CHANGE] Fix aruba deprecation warning
 
 # 4.0.0 / 2019-02-27 [(commits)](https://github.com/whitesmith/rubycritic/compare/v3.5.1...v4.0.0)
@@ -243,7 +243,6 @@
 # 1.0.0 / 2014-07-13
 
 * Official Release
-
 
 [@LeeXGreen]: https://github.com/LeeXGreen
 [@crackofdusk]: https://github.com/crackofdusk

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,6 +75,7 @@ If you are experiencing unexpected behavior and, after having read the documenta
 
 Changelog entry format
 ------------------------
+
 Here are a few examples:
 
 ```

--- a/README.md
+++ b/README.md
@@ -1,15 +1,14 @@
-RubyCritic
-==========
+# RubyCritic
 
 [![Gem Version](https://badge.fury.io/rb/rubycritic.svg)](http://badge.fury.io/rb/rubycritic)
 [![Build Status](https://travis-ci.org/whitesmith/rubycritic.svg?branch=master)](https://travis-ci.org/whitesmith/rubycritic)
 [![Code Climate](https://codeclimate.com/github/whitesmith/rubycritic/badges/gpa.svg)](https://codeclimate.com/github/whitesmith/rubycritic)
 
-<img src="https://github.com/whitesmith/rubycritic/raw/master/images/logo.png" alt="RubyCritic Icon" align="right" />
+<img src="https://github.com/whitesmith/rubycritic/raw/master/images/logo.png" alt="RubyCritic Icon" align="right">
 
 RubyCritic is a gem that wraps around static analysis gems such as [Reek][1], [Flay][2] and [Flog][3] to provide a quality report of your Ruby code.
 
-**Table of Contents**
+## Table of Contents
 
 - [Overview](#overview)
 - [Getting Started](#getting-started)
@@ -21,7 +20,6 @@ RubyCritic is a gem that wraps around static analysis gems such as [Reek][1], [F
 - [Improving RubyCritic](#improving-rubyCritic)
 - [Contributors](#contributors)
 - [Credits](#credits)
-
 
 ## Overview
 
@@ -68,7 +66,6 @@ This gem provides features such as:
 
 Checkout the `/docs` if you want to read more about our [core metrics](https://github.com/whitesmith/rubycritic/blob/master/docs/core-metrics.md).
 
-
 ## Getting Started
 
 RubyCritic can be installed with the following command:
@@ -89,7 +86,6 @@ And then execute:
 ```bash
 $ bundle
 ```
-
 
 ## Usage
 
@@ -138,6 +134,7 @@ $ rubycritic --help
 You also can use a config file. Just create a `.rubycritic.yml` on your project root path.
 
 Here are one example:
+
 ```yml
 mode_ci:
   enabled: true # default is false
@@ -162,17 +159,15 @@ paths: # Files to analyse.
   project root and `RubyCritic` will respect this configuration.
 * [`flay`](https://github.com/seattlerb/flay): We use `flay`'s default configuration.
 * [`flog`](https://github.com/seattlerb/flog): We use `flog`'s default configuration with a couple of [smaller tweaks](https://github.com/whitesmith/rubycritic/blob/master/lib/rubycritic/analysers/helpers/flog.rb#L5):
-    * `all`: Forces `flog` to report scores on all classes and methods. Without this option `flog` will only give results up to a certain threshold.
-    * `continue`: Makes it so that `flog` does not abort when a ruby file cannot be parsed.
-    * `methods`: Configures `flog` to skip code outside of methods. It prevents `flog` from reporting on the "methods" `private` and `protected`. It also prevents `flog` from reporting on Rails methods like `before_action` and `has_many`.
-
+  * `all`: Forces `flog` to report scores on all classes and methods. Without this option `flog` will only give results up to a certain threshold.
+  * `continue`: Makes it so that `flog` does not abort when a ruby file cannot be parsed.
+  * `methods`: Configures `flog` to skip code outside of methods. It prevents `flog` from reporting on the "methods" `private` and `protected`. It also prevents `flog` from reporting on Rails methods like `before_action` and `has_many`.
 
 ### Alternative Usage Methods
 
 If you're fond of Guard you might like [guard-rubycritic][4]. It automatically analyses your Ruby files as they are modified.
 
 For continuous integration, you can give [Jenkins CI][5] a spin. With it, you can [easily build your own (poor-man's) Code Climate][6]!
-
 
 ### Rake Task
 
@@ -225,7 +220,6 @@ RubyCritic is supporting Ruby versions:
 * 2.5
 * 2.6
 
-
 ## Improving RubyCritic
 
 RubyCritic doesn't have to remain a second choice to other code quality analysis services. Together, we can improve it and continue to build on the great code metric tools that are available in the Ruby ecosystem.
@@ -236,9 +230,7 @@ Similarly, Pull Requests that improve the look and feel of the gem, that tweak t
 
 See RubyCritic's [contributing guidelines](https://github.com/whitesmith/rubycritic/blob/master/CONTRIBUTING.md) about how to proceed.
 
-
 ## Contributors
-
 
 `RubyCritics` initial author was [Guilherme Simões](https://github.com/guilhermesimoes).
 
@@ -247,7 +239,6 @@ The current core team consists of:
 * [Nuno Silva](https://github.com/Onumis)
 * [Lucas Mazza](https://github.com/lucasmazza)
 * [Timo Rößner](https://github.com/troessner)
-
 
 ## Credits
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -39,7 +39,7 @@ These are more nice-to-haves than promises. We can always dream. But this is wha
 
   - [ ] [Brakeman](https://github.com/presidentbeef/brakeman) to provide security issues (Rails-only feature)
 
-  - [ ] [Rails Best Practices](https://github.com/railsbp/rails_best_practices) to provide Rails smells (Rails-only feature) #14 
+  - [ ] [Rails Best Practices](https://github.com/railsbp/rails_best_practices) to provide Rails smells (Rails-only feature) #14
 
   - [ ] [SandiMeter](https://github.com/makaroni4/sandi_meter) #15
 

--- a/docs/core-metrics.md
+++ b/docs/core-metrics.md
@@ -46,7 +46,6 @@ Each file is represented by a dot. **The closer they are to the bottom-left corn
 But keep in mind that you cannot reduce churn (well... not unless you re-write your repo's history :neckbeard:), so try to keep the dots as close to the bottom as possible.
 Chad made a nice [summary if you want to know more][8] about the meaning behind each quadrant.
 
-
 ## Rating
 
 This is a letter from `A` to `F`, `A` being the best. This serves as a baseline to tell you how *smelly* a file is.
@@ -60,7 +59,6 @@ Generally `A`'s & `B`'s are good enough, `C`'s serve as a warning and `D`'s & `F
 
 The definition of this **cost** varies from tool to tool, but it's always a non-negative number, with high values indicating worse smells.
 The **complexity** of a file also (slightly) affects its final cost.
-
 
 [1]: https://gist.github.com/brynary/21369b5892525e1bd102
 [2]: https://github.com/troessner/reek

--- a/docs/jenkins-pr-reviews.md
+++ b/docs/jenkins-pr-reviews.md
@@ -15,7 +15,6 @@ For creating comments on PRs we are going to use the [Violation Comments to GitH
 The Violation plugin has parsers for many different formats, and the GoLint one is compatible with the `lint` format created by RubyCritic.
 We're assuming that you use a `Jenkinsfile` for creating a pipeline, but the approach can be adapted to other scenarios.
 
-
 ```groovy
 pipeline {
   agent any

--- a/rubycritic.gemspec
+++ b/rubycritic.gemspec
@@ -46,6 +46,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'cucumber', '~> 3.0', '>= 2.2.0'
   spec.add_development_dependency 'diff-lcs', '~> 1.3'
   spec.add_development_dependency 'fakefs', '~> 0.10', '>= 0.10.0'
+  spec.add_development_dependency 'mdl', '~> 0.5.0'
   spec.add_development_dependency 'minitest', '~> 5.3', '>= 5.3.0'
   spec.add_development_dependency 'minitest-around', '~> 0.5.0', '>= 0.4.0'
   spec.add_development_dependency 'mocha', '~> 1.1', '>= 1.1.0'


### PR DESCRIPTION
Some basic markdown linting removing trailing whitespace and excess blank lines and mods to headings and indents to lists.  

Add config file `.mdlrc` to control which rules are run with basic setup of rules excluded for now.  

Add Rubygem `mdl` as development dependency. 

Correct typo in CHANGELOG.

https://github.com/markdownlint/markdownlint

https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md

https://rubygems.org/gems/mdl