### PR TITLE
Fix YAML configuration file 'formats' processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,8 @@ threshold_score: 10 # default is 0
 deduplicate_symlinks: true # default is false
 suppress_ratings: true # default is false
 no_browser: true # default is false
-format: console # Available values are: html, json, console, lint. Default value is html.
+formats: # Available values are: html, json, console, lint. Default value is html.
+  - console
 minimum_score: 95 # default is 0
 paths: # Files to analyse.
   - 'app/controllers/'

--- a/lib/rubycritic/cli/options.rb
+++ b/lib/rubycritic/cli/options.rb
@@ -25,7 +25,7 @@ module RubyCritic
         argv_hash = argv_options.to_h
 
         file_hash.merge(argv_hash) do |_, file_option, argv_option|
-          argv_option.nil? ? file_option : argv_option
+          Array(argv_option).empty? ? file_option : argv_option
         end
       end
     end

--- a/lib/rubycritic/cli/options/file.rb
+++ b/lib/rubycritic/cli/options/file.rb
@@ -76,10 +76,10 @@ module RubyCritic
         end
 
         def formats
-          formats = options['formats'] || []
+          formats = Array(options['formats'])
           formats.select do |format|
             %w[html json console lint].include?(format)
-          end
+          end.map(&:to_sym)
         end
 
         def minimum_score


### PR DESCRIPTION
Fixes: Ignores .rubycritic.yml file #303 

See #303 for details of the problem and why each of the changes were made.