### PR TITLE
Correct color coding for code coverage ratings in the Coverage section

### DIFF
--- a/lib/rubycritic/generators/html/templates/simple_cov_index.html.erb
+++ b/lib/rubycritic/generators/html/templates/simple_cov_index.html.erb
@@ -23,7 +23,7 @@
               <tr>
                 <% unless Config.suppress_ratings %>
                   <td>
-                    <div class="rating <%= analysed_module.rating.to_s.downcase %>"><%= analysed_module.coverage_rating %></div>
+                    <div class="rating <%= analysed_module.coverage_rating.to_s.downcase %>"><%= analysed_module.coverage_rating %></div>
                   </td>
                 <% end %>
                 <td>


### PR DESCRIPTION
Hey @Onumis, 

This PR fixes #324. It's pretty straightforward: 

> Color coding for each grade should be based in coverage_rating, not rating

Please check it out and let me know if it's okay.

Thanks! 