### PR TITLE
Fix deprecation warnings related to Minitest 6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # master [(unreleased)](https://github.com/whitesmith/rubycritic/compare/v4.2.1...master)
 
+* [BUGFIX] Fix deprecation warnings related to Minitest 6 (by [@jsantos][])
+
 # v4.2.1 / 2019-10-29 [(commits)](https://github.com/whitesmith/rubycritic/compare/v4.2.0...v4.2.1)
 
 * [BUGFIX] Fix Color coding of files in Coverage section (by [@etagwerker][])

--- a/test/lib/rubycritic/analysers/churn_test.rb
+++ b/test/lib/rubycritic/analysers/churn_test.rb
@@ -15,11 +15,11 @@ describe RubyCritic::Analyser::Churn do
     end
 
     it 'calculates its churn' do
-      @analysed_module.churn.must_equal 1
+      _(@analysed_module.churn).must_equal 1
     end
 
     it 'determines the date of its last commit' do
-      @analysed_module.committed_at.must_equal '2013-10-09 12:52:49 +0100'
+      _(@analysed_module.committed_at).must_equal '2013-10-09 12:52:49 +0100'
     end
   end
 end

--- a/test/lib/rubycritic/analysers/complexity_test.rb
+++ b/test/lib/rubycritic/analysers/complexity_test.rb
@@ -12,7 +12,7 @@ describe RubyCritic::Analyser::Complexity do
     end
 
     it 'calculates its complexity' do
-      @analysed_module.complexity.must_be :>, 0
+      _(@analysed_module.complexity).must_be :>, 0
     end
   end
 end

--- a/test/lib/rubycritic/analysers/helpers/methods_counter_test.rb
+++ b/test/lib/rubycritic/analysers/helpers/methods_counter_test.rb
@@ -8,14 +8,14 @@ describe RubyCritic::MethodsCounter do
     context 'when a file contains Ruby code' do
       it 'calculates the number of methods' do
         analysed_module = AnalysedModuleDouble.new(path: 'test/samples/methods_count.rb')
-        RubyCritic::MethodsCounter.new(analysed_module).count.must_equal 2
+        _(RubyCritic::MethodsCounter.new(analysed_module).count).must_equal 2
       end
     end
 
     context 'when a file is empty' do
       it 'returns 0 as the number of methods' do
         analysed_module = AnalysedModuleDouble.new(path: 'test/samples/empty.rb')
-        RubyCritic::MethodsCounter.new(analysed_module).count.must_equal 0
+        _(RubyCritic::MethodsCounter.new(analysed_module).count).must_equal 0
       end
     end
 
@@ -23,7 +23,7 @@ describe RubyCritic::MethodsCounter do
       it 'does not blow up and returns 0 as the number of methods' do
         analysed_module = AnalysedModuleDouble.new(path: 'test/samples/no_methods.rb')
         capture_output_streams do
-          RubyCritic::MethodsCounter.new(analysed_module).count.must_equal 0
+          _(RubyCritic::MethodsCounter.new(analysed_module).count).must_equal 0
         end
       end
     end

--- a/test/lib/rubycritic/analysers/helpers/modules_locator_test.rb
+++ b/test/lib/rubycritic/analysers/helpers/modules_locator_test.rb
@@ -13,8 +13,8 @@ describe RubyCritic::ModulesLocator do
           pathname: Pathname.new('test/samples/module_names.rb'),
           methods_count: 1
         )
-        RubyCritic::ModulesLocator.new(analysed_module).names
-                                  .must_equal ['Foo', 'Foo::Bar', 'Foo::Baz', 'Foo::Qux', 'Foo::Quux::Corge']
+        _(RubyCritic::ModulesLocator.new(analysed_module).names)
+          .must_equal ['Foo', 'Foo::Bar', 'Foo::Baz', 'Foo::Qux', 'Foo::Quux::Corge']
       end
     end
 
@@ -24,7 +24,7 @@ describe RubyCritic::ModulesLocator do
           pathname: Pathname.new('test/samples/empty.rb'),
           methods_count: 1
         )
-        RubyCritic::ModulesLocator.new(analysed_module).names.must_equal ['Empty']
+        _(RubyCritic::ModulesLocator.new(analysed_module).names).must_equal ['Empty']
       end
     end
 
@@ -35,7 +35,7 @@ describe RubyCritic::ModulesLocator do
           methods_count: 0
         )
         capture_output_streams do
-          RubyCritic::ModulesLocator.new(analysed_module).names.must_equal ['Foo::NoMethods']
+          _(RubyCritic::ModulesLocator.new(analysed_module).names).must_equal ['Foo::NoMethods']
         end
       end
     end

--- a/test/lib/rubycritic/analysers/smells/flay_test.rb
+++ b/test/lib/rubycritic/analysers/smells/flay_test.rb
@@ -16,26 +16,26 @@ describe RubyCritic::Analyser::FlaySmells do
     end
 
     it 'detects its smells' do
-      @analysed_modules.first.smells?.must_equal true
+      _(@analysed_modules.first.smells?).must_equal true
     end
 
     it 'creates smells with messages' do
       smell = @analysed_modules.first.smells.first
-      smell.message.must_be_instance_of String
+      _(smell.message).must_be_instance_of String
     end
 
     it 'creates smells with scores' do
       smell = @analysed_modules.first.smells.first
-      smell.score.must_be_kind_of Numeric
+      _(smell.score).must_be_kind_of Numeric
     end
 
     it 'creates smells with more than one location' do
       smell = @analysed_modules.first.smells.first
-      smell.multiple_locations?.must_equal true
+      _(smell.multiple_locations?).must_equal true
     end
 
     it 'calculates the mass of duplicate code' do
-      @analysed_modules.first.duplication.must_be(:>, 0)
+      _(@analysed_modules.first.duplication).must_be(:>, 0)
     end
   end
 end

--- a/test/lib/rubycritic/analysers/smells/flog_test.rb
+++ b/test/lib/rubycritic/analysers/smells/flog_test.rb
@@ -12,17 +12,17 @@ describe RubyCritic::Analyser::FlogSmells do
     end
 
     it 'detects its smells' do
-      @analysed_module.smells.length.must_equal 1
+      _(@analysed_module.smells.length).must_equal 1
     end
 
     it 'creates smells with messages' do
       smell = @analysed_module.smells.first
-      smell.message.must_be_instance_of String
+      _(smell.message).must_be_instance_of String
     end
 
     it 'creates smells with scores' do
       smell = @analysed_module.smells.first
-      smell.score.must_be :>, 0
+      _(smell.score).must_be :>, 0
     end
   end
 end

--- a/test/lib/rubycritic/analysers/smells/reek_test.rb
+++ b/test/lib/rubycritic/analysers/smells/reek_test.rb
@@ -13,20 +13,20 @@ describe RubyCritic::Analyser::ReekSmells do
     end
 
     it 'detects its smells' do
-      @analysed_module.smells.length.must_equal 2
+      _(@analysed_module.smells.length).must_equal 2
     end
 
     it 'respects the .reek file' do
       messages = @analysed_module.smells.map(&:message)
-      messages.wont_include "has the parameter name 'a'"
+      _(messages).wont_include "has the parameter name 'a'"
     end
 
     it 'creates smells with messages' do
       first_smell = @analysed_module.smells.first
-      first_smell.message.must_equal "has boolean parameter 'reek'"
+      _(first_smell.message).must_equal "has boolean parameter 'reek'"
 
       last_smell = @analysed_module.smells.last
-      last_smell.message.must_equal 'has no descriptive comment'
+      _(last_smell.message).must_equal 'has no descriptive comment'
     end
   end
 end

--- a/test/lib/rubycritic/analysis_summary_test.rb
+++ b/test/lib/rubycritic/analysis_summary_test.rb
@@ -19,11 +19,11 @@ module RubyCritic
 
     describe '.root' do
       it 'computes correct summary' do
-        @summary['A'].to_a.must_equal({ files: 3, churns: 9, smells: 6 }.to_a)
-        @summary['B'].to_a.must_equal({ files: 1, churns: 5, smells: 2 }.to_a)
-        @summary['C'].to_a.must_equal({ files: 0, churns: 0, smells: 0 }.to_a)
-        @summary['D'].to_a.must_equal({ files: 0, churns: 0, smells: 0 }.to_a)
-        @summary['F'].to_a.must_equal({ files: 0, churns: 0, smells: 0 }.to_a)
+        _(@summary['A'].to_a).must_equal({ files: 3, churns: 9, smells: 6 }.to_a)
+        _(@summary['B'].to_a).must_equal({ files: 1, churns: 5, smells: 2 }.to_a)
+        _(@summary['C'].to_a).must_equal({ files: 0, churns: 0, smells: 0 }.to_a)
+        _(@summary['D'].to_a).must_equal({ files: 0, churns: 0, smells: 0 }.to_a)
+        _(@summary['F'].to_a).must_equal({ files: 0, churns: 0, smells: 0 }.to_a)
       end
     end
   end

--- a/test/lib/rubycritic/browser_test.rb
+++ b/test/lib/rubycritic/browser_test.rb
@@ -12,7 +12,7 @@ describe RubyCritic::Browser do
   describe '#open' do
     it 'should be open report with launch browser' do
       Launchy.stubs(:open).returns(true)
-      @browser.open.must_equal true
+      _(@browser.open).must_equal true
     end
   end
 end

--- a/test/lib/rubycritic/commands/compare_test.rb
+++ b/test/lib/rubycritic/commands/compare_test.rb
@@ -54,9 +54,9 @@ describe RubyCritic::Command::Compare do
         comparison.expects(:abort).once
 
         status_reporter = comparison.execute
-        status_reporter.score.must_equal RubyCritic::Config.feature_branch_score
-        status_reporter.score.wont_equal RubyCritic::Config.base_branch_score
-        status_reporter.status_message.must_equal "Score: #{RubyCritic::Config.feature_branch_score}"
+        _(status_reporter.score).must_equal RubyCritic::Config.feature_branch_score
+        _(status_reporter.score).wont_equal RubyCritic::Config.base_branch_score
+        _(status_reporter.status_message).must_equal "Score: #{RubyCritic::Config.feature_branch_score}"
       end
     end
 
@@ -73,9 +73,9 @@ describe RubyCritic::Command::Compare do
         options = RubyCritic::Cli::Options.new(options).parse.to_h
         RubyCritic::Config.set(options)
         status_reporter = RubyCritic::Command::Compare.new(options).execute
-        status_reporter.score.must_equal RubyCritic::Config.feature_branch_score
-        status_reporter.score.must_equal RubyCritic::Config.base_branch_score
-        status_reporter.status_message.must_equal "Score: #{RubyCritic::Config.feature_branch_score}"
+        _(status_reporter.score).must_equal RubyCritic::Config.feature_branch_score
+        _(status_reporter.score).must_equal RubyCritic::Config.base_branch_score
+        _(status_reporter.status_message).must_equal "Score: #{RubyCritic::Config.feature_branch_score}"
       end
     end
   end
@@ -87,10 +87,10 @@ describe RubyCritic::Command::Compare do
     end
 
     it 'with -b option withour pull request id' do
-      @options[:base_branch].must_equal 'base_branch'
-      @options[:feature_branch].must_equal 'feature_branch'
-      @options[:mode].must_equal :compare_branches
-      @options[:threshold_score].must_equal 10
+      _(@options[:base_branch]).must_equal 'base_branch'
+      _(@options[:feature_branch]).must_equal 'feature_branch'
+      _(@options[:mode]).must_equal :compare_branches
+      _(@options[:threshold_score]).must_equal 10
     end
   end
 end

--- a/test/lib/rubycritic/commands/status_reporter_test.rb
+++ b/test/lib/rubycritic/commands/status_reporter_test.rb
@@ -16,20 +16,20 @@ describe RubyCritic::Command::StatusReporter do
     end
 
     it 'has a default' do
-      @reporter.status.must_equal success_status
-      @reporter.status_message.must_be_nil
+      _(@reporter.status).must_equal success_status
+      _(@reporter.status_message).must_be_nil
     end
 
     it 'accept a score' do
       @reporter.score = 50.0
-      @reporter.status.must_equal success_status
-      @reporter.status_message.must_equal 'Score: 50.0'
+      _(@reporter.status).must_equal success_status
+      _(@reporter.status_message).must_equal 'Score: 50.0'
     end
 
     it 'should format the score' do
       @reporter.score = 98.95258620689656
-      @reporter.status.must_equal success_status
-      @reporter.status_message.must_equal 'Score: 98.95'
+      _(@reporter.status).must_equal success_status
+      _(@reporter.status_message).must_equal 'Score: 98.95'
     end
   end
 
@@ -41,22 +41,22 @@ describe RubyCritic::Command::StatusReporter do
     end
 
     it 'has a default' do
-      @reporter.status.must_equal success_status
-      @reporter.status_message.must_be_nil
+      _(@reporter.status).must_equal success_status
+      _(@reporter.status_message).must_be_nil
     end
 
     describe 'when score is below minimum' do
       let(:score) { 98.0 }
       it 'should return the correct status' do
         @reporter.score = score
-        @reporter.status.must_equal score_below_minimum
-        @reporter.status_message.must_equal 'Score (98.0) is below the minimum 99.0'
+        _(@reporter.status).must_equal score_below_minimum
+        _(@reporter.status_message).must_equal 'Score (98.0) is below the minimum 99.0'
       end
 
       it 'should format the score' do
         @reporter.score = 98.95258620689656
-        @reporter.status.must_equal score_below_minimum
-        @reporter.status_message.must_equal 'Score (98.95) is below the minimum 99.0'
+        _(@reporter.status).must_equal score_below_minimum
+        _(@reporter.status_message).must_equal 'Score (98.95) is below the minimum 99.0'
       end
     end
 
@@ -64,8 +64,8 @@ describe RubyCritic::Command::StatusReporter do
       let(:score) { 99.0 }
       it 'should return the correct status' do
         @reporter.score = score
-        @reporter.status.must_equal success_status
-        @reporter.status_message.must_equal 'Score: 99.0'
+        _(@reporter.status).must_equal success_status
+        _(@reporter.status_message).must_equal 'Score: 99.0'
       end
     end
 
@@ -73,8 +73,8 @@ describe RubyCritic::Command::StatusReporter do
       let(:score) { 100.0 }
       it 'should return the correct status' do
         @reporter.score = score
-        @reporter.status.must_equal success_status
-        @reporter.status_message.must_equal 'Score: 100.0'
+        _(@reporter.status).must_equal success_status
+        _(@reporter.status_message).must_equal 'Score: 100.0'
       end
     end
   end

--- a/test/lib/rubycritic/configuration_test.rb
+++ b/test/lib/rubycritic/configuration_test.rb
@@ -11,17 +11,17 @@ describe RubyCritic::Configuration do
     end
 
     it 'has a default' do
-      RubyCritic::Config.root.must_be_instance_of String
+      _(RubyCritic::Config.root).must_be_instance_of String
     end
 
     it 'can be set to a relative path' do
       RubyCritic::Config.root = 'foo'
-      RubyCritic::Config.root.must_equal File.expand_path('foo')
+      _(RubyCritic::Config.root).must_equal File.expand_path('foo')
     end
 
     it 'can be set to an absolute path' do
       RubyCritic::Config.root = '/foo'
-      RubyCritic::Config.root.must_equal '/foo'
+      _(RubyCritic::Config.root).must_equal '/foo'
     end
 
     after do
@@ -35,7 +35,7 @@ describe RubyCritic::Configuration do
     end
 
     it 'sets html format by default' do
-      RubyCritic::Config.formats.must_equal [:html]
+      _(RubyCritic::Config.formats).must_equal [:html]
     end
   end
 end

--- a/test/lib/rubycritic/core/analysed_module_test.rb
+++ b/test/lib/rubycritic/core/analysed_module_test.rb
@@ -22,27 +22,27 @@ describe RubyCritic::AnalysedModule do
     end
 
     it 'has a name reader' do
-      @analysed_module.name.must_equal @name
+      _(@analysed_module.name).must_equal @name
     end
 
     it 'has a pathname reader' do
-      @analysed_module.pathname.must_equal @pathname
+      _(@analysed_module.pathname).must_equal @pathname
     end
 
     it 'has a path reader' do
-      @analysed_module.path.must_equal @pathname.to_s
+      _(@analysed_module.path).must_equal @pathname.to_s
     end
 
     it 'has a smells reader' do
-      @analysed_module.smells.must_equal @smells
+      _(@analysed_module.smells).must_equal @smells
     end
 
     it 'has a churn reader' do
-      @analysed_module.churn.must_equal @churn
+      _(@analysed_module.churn).must_equal @churn
     end
 
     it 'has a complexity reader' do
-      @analysed_module.complexity.must_equal @complexity
+      _(@analysed_module.complexity).must_equal @complexity
     end
   end
 
@@ -50,7 +50,7 @@ describe RubyCritic::AnalysedModule do
     it 'returns the remediation cost of fixing the analysed_module' do
       smells = [SmellDouble.new(cost: 1), SmellDouble.new(cost: 2)]
       analysed_module = RubyCritic::AnalysedModule.new(smells: smells, complexity: 0)
-      analysed_module.cost.must_equal 3
+      _(analysed_module.cost).must_equal 3
     end
   end
 
@@ -58,14 +58,14 @@ describe RubyCritic::AnalysedModule do
     context 'when the file has no methods' do
       it 'returns a placeholder' do
         analysed_module = RubyCritic::AnalysedModule.new(complexity: 0, methods_count: 0)
-        analysed_module.complexity_per_method.must_equal 'N/A'
+        _(analysed_module.complexity_per_method).must_equal 'N/A'
       end
     end
 
     context 'when the file has at least one method' do
       it 'returns the average complexity per method' do
         analysed_module = RubyCritic::AnalysedModule.new(complexity: 10, methods_count: 2)
-        analysed_module.complexity_per_method.must_equal 5
+        _(analysed_module.complexity_per_method).must_equal 5
       end
     end
   end
@@ -73,7 +73,7 @@ describe RubyCritic::AnalysedModule do
   describe '#smells?' do
     it 'returns true if the analysed_module has at least one smell' do
       analysed_module = RubyCritic::AnalysedModule.new(smells: [SmellDouble.new])
-      analysed_module.smells?.must_equal true
+      _(analysed_module.smells?).must_equal true
     end
   end
 
@@ -82,7 +82,7 @@ describe RubyCritic::AnalysedModule do
       location = RubyCritic::Location.new('./foo', '42')
       smells = [RubyCritic::Smell.new(locations: [location])]
       analysed_module = RubyCritic::AnalysedModule.new(smells: smells)
-      analysed_module.smells_at_location(location).must_equal smells
+      _(analysed_module.smells_at_location(location)).must_equal smells
     end
   end
 end

--- a/test/lib/rubycritic/core/analysed_modules_collection_test.rb
+++ b/test/lib/rubycritic/core/analysed_modules_collection_test.rb
@@ -11,7 +11,7 @@ describe RubyCritic::AnalysedModulesCollection do
       let(:paths) { '' }
 
       it 'returns an empty collection' do
-        subject.count.must_equal 0
+        _(subject.count).must_equal 0
       end
     end
 
@@ -19,8 +19,8 @@ describe RubyCritic::AnalysedModulesCollection do
       let(:paths) { %w[test/samples/doesnt_exist.rb test/samples/no_methods.rb test/samples/empty.rb] }
 
       it 'registers one AnalysedModule element per existent file' do
-        subject.count.must_equal 2
-        subject.all? { |a| a.is_a?(RubyCritic::AnalysedModule) }.must_equal true
+        _(subject.count).must_equal 2
+        _(subject.all? { |a| a.is_a?(RubyCritic::AnalysedModule) }).must_equal true
       end
     end
 
@@ -28,7 +28,7 @@ describe RubyCritic::AnalysedModulesCollection do
       let(:paths) { 'test/samples/' }
 
       it 'recursively registers all files' do
-        subject.count.must_equal Dir['test/samples/**/*.rb'].count
+        _(subject.count).must_equal Dir['test/samples/**/*.rb'].count
       end
     end
 
@@ -36,7 +36,7 @@ describe RubyCritic::AnalysedModulesCollection do
       let(:paths) { %w[test/samples/flog test/samples/flog/complex.rb] }
 
       it 'returns a redundant collection' do
-        subject.count.must_equal 3
+        _(subject.count).must_equal 3
       end
     end
 
@@ -50,13 +50,13 @@ describe RubyCritic::AnalysedModulesCollection do
 
       it 'registers one AnalysedModule element per existent file' do
         analysed_modules_collection = RubyCritic::AnalysedModulesCollection.new(paths, analysed_modules)
-        analysed_modules_collection.count.must_equal 1
+        _(analysed_modules_collection.count).must_equal 1
         analysed_module = analysed_modules_collection.first
-        analysed_module.name.must_equal 'Name'
-        analysed_module.churn.must_equal 2
-        analysed_module.complexity.must_equal 2
-        analysed_module.duplication.must_equal 0
-        analysed_module.methods_count.must_equal 2
+        _(analysed_module.name).must_equal 'Name'
+        _(analysed_module.churn).must_equal 2
+        _(analysed_module.complexity).must_equal 2
+        _(analysed_module.duplication).must_equal 0
+        _(analysed_module.methods_count).must_equal 2
       end
     end
   end
@@ -72,9 +72,9 @@ describe RubyCritic::AnalysedModulesCollection do
       end
 
       it 'registers one AnalysedModule element per existent file' do
-        subject.count.must_equal 2
-        subject.where(['test/samples/empty.rb']).count.must_equal 1
-        subject.where(['test/samples/no_methods.rb']).count.must_equal 1
+        _(subject.count).must_equal 2
+        _(subject.where(['test/samples/empty.rb']).count).must_equal 1
+        _(subject.where(['test/samples/no_methods.rb']).count).must_equal 1
       end
     end
   end
@@ -84,7 +84,7 @@ describe RubyCritic::AnalysedModulesCollection do
       let(:paths) { '' }
 
       it 'returns zero' do
-        subject.score.must_equal 0.0
+        _(subject.score).must_equal 0.0
       end
     end
 
@@ -92,7 +92,7 @@ describe RubyCritic::AnalysedModulesCollection do
       let(:paths) { 'test/samples/flog' }
 
       it 'returns zero' do
-        subject.score.must_equal 0.0
+        _(subject.score).must_equal 0.0
       end
     end
 
@@ -109,7 +109,7 @@ describe RubyCritic::AnalysedModulesCollection do
         let(:costs) { [0.0, 0.0, 0.0, 0.0] }
 
         it 'returns the maximum score' do
-          subject.score.must_equal 100.0
+          _(subject.score).must_equal 100.0
         end
       end
 
@@ -117,7 +117,7 @@ describe RubyCritic::AnalysedModulesCollection do
         let(:costs) { [16.0, 16.0, 16.0, 16.0] }
 
         it 'returns zero' do
-          subject.score.must_equal 0.0
+          _(subject.score).must_equal 0.0
         end
       end
 
@@ -125,7 +125,7 @@ describe RubyCritic::AnalysedModulesCollection do
         let(:costs) { [32.0, 32.0, 32.0, 32.0] }
 
         it 'returns zero' do
-          subject.score.must_equal 0.0
+          _(subject.score).must_equal 0.0
         end
       end
 
@@ -133,7 +133,7 @@ describe RubyCritic::AnalysedModulesCollection do
         let(:costs) { [32.0, 2.0, 0.0, 2.0] }
 
         it 'properly calculates the score' do
-          subject.score.must_equal 43.75
+          _(subject.score).must_equal 43.75
         end
       end
 
@@ -141,7 +141,7 @@ describe RubyCritic::AnalysedModulesCollection do
         let(:costs) { [220.0, 2.0, 0.0, 2.0] }
 
         it 'reduces the impact in the result' do
-          subject.score.must_equal 43.75
+          _(subject.score).must_equal 43.75
         end
       end
     end

--- a/test/lib/rubycritic/core/location_test.rb
+++ b/test/lib/rubycritic/core/location_test.rb
@@ -12,28 +12,28 @@ describe RubyCritic::Location do
     end
 
     it 'has a pathname' do
-      @location.pathname.must_equal Pathname.new(@path)
+      _(@location.pathname).must_equal Pathname.new(@path)
     end
 
     it 'has a line number' do
-      @location.line.must_equal @line.to_i
+      _(@location.line).must_equal @line.to_i
     end
 
     it 'has a file name' do
-      @location.file_name.must_equal 'foo'
+      _(@location.file_name).must_equal 'foo'
     end
   end
 
   it 'is comparable' do
     location1 = RubyCritic::Location.new('./foo', 42)
     location2 = RubyCritic::Location.new('./foo', 42)
-    location1.must_equal location2
+    _(location1).must_equal location2
   end
 
   it 'is sortable' do
     location1 = RubyCritic::Location.new('./foo', 42)
     location2 = RubyCritic::Location.new('./bar', 23)
     location3 = RubyCritic::Location.new('./bar', 16)
-    [location1, location2, location3].sort.must_equal [location3, location2, location1]
+    _([location1, location2, location3].sort).must_equal [location3, location2, location1]
   end
 end

--- a/test/lib/rubycritic/core/smell_test.rb
+++ b/test/lib/rubycritic/core/smell_test.rb
@@ -21,23 +21,23 @@ describe RubyCritic::Smell do
     end
 
     it 'has a context reader' do
-      @smell.context.must_equal @context
+      _(@smell.context).must_equal @context
     end
 
     it 'has a locations reader' do
-      @smell.locations.must_equal @locations
+      _(@smell.locations).must_equal @locations
     end
 
     it 'has a message reader' do
-      @smell.message.must_equal @message
+      _(@smell.message).must_equal @message
     end
 
     it 'has a score reader' do
-      @smell.score.must_equal @score
+      _(@smell.score).must_equal @score
     end
 
     it 'has a type reader' do
-      @smell.type.must_equal @type
+      _(@smell.type).must_equal @type
     end
   end
 
@@ -45,7 +45,7 @@ describe RubyCritic::Smell do
     it 'returns true if the smell has a location that matches the location passed as argument' do
       location = RubyCritic::Location.new('./foo', '42')
       smell = RubyCritic::Smell.new(locations: [location])
-      smell.at_location?(location).must_equal true
+      _(smell.at_location?(location)).must_equal true
     end
   end
 
@@ -54,7 +54,7 @@ describe RubyCritic::Smell do
       location1 = RubyCritic::Location.new('./foo', '42')
       location2 = RubyCritic::Location.new('./foo', '23')
       smell = RubyCritic::Smell.new(locations: [location1, location2])
-      smell.multiple_locations?.must_equal true
+      _(smell.multiple_locations?).must_equal true
     end
   end
 
@@ -68,7 +68,7 @@ describe RubyCritic::Smell do
       }
       smell1 = RubyCritic::Smell.new(attributes)
       smell2 = RubyCritic::Smell.new(attributes)
-      smell1.must_equal smell2
+      _(smell1).must_equal smell2
     end
   end
 
@@ -76,25 +76,25 @@ describe RubyCritic::Smell do
     it 'handles one word type names for reek smells' do
       smell = RubyCritic::Smell.new(type: 'Complexity', analyser: 'reek')
 
-      smell.doc_url.must_equal('https://github.com/troessner/reek/blob/master/docs/Complexity.md')
+      _(smell.doc_url).must_equal('https://github.com/troessner/reek/blob/master/docs/Complexity.md')
     end
 
     it 'handles multiple word type names for reek smells' do
       smell = RubyCritic::Smell.new(type: 'TooManyStatements', analyser: 'reek')
 
-      smell.doc_url.must_equal('https://github.com/troessner/reek/blob/master/docs/Too-Many-Statements.md')
+      _(smell.doc_url).must_equal('https://github.com/troessner/reek/blob/master/docs/Too-Many-Statements.md')
     end
 
     it 'handles flay smells' do
       smell = RubyCritic::Smell.new(type: 'DuplicateCode', analyser: 'flay')
 
-      smell.doc_url.must_equal('http://docs.seattlerb.org/flay/')
+      _(smell.doc_url).must_equal('http://docs.seattlerb.org/flay/')
     end
 
     it 'handles flog smells' do
       smell = RubyCritic::Smell.new(type: 'VeryHighComplexity', analyser: 'flog')
 
-      smell.doc_url.must_equal('http://docs.seattlerb.org/flog/')
+      _(smell.doc_url).must_equal('http://docs.seattlerb.org/flog/')
     end
 
     it 'raises an error for unknown analysers' do

--- a/test/lib/rubycritic/core/smells_array_test.rb
+++ b/test/lib/rubycritic/core/smells_array_test.rb
@@ -11,20 +11,20 @@ describe 'Array of Smells' do
     smell1 = RubyCritic::Smell.new(locations: [location1])
     smell2 = RubyCritic::Smell.new(locations: [location2])
     smell3 = RubyCritic::Smell.new(locations: [location3])
-    [smell1, smell2, smell3].sort.must_equal [smell3, smell2, smell1]
+    _([smell1, smell2, smell3].sort).must_equal [smell3, smell2, smell1]
   end
 
   it 'implements set intersection' do
     smell1 = RubyCritic::Smell.new(context: '#bar')
     smell2 = RubyCritic::Smell.new(context: '#bar')
     smell3 = RubyCritic::Smell.new(context: '#foo')
-    ([smell1, smell3] & [smell2]).must_equal [smell1]
+    _([smell1, smell3] & [smell2]).must_equal [smell1]
   end
 
   it 'implements set union' do
     smell1 = RubyCritic::Smell.new(context: '#bar')
     smell2 = RubyCritic::Smell.new(context: '#bar')
     smell3 = RubyCritic::Smell.new(context: '#foo')
-    ([smell1, smell3] | [smell2]).must_equal [smell1, smell3]
+    _([smell1, smell3] | [smell2]).must_equal [smell1, smell3]
   end
 end

--- a/test/lib/rubycritic/generators/turbulence_test.rb
+++ b/test/lib/rubycritic/generators/turbulence_test.rb
@@ -9,9 +9,9 @@ describe RubyCritic::Turbulence do
       files = [AnalysedModuleDouble.new(name: 'Foo', churn: 1, complexity: 2)]
       turbulence_data = RubyCritic::Turbulence.data(files)
       instance_parsed_json = JSON.parse(turbulence_data).first
-      instance_parsed_json['name'].must_equal 'Foo'
-      instance_parsed_json['x'].must_equal 1
-      instance_parsed_json['y'].must_equal 2
+      _(instance_parsed_json['name']).must_equal 'Foo'
+      _(instance_parsed_json['x']).must_equal 1
+      _(instance_parsed_json['y']).must_equal 2
     end
   end
 end

--- a/test/lib/rubycritic/generators/view_helpers_test.rb
+++ b/test/lib/rubycritic/generators/view_helpers_test.rb
@@ -11,21 +11,21 @@ describe RubyCritic::ViewHelpers do
     describe '#file_path' do
       context 'when the other file is in the same directory' do
         it 'creates a relative path to a file' do
-          generator.file_path('bar.html').to_s.must_equal 'bar.html'
+          _(generator.file_path('bar.html').to_s).must_equal 'bar.html'
         end
       end
 
       context 'when the other file is in a subdirectory' do
         it 'creates a relative path to a file' do
-          generator.file_path('subdirectory/bar.html').to_s.must_equal 'subdirectory/bar.html'
+          _(generator.file_path('subdirectory/bar.html').to_s).must_equal 'subdirectory/bar.html'
         end
       end
     end
 
     describe '#asset_path' do
       it 'creates a relative path to an asset' do
-        generator.asset_path('stylesheets/application.css').to_s
-                 .must_equal 'assets/stylesheets/application.css'
+        _(generator.asset_path('stylesheets/application.css').to_s)
+          .must_equal 'assets/stylesheets/application.css'
       end
     end
   end
@@ -36,33 +36,33 @@ describe RubyCritic::ViewHelpers do
     describe '#file_path' do
       context 'when the other file is in the same directory' do
         it 'creates a relative path to a file' do
-          generator.file_path('lets/go/crazy/bar.html').to_s.must_equal 'bar.html'
+          _(generator.file_path('lets/go/crazy/bar.html').to_s).must_equal 'bar.html'
         end
       end
 
       context 'when the other file is in the root directory' do
         it 'creates a relative path to a file' do
-          generator.file_path('bar.html').to_s.must_equal '../../../bar.html'
+          _(generator.file_path('bar.html').to_s).must_equal '../../../bar.html'
         end
       end
 
       context 'when the other file has n-1 directories in common' do
         it 'creates a relative path to a file' do
-          generator.file_path('lets/go/home/bar.html').to_s.must_equal '../home/bar.html'
+          _(generator.file_path('lets/go/home/bar.html').to_s).must_equal '../home/bar.html'
         end
       end
 
       context 'when the other file is one directory deeper' do
         it 'creates a relative path to a file' do
-          generator.file_path('lets/go/crazy/everybody/bar.html').to_s.must_equal 'everybody/bar.html'
+          _(generator.file_path('lets/go/crazy/everybody/bar.html').to_s).must_equal 'everybody/bar.html'
         end
       end
     end
 
     describe '#asset_path' do
       it 'creates a relative path to an asset' do
-        generator.asset_path('stylesheets/application.css').to_s
-                 .must_equal '../../../assets/stylesheets/application.css'
+        _(generator.asset_path('stylesheets/application.css').to_s)
+          .must_equal '../../../assets/stylesheets/application.css'
       end
     end
   end

--- a/test/lib/rubycritic/smells_status_setter_test.rb
+++ b/test/lib/rubycritic/smells_status_setter_test.rb
@@ -13,12 +13,12 @@ describe RubyCritic::SmellsStatusSetter do
 
     it 'marks old smells' do
       RubyCritic::SmellsStatusSetter.set(@smells, @smells)
-      @smell.status.must_equal :old
+      _(@smell.status).must_equal :old
     end
 
     it 'marks new smells' do
       RubyCritic::SmellsStatusSetter.set([], @smells)
-      @smell.status.must_equal :new
+      _(@smell.status).must_equal :new
     end
   end
 end

--- a/test/lib/rubycritic/source_control_systems/base_test.rb
+++ b/test/lib/rubycritic/source_control_systems/base_test.rb
@@ -15,7 +15,7 @@ describe RubyCritic::SourceControlSystem::Base do
       it 'creates an instance of that source control system' do
         RubyCritic::SourceControlSystem::Git.stubs(:supported?).returns(true)
         system = RubyCritic::SourceControlSystem::Base.create
-        system.must_be_instance_of RubyCritic::SourceControlSystem::Git
+        _(system).must_be_instance_of RubyCritic::SourceControlSystem::Git
       end
     end
 
@@ -23,7 +23,7 @@ describe RubyCritic::SourceControlSystem::Base do
       it 'creates a source control system double' do
         capture_output_streams do
           system = RubyCritic::SourceControlSystem::Base.create
-          system.must_be_instance_of RubyCritic::SourceControlSystem::Double
+          _(system).must_be_instance_of RubyCritic::SourceControlSystem::Double
         end
       end
     end

--- a/test/lib/rubycritic/source_control_systems/perforce_test.rb
+++ b/test/lib/rubycritic/source_control_systems/perforce_test.rb
@@ -24,7 +24,7 @@ describe RubyCritic::SourceControlSystem::Perforce do
           File.stubs(:executable?).with('/perforce/path/p4/p4').returns(true)
           RubyCritic::SourceControlSystem::Perforce.stubs(:in_client_directory?).returns(true)
 
-          RubyCritic::SourceControlSystem::Perforce.supported?.must_equal true
+          _(RubyCritic::SourceControlSystem::Perforce.supported?).must_equal true
         end
       end
 
@@ -37,7 +37,7 @@ describe RubyCritic::SourceControlSystem::Perforce do
           File.stubs(:executable?).with('/perforce/path/p4/p4').returns(false)
           File.stubs(:executable?).with('/other/useless_path/p4').returns(false)
 
-          RubyCritic::SourceControlSystem::Perforce.supported?.must_equal false
+          _(RubyCritic::SourceControlSystem::Perforce.supported?).must_equal false
         end
 
         it 'returns false if no p4 client is set in environment variables' do
@@ -47,7 +47,7 @@ describe RubyCritic::SourceControlSystem::Perforce do
           File.stubs(:executable?).with('/some/path/p4').returns(false)
           File.stubs(:executable?).with('/perforce/path/p4/p4').returns(true)
 
-          RubyCritic::SourceControlSystem::Perforce.supported?.must_equal false
+          _(RubyCritic::SourceControlSystem::Perforce.supported?).must_equal false
         end
 
         it 'returns false if the current directory is not under p4 client' do
@@ -58,7 +58,7 @@ describe RubyCritic::SourceControlSystem::Perforce do
           File.stubs(:executable?).with('/perforce/path/p4/p4').returns(true)
           RubyCritic::SourceControlSystem::Perforce.stubs(:in_client_directory?).returns(false)
 
-          RubyCritic::SourceControlSystem::Perforce.supported?.must_equal false
+          _(RubyCritic::SourceControlSystem::Perforce.supported?).must_equal false
         end
       end
     end
@@ -80,7 +80,7 @@ describe RubyCritic::SourceControlSystem::Perforce do
 
         it 'calls p4 info and parse the result' do
           RubyCritic::SourceControlSystem::Perforce.stubs(:`).with('p4 info').returns(p4_info)
-          RubyCritic::SourceControlSystem::Perforce.in_client_directory?.must_equal true
+          _(RubyCritic::SourceControlSystem::Perforce.in_client_directory?).must_equal true
         end
       end
 
@@ -100,7 +100,7 @@ describe RubyCritic::SourceControlSystem::Perforce do
 
         it 'calls p4 info and parse the result' do
           RubyCritic::SourceControlSystem::Perforce.stubs(:`).with('p4 info').returns(p4_info)
-          RubyCritic::SourceControlSystem::Perforce.in_client_directory?.must_equal false
+          _(RubyCritic::SourceControlSystem::Perforce.in_client_directory?).must_equal false
         end
       end
     end
@@ -125,29 +125,29 @@ describe RubyCritic::SourceControlSystem::Perforce do
         it 'builds the perforce file cache' do
           RubyCritic::SourceControlSystem::Perforce.stubs(:`).returns(p4_stats)
           file_cache = @system.send(:perforce_files)
-          file_cache.size.must_equal 2
+          _(file_cache.size).must_equal 2
 
           first_file = file_cache['/path/to/client/a_ruby_file.rb']
-          first_file.filename.must_equal '/path/to/client/a_ruby_file.rb'
-          first_file.revision.must_equal '16'
-          first_file.last_commit.must_equal '1473075551'
-          first_file.head.must_equal '2103503'
-          first_file.opened?.must_equal false
+          _(first_file.filename).must_equal '/path/to/client/a_ruby_file.rb'
+          _(first_file.revision).must_equal '16'
+          _(first_file.last_commit).must_equal '1473075551'
+          _(first_file.head).must_equal '2103503'
+          _(first_file.opened?).must_equal false
 
           second_file = file_cache['/path/to/client/second_ruby_file.rb']
-          second_file.filename.must_equal '/path/to/client/second_ruby_file.rb'
-          second_file.revision.must_equal '12'
-          second_file.last_commit.must_equal '1464601668'
-          second_file.head.must_equal '2103504'
-          second_file.opened?.must_equal true
+          _(second_file.filename).must_equal '/path/to/client/second_ruby_file.rb'
+          _(second_file.revision).must_equal '12'
+          _(second_file.last_commit).must_equal '1464601668'
+          _(second_file.head).must_equal '2103504'
+          _(second_file.opened?).must_equal true
         end
       end
 
       it 'retrieves the number revisions of the ruby files' do
         Dir.stubs(:getwd).returns('/path/to/client')
         RubyCritic::SourceControlSystem::Perforce.stubs(:`).once.returns(p4_stats)
-        @system.revisions_count('a_ruby_file.rb').must_equal 16
-        @system.revisions_count('second_ruby_file.rb').must_equal 12
+        _(@system.revisions_count('a_ruby_file.rb')).must_equal 16
+        _(@system.revisions_count('second_ruby_file.rb')).must_equal 12
       end
 
       it 'retrieves the date of the last commit of the ruby files' do
@@ -155,21 +155,21 @@ describe RubyCritic::SourceControlSystem::Perforce do
         ENV['TZ'] = 'utc'
         Dir.stubs(:getwd).returns('/path/to/client')
         RubyCritic::SourceControlSystem::Perforce.stubs(:`).once.returns(p4_stats)
-        @system.date_of_last_commit('a_ruby_file.rb').must_equal '2016-09-05 11:39:11 +0000'
-        @system.date_of_last_commit('second_ruby_file.rb').must_equal '2016-05-30 09:47:48 +0000'
+        _(@system.date_of_last_commit('a_ruby_file.rb')).must_equal '2016-09-05 11:39:11 +0000'
+        _(@system.date_of_last_commit('second_ruby_file.rb')).must_equal '2016-05-30 09:47:48 +0000'
         ENV['TZ'] = oldtz
       end
 
       it 'retrieves the information if the ruby file is opened (in the changelist and ready to commit)' do
         Dir.stubs(:getwd).returns('/path/to/client')
         RubyCritic::SourceControlSystem::Perforce.stubs(:`).once.returns(p4_stats)
-        @system.revision?.must_equal true
+        _(@system.revision?).must_equal true
       end
 
       it 'retrieves the head reference of the repository' do
         Dir.stubs(:getwd).returns('/path/to/client')
         RubyCritic::SourceControlSystem::Perforce.stubs(:`).once.returns(p4_stats)
-        @system.head_reference.must_equal '2103504'
+        _(@system.head_reference).must_equal '2103504'
       end
     end
   end

--- a/test/lib/rubycritic/source_locator_test.rb
+++ b/test/lib/rubycritic/source_locator_test.rb
@@ -12,24 +12,24 @@ describe RubyCritic::SourceLocator do
   describe '#paths' do
     it 'finds a single file' do
       paths = ['file0.rb']
-      RubyCritic::SourceLocator.new(paths).paths.must_equal paths
+      _(RubyCritic::SourceLocator.new(paths).paths).must_equal paths
     end
 
     it 'finds all the files inside a given directory' do
       initial_paths = ['dir1']
       final_paths = ['dir1/file1.rb']
-      RubyCritic::SourceLocator.new(initial_paths).paths.must_equal final_paths
+      _(RubyCritic::SourceLocator.new(initial_paths).paths).must_equal final_paths
     end
 
     it 'finds files through multiple paths' do
       paths = ['dir1/file1.rb', 'file0.rb']
-      RubyCritic::SourceLocator.new(paths).paths.must_match_array paths
+      _(RubyCritic::SourceLocator.new(paths).paths).must_match_array paths
     end
 
     it 'finds all the files' do
       initial_paths = ['.']
       final_paths = ['dir1/file1.rb', 'file0.rb', 'file0_symlink.rb']
-      RubyCritic::SourceLocator.new(initial_paths).paths.must_match_array final_paths
+      _(RubyCritic::SourceLocator.new(initial_paths).paths).must_match_array final_paths
     end
 
     context 'when configured to deduplicate symlinks' do
@@ -37,32 +37,32 @@ describe RubyCritic::SourceLocator do
         RubyCritic::Config.stubs(:deduplicate_symlinks).returns(true)
         initial_paths = ['file0.rb', 'file0_symlink.rb']
         final_paths = ['file0.rb']
-        RubyCritic::SourceLocator.new(initial_paths).paths.must_match_array final_paths
+        _(RubyCritic::SourceLocator.new(initial_paths).paths).must_match_array final_paths
       end
     end
 
     it 'cleans paths of consecutive slashes and useless dots' do
       initial_paths = ['.//file0.rb']
       final_paths = ['file0.rb']
-      RubyCritic::SourceLocator.new(initial_paths).paths.must_equal final_paths
+      _(RubyCritic::SourceLocator.new(initial_paths).paths).must_equal final_paths
     end
 
     it 'ignores paths to non-existent files' do
       initial_paths = ['non_existent_dir1/non_existent_file1.rb', 'non_existent_file0.rb']
       final_paths = []
-      RubyCritic::SourceLocator.new(initial_paths).paths.must_equal final_paths
+      _(RubyCritic::SourceLocator.new(initial_paths).paths).must_equal final_paths
     end
 
     it 'ignores paths to files that do not match the Ruby extension' do
       initial_paths = ['file_with_no_extension', 'file_with_different_extension.py']
       final_paths = []
-      RubyCritic::SourceLocator.new(initial_paths).paths.must_equal final_paths
+      _(RubyCritic::SourceLocator.new(initial_paths).paths).must_equal final_paths
     end
 
     it 'can deal with nil paths' do
       paths = nil
       final_paths = []
-      RubyCritic::SourceLocator.new(paths).paths.must_equal final_paths
+      _(RubyCritic::SourceLocator.new(paths).paths).must_equal final_paths
     end
   end
 
@@ -70,7 +70,7 @@ describe RubyCritic::SourceLocator do
     it 'finds a single file' do
       initial_paths = ['file0.rb']
       final_pathnames = [Pathname.new('file0.rb')]
-      RubyCritic::SourceLocator.new(initial_paths).pathnames.must_equal final_pathnames
+      _(RubyCritic::SourceLocator.new(initial_paths).pathnames).must_equal final_pathnames
     end
   end
 

--- a/test/lib/rubycritic/version_test.rb
+++ b/test/lib/rubycritic/version_test.rb
@@ -5,6 +5,6 @@ require 'rubycritic/version'
 
 describe 'RubyCritic version' do
   it 'is defined' do
-    RubyCritic::VERSION.wont_be_nil
+    _(RubyCritic::VERSION).wont_be_nil
   end
 end


### PR DESCRIPTION
Fixes #323

Minitest 6 will deprecate global expectations, so the most recent versions are already warning us about these.

This PR changes the existing expectations on the project to local (`_()` syntax).

