### PR TITLE
Expand Churn vs. Complexity chart to full-width on small screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # master [(unreleased)](https://github.com/whitesmith/rubycritic/compare/v4.2.1...master)
 
 * [BUGFIX] Fix deprecation warnings related to Minitest 6 (by [@jsantos][])
+* [BUGFIX] Expand Churn vs. Complexity chart to full-width on small screen (by [@teohm][])
 
 # v4.2.1 / 2019-10-29 [(commits)](https://github.com/whitesmith/rubycritic/compare/v4.2.0...v4.2.1)
 

--- a/lib/rubycritic/generators/html/templates/overview.html.erb
+++ b/lib/rubycritic/generators/html/templates/overview.html.erb
@@ -18,7 +18,7 @@
         <!--End Grade Wrapper-->
 
         <!--Churn vs Complexity graph-->
-        <div class="col-xs-7 col-sm-7 col-md-6 col-lg-8">
+        <div class="col-xs-12 col-sm-7 col-md-6 col-lg-8">
           <div class="Graph_Cards fadeIn">
             <% if Config.source_control_present? %>
               <div id="churn-vs-complexity-graph-container" class="chart-container"></div>


### PR DESCRIPTION
Check list:
- [x] Add an entry to the [changelog](/CHANGELOG.md)
- [x] [Squash all commits into a single one](/CONTRIBUTING.md)
- [x] Describe your PR, link issues, etc.

Churn vs. Complexity chart on Overview page does not expand to full width on small screen (xs breakpoint in Bootstrap CSS):

<img width="687" alt="Screenshot 2019-11-05 at 3 55 36 PM" src="https://user-images.githubusercontent.com/164703/68189163-cd643180-ffe5-11e9-99d9-fbc23b826d12.png">

-------

This small patch fix the styling so that the chart expands to full width on small screen:

<img width="691" alt="Screenshot 2019-11-05 at 3 55 21 PM" src="https://user-images.githubusercontent.com/164703/68189222-e240c500-ffe5-11e9-9652-39bf139d1dfe.png">

Update: As requested by @etagwerker, a screenshot of big screen with no visual changes as expected:

<img width="1351" alt="Screenshot 2019-11-09 at 4 41 32 AM" src="https://user-images.githubusercontent.com/164703/68509190-552e9200-02ab-11ea-8a67-0072fce846af.png">
