### PR TITLE
Fixes/compare coverage type error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # master [(unreleased)](https://github.com/whitesmith/rubycritic/compare/v4.2.2...master)
 
+* [BUGFIX] Fixes TypeError when `.resultset.json` is not found (by [@etagwerker][])
+
 # v4.2.2 / 2019-11-12 [(commits)](https://github.com/whitesmith/rubycritic/compare/v4.2.1...v4.2.2)
 
 * [BUGFIX] Fix deprecation warnings related to Minitest 6 (by [@jsantos][])

--- a/lib/rubycritic/core/analysed_module.rb
+++ b/lib/rubycritic/core/analysed_module.rb
@@ -10,7 +10,7 @@ module RubyCritic
     # Complexity is reduced by a factor of 25 when calculating cost
     COMPLEXITY_FACTOR = 25.0
 
-    attribute :coverage
+    attribute :coverage, Float, default: 0.0
     attribute :name
     attribute :smells_count
     attribute :file_location


### PR DESCRIPTION
Hey @Onumis, 

This PR makes sure that `coverage` has the right default.

When `coverage` is not defined because SimpleCov's `.resultset.json`, this makes sure that the default value is 0.0 (not `nil`)

Fixes #332

Check list:
- [x] Add an entry to the [changelog](/CHANGELOG.md)
- [x] [Squash all commits into a single one](/CONTRIBUTING.md)
- [x] Describe your PR, link issues, etc.
