### PR TITLE
Remove gem update and bundler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ sudo: false
 language: ruby
 cache:
   bundler: true
+before_install:
+  - gem update --system --force
+  - gem install bundler
 matrix:
   include:
     - rvm: 2.3.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ sudo: false
 language: ruby
 cache:
   bundler: true
-before_install:
-  - gem update --system
-  - gem install bundler
 matrix:
   include:
     - rvm: 2.3.0


### PR DESCRIPTION
Bundler now comes vendored in rubygems:
https://github.com/rubygems/rubygems/releases/tag/v3.1.0

