### PR TITLE
Fix `switch_branch': undefined method `blank?' for "":String (NoMethodError)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # master [(unreleased)](https://github.com/whitesmith/rubycritic/compare/v4.3.0...master)
 
+* [BUGFIX] Fixes NoMethodError on RubyCritic::SourceControlSystem::Git.switch_branch (by [@eitoball][])
+
 # v4.3.0 / 2019-23-26 [(commits)](https://github.com/whitesmith/rubycritic/compare/v4.2.2...v4.3.0)
 
 * [FEATURE] Show which files are uncommited in git (by [@GeoffTidey][])

--- a/lib/rubycritic/source_control_systems/git.rb
+++ b/lib/rubycritic/source_control_systems/git.rb
@@ -52,7 +52,7 @@ module RubyCritic
       end
 
       def self.switch_branch(branch)
-        dirty = !uncommitted_changes.blank?
+        dirty = !uncommitted_changes.empty?
         abort("Uncommitted changes are present: #{uncommitted_changes}") if dirty
 
         git("checkout #{branch}")

--- a/test/lib/rubycritic/commands/compare_test.rb
+++ b/test/lib/rubycritic/commands/compare_test.rb
@@ -37,45 +37,40 @@ describe RubyCritic::Command::Compare do
     end
 
     context 'when file from feature_branch has a worse score than base_branch' do
-      before do
-        RubyCritic::SourceControlSystem::Git.class_eval do
-          def self.switch_branch(branch)
-            FileUtils.cp "test/samples/#{branch}_file.rb", 'test/samples/compare_file.rb'
-          end
-        end
-      end
-
       it 'errors by aborting the process' do
         options = ['-b', 'base_branch', '-t', '0', 'test/samples/compare_file.rb']
         options = RubyCritic::Cli::Options.new(options).parse.to_h
         RubyCritic::Config.set(options)
 
-        comparison = RubyCritic::Command::Compare.new(options)
-        comparison.expects(:abort).once
+        copy_proc = proc do |branch|
+          FileUtils.cp "test/samples/#{branch}_file.rb", 'test/samples/compare_file.rb'
+        end
+        RubyCritic::SourceControlSystem::Git.stub(:switch_branch, copy_proc) do
+          comparison = RubyCritic::Command::Compare.new(options)
+          comparison.expects(:abort).once
 
-        status_reporter = comparison.execute
-        _(status_reporter.score).must_equal RubyCritic::Config.feature_branch_score
-        _(status_reporter.score).wont_equal RubyCritic::Config.base_branch_score
-        _(status_reporter.status_message).must_equal "Score: #{RubyCritic::Config.feature_branch_score}"
+          status_reporter = comparison.execute
+          _(status_reporter.score).must_equal RubyCritic::Config.feature_branch_score
+          _(status_reporter.score).wont_equal RubyCritic::Config.base_branch_score
+          _(status_reporter.status_message).must_equal "Score: #{RubyCritic::Config.feature_branch_score}"
+        end
       end
     end
 
     context 'when file from feature_branch has an equal or better score than base_branch' do
-      before do
-        RubyCritic::SourceControlSystem::Git.class_eval do
-          def self.switch_branch(_branch)
-            FileUtils.cp 'test/samples/base_branch_file.rb', 'test/samples/compare_file.rb'
-          end
-        end
-      end
       it 'outputs score' do
         options = ['-b', 'feature_branch', '-t', '0', 'test/samples/compare_file.rb']
         options = RubyCritic::Cli::Options.new(options).parse.to_h
         RubyCritic::Config.set(options)
-        status_reporter = RubyCritic::Command::Compare.new(options).execute
-        _(status_reporter.score).must_equal RubyCritic::Config.feature_branch_score
-        _(status_reporter.score).must_equal RubyCritic::Config.base_branch_score
-        _(status_reporter.status_message).must_equal "Score: #{RubyCritic::Config.feature_branch_score}"
+        copy_proc = proc do |_|
+          FileUtils.cp 'test/samples/base_branch_file.rb', 'test/samples/compare_file.rb'
+        end
+        RubyCritic::SourceControlSystem::Git.stub(:switch_branch, copy_proc) do
+          status_reporter = RubyCritic::Command::Compare.new(options).execute
+          _(status_reporter.score).must_equal RubyCritic::Config.feature_branch_score
+          _(status_reporter.score).must_equal RubyCritic::Config.base_branch_score
+          _(status_reporter.status_message).must_equal "Score: #{RubyCritic::Config.feature_branch_score}"
+        end
       end
     end
   end

--- a/test/lib/rubycritic/source_control_systems/git_test.rb
+++ b/test/lib/rubycritic/source_control_systems/git_test.rb
@@ -2,14 +2,13 @@
 
 require 'test_helper'
 require 'rubycritic/source_control_systems/base'
-require_relative 'interfaces/basic'
-require_relative 'interfaces/time_travel'
 
-class GitTest < Minitest::Test
-  include BasicInterface
-  include TimeTravelInterface
-
-  def setup
-    @system = RubyCritic::SourceControlSystem::Git.new
+describe RubyCritic::SourceControlSystem::Git do
+  describe '.switch_branch' do
+    it 'should not raise NoMethodError' do
+      RubyCritic::SourceControlSystem::Git.stubs(:uncommitted_changes).returns('')
+      RubyCritic::SourceControlSystem::Git.expects(:git)
+      RubyCritic::SourceControlSystem::Git.switch_branch('_branch_')
+    end
   end
 end


### PR DESCRIPTION
This PR should fix an error like following when running version 4.3.0 of rubycritic.

```
../rubycritic-4.3.0/lib/rubycritic/source_control_systems/git.rb:55:in `switch_branch': undefined method `blank?' for "":String (NoMethodError)
```

`String#blank?` is defined by [ActiveSupport](https://api.rubyonrails.org/classes/String.html#method-i-blank-3F), not in ruby standard `String` class.

Check list:
- [x] Add an entry to the [changelog](/CHANGELOG.md)
- [x] [Squash all commits into a single one](/CONTRIBUTING.md)
- [x] Describe your PR, link issues, etc.
