### PR TITLE
Relax version constraint on `parser` gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # master [(unreleased)](https://github.com/whitesmith/rubycritic/compare/v4.3.1...master)
 
+* [BUGFIX] Relax constraint on `parser` gem (by [@lloydwatkin][])
+
 # v4.3.1 / 2019-12-30 [(commits)](https://github.com/whitesmith/rubycritic/compare/v4.3.0...v4.3.1)
 
 * [BUGFIX] Fixes NoMethodError on RubyCritic::SourceControlSystem::Git.switch_branch (by [@eitoball][])
@@ -316,3 +318,4 @@
 [@cvoltz]: https://github.com/cvoltz
 [@Adre]: https://github.com/Adre
 [@GeoffTidey]: https://github.com/GeoffTidey
+[@lloydwatkin]: https://github.com/lloydwatkin

--- a/rubycritic.gemspec
+++ b/rubycritic.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'flay', '~> 2.8'
   spec.add_runtime_dependency 'flog', '~> 4.4'
   spec.add_runtime_dependency 'launchy', '2.4.3'
-  spec.add_runtime_dependency 'parser', '~> 2.6.0'
+  spec.add_runtime_dependency 'parser', '>= 2.6.0'
   spec.add_runtime_dependency 'rainbow', '~> 3.0'
   spec.add_runtime_dependency 'reek', '~> 5.0', '< 6.0'
   spec.add_runtime_dependency 'ruby_parser', '~> 3.8'


### PR DESCRIPTION
Fixes #341

Relaxes constraint on `parser` gem from `~> 2.6.0` to `> 2.6.0`.

Check list:
- [x] Add an entry to the [changelog](/CHANGELOG.md)
- [ ] [Squash all commits into a single one](/CONTRIBUTING.md)
- [x] Describe your PR, link issues, etc.
