### PR TITLE
Take .flayignore file into account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # master [(unreleased)](https://github.com/whitesmith/rubycritic/compare/v4.3.3...master)
 
+* [FEATURE] Take into account the `.flayignore` file (by [@Flink][])
+
 # v4.3.3 / 2020-01-31 [(commits)](https://github.com/whitesmith/rubycritic/compare/v4.3.2...v4.3.3)
 
 * [BUGFIX] Relax constraint on `simplecov` gem (by [@etagwerker][])
@@ -325,3 +327,4 @@
 [@Adre]: https://github.com/Adre
 [@GeoffTidey]: https://github.com/GeoffTidey
 [@lloydwatkin]: https://github.com/lloydwatkin
+[@Flink]: https://github.com/Flink

--- a/lib/rubycritic/analysers/helpers/flay.rb
+++ b/lib/rubycritic/analysers/helpers/flay.rb
@@ -6,6 +6,7 @@ module RubyCritic
   class Flay < ::Flay
     def initialize(paths)
       super()
+      paths = PathExpander.new([], '').filter_files(paths, DEFAULT_IGNORE)
       process(*paths)
       analyze
     end

--- a/test/lib/rubycritic/analysers/smells/flay_test.rb
+++ b/test/lib/rubycritic/analysers/smells/flay_test.rb
@@ -38,4 +38,27 @@ describe RubyCritic::Analyser::FlaySmells do
       _(@analysed_modules.first.duplication).must_be(:>, 0)
     end
   end
+
+  context 'when some files are ignored using .flayignore' do
+    before do
+      FileUtils.ln_s('test/samples/flay/.flayignore', '.')
+      @analysed_modules = [
+        RubyCritic::AnalysedModule.new(pathname: Pathname.new('test/samples/flay/smelly.rb')),
+        RubyCritic::AnalysedModule.new(pathname: Pathname.new('test/samples/flay/smelly2.rb'))
+      ]
+      RubyCritic::Analyser::FlaySmells.new(@analysed_modules).run
+    end
+
+    after do
+      FileUtils.rm(%w[.flayignore])
+    end
+
+    it "doesn't detect smells for the ignored files" do
+      _(@analysed_modules.first.smells?).must_equal false
+    end
+
+    it 'still detects smells for non-ignored files' do
+      _(@analysed_modules.last.smells?).must_equal true
+    end
+  end
 end

--- a/test/samples/flay/.flayignore
+++ b/test/samples/flay/.flayignore
@@ -1,0 +1,1 @@
+test/samples/flay/smelly.rb

--- a/test/samples/flay/smelly2.rb
+++ b/test/samples/flay/smelly2.rb
@@ -5,4 +5,11 @@ class Roose
     parts -= 3
     parts -= 4
   end
+
+  def duplicate(parts)
+    parts -= 1
+    parts -= 2
+    parts -= 3
+    parts -= 4
+  end
 end


### PR DESCRIPTION
Flay accepts a `.flayignore` file containing paths allowing to skip its
analysis for the provided paths. The current version of Rubycritic
ignores this file and Flay will always apply to all the paths provided
to Rubycritic.

This patch addresses this issue by taking a small snippet of code from
the Flay source itself and apply it to the Flay helper class. Now the
`.flayignore` file is honored as expected.
