### PR TITLE
Make the revision count faster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # master [(unreleased)](https://github.com/whitesmith/rubycritic/compare/v4.4.0...master)
 
+* [CHANGE] Rewrite how churn is calculated to make it faster
+
 # v4.4.0 / 2020-02-15 [(commits)](https://github.com/whitesmith/rubycritic/compare/v4.3.3...v4.4.0)
 
 * [FEATURE] Take into account the `.flayignore` file (by [@Flink][])

--- a/lib/rubycritic/source_control_systems/git.rb
+++ b/lib/rubycritic/source_control_systems/git.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'tty/which'
+require 'rubycritic/source_control_systems/git/churn'
 
 module RubyCritic
   module SourceControlSystem
@@ -28,12 +29,16 @@ module RubyCritic
         'Git'
       end
 
+      def churn
+        @churn ||= Churn.new
+      end
+
       def revisions_count(path)
-        git("log --follow --format=%h #{path.shellescape}").count("\n")
+        churn.revisions_count(path)
       end
 
       def date_of_last_commit(path)
-        git("log -1 --date=iso --format=%ad #{path.shellescape}").chomp!
+        churn.date_of_last_commit(path)
       end
 
       def revision?

--- a/lib/rubycritic/source_control_systems/git/churn.rb
+++ b/lib/rubycritic/source_control_systems/git/churn.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+module RubyCritic
+  module SourceControlSystem
+    class Git < Base
+      Stats = Struct.new(:count, :date)
+
+      class Renames
+        def initialize
+          @data = {}
+        end
+
+        def renamed(from, to)
+          current = current(to)
+          @data[from] = current
+        end
+
+        def current(name)
+          @data.fetch(name, name)
+        end
+      end
+
+      class Churn
+        def initialize
+          @renames = Renames.new
+          @date = nil
+          @stats = {}
+
+          call
+        end
+
+        def revisions_count(path)
+          stats(path).count
+        end
+
+        def date_of_last_commit(path)
+          stats(path).date
+        end
+
+        private
+
+        def call
+          Git
+            .git("log --all --date=iso --follow --format='format:date:%x09%ad' --name-status .")
+            .split("\n")
+            .reject(&:empty?)
+            .each { |line| process_line(line) }
+        end
+
+        def process_line(line)
+          operation, *rest = line.split("\t")
+
+          case operation
+          when /^date:/
+            process_date(*rest)
+          when /^R/
+            process_rename(*rest)
+          else
+            process_file(*rest)
+          end
+        end
+
+        def process_date(date)
+          @date = date
+        end
+
+        def process_rename(from, to)
+          @renames.renamed(from, to)
+          process_file(to)
+        end
+
+        def process_file(filename)
+          record_commit(@renames.current(filename), @date)
+        end
+
+        def record_commit(filename, date)
+          stats = @stats[filename] ||= Stats.new(0, date)
+          stats.count += 1
+        end
+
+        def stats(path)
+          @stats.fetch(path, Stats.new(0))
+        end
+      end
+    end
+  end
+end

--- a/test/lib/rubycritic/source_control_systems/git/churn_test.rb
+++ b/test/lib/rubycritic/source_control_systems/git/churn_test.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+describe RubyCritic::SourceControlSystem::Git::Churn do
+  let(:churn) { RubyCritic::SourceControlSystem::Git::Churn.new }
+
+  before do
+    RubyCritic::SourceControlSystem::Git.stubs(:git).returns(git_log)
+  end
+
+  let(:git_log) do
+    <<~GIT_LOG
+      date:\t2020-01-31 08:01:07 -0500
+      M\tCHANGELOG.md
+      M\trubycritic.gemspec
+
+      date:\t2020-01-27 19:42:04 +0000
+      M\tCHANGELOG.md
+      M\tlib/rubycritic/version.rb
+
+      date:\t2020-01-22 09:51:16 +0000
+      M\tCHANGELOG.md
+      M\trubycritic.gemspec
+
+      date:\t2019-12-30 10:46:58 +0000
+      M\tCHANGELOG.md
+      M\tlib/rubycritic/version.rb
+
+      date:\t2019-12-30 19:11:09 +0900
+      M\tCHANGELOG.md
+      M\tlib/rubycritic/source_control_systems/git.rb
+      M\ttest/lib/rubycritic/commands/compare_test.rb
+      M\ttest/lib/rubycritic/source_control_systems/git_test.rb
+
+      date:\t2014-03-19 18:17:28 +0000
+      M\tlib/rubycritic/report_generators/base_generator.rb
+      A\tlib/rubycritic/report_generators/index_generator.rb
+      M\tlib/rubycritic/report_generators/reporter.rb
+      A\tlib/rubycritic/report_generators/templates/index.html.erb
+      M\tlib/rubycritic/report_generators/templates/layouts/application.html.erb
+
+      date:\t2014-03-19 18:07:59 +0000
+      M\tlib/rubycritic.rb
+      A\tlib/rubycritic/report_generators/base_generator.rb
+      M\tlib/rubycritic/report_generators/file_generator.rb
+      M\tlib/rubycritic/report_generators/line_generator.rb
+      R081\tlib/rubycritic/report_generators/report_generator.rb\tlib/rubycritic/report_generators/reporter.rb
+
+      date:\t2014-03-19 17:23:21 +0000
+      M\tlib/rubycritic/report_generators/file_generator.rb
+      M\tlib/rubycritic/report_generators/line_generator.rb
+      M\tlib/rubycritic/report_generators/report_generator.rb
+
+      date:\t2014-03-18 23:02:01 +0000
+      M\tlib/rubycritic.rb
+      M\tlib/rubycritic/cli.rb
+      A\tlib/rubycritic/report_generators/assets/stylesheets/application.css
+      A\tlib/rubycritic/report_generators/file_generator.rb
+      A\tlib/rubycritic/report_generators/line_generator.rb
+      A\tlib/rubycritic/report_generators/report_generator.rb
+      A\tlib/rubycritic/report_generators/templates/file.html.erb
+      A\tlib/rubycritic/report_generators/templates/layouts/application.html.erb
+      A\tlib/rubycritic/report_generators/templates/line.html.erb
+      A\tlib/rubycritic/report_generators/templates/smelly_line.html.erb
+    GIT_LOG
+  end
+
+  describe '#revisions_count' do
+    it "counts the commits of a file that doesn't change name" do
+      _(churn.revisions_count('CHANGELOG.md')).must_equal 5
+    end
+
+    it 'counts the commits including the old name of a renamed file' do
+      _(churn.revisions_count('lib/rubycritic/report_generators/reporter.rb'))
+        .must_equal 4
+    end
+
+    it 'returns 0 for an uncommited file' do
+      _(churn.revisions_count('non_existant_file')).must_equal 0
+    end
+  end
+
+  describe '#date_of_last_commit' do
+    it 'returns the last commit containing the file' do
+      _(churn.date_of_last_commit('lib/rubycritic/report_generators/reporter.rb'))
+        .must_equal '2014-03-19 18:17:28 +0000'
+    end
+
+    it 'returns nil for an uncommited file' do
+      assert_nil(churn.date_of_last_commit('non_existant_file'))
+    end
+  end
+end


### PR DESCRIPTION
Changed the revision count from running git log for every file to run
git log once for the project and process the results.

This solves a problem for us trying to add rubycritic to our CI pipeline where it would take 40 minutes to run. After this change it takes 5 minutes, and the churn stage itself is done in seconds.

This indirectly fixes https://github.com/whitesmith/rubycritic/issues/37 by making the churn fast enough that it would no longer be necessary to filter commits for speed.

Check list:
- [x] Add an entry to the [changelog](/CHANGELOG.md)
- [x] [Squash all commits into a single one](/CONTRIBUTING.md)
- [x] Describe your PR, link issues, etc.
