### PR TITLE
Reek excluded_path configuration not being picked up

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -170,3 +170,5 @@ detectors:
   BooleanParameter:
     exclude:
     - RubyCritic::Config#self.respond_to_missing?
+exclude_paths:
+    - test/samples/reek/excluded_smelly.rb # This is needed for the tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # master [(unreleased)](https://github.com/whitesmith/rubycritic/compare/v4.4.1...master)
 
+# v4.4.2 / 2020-03-02 [(commits)](https://github.com/whitesmith/rubycritic/compare/v4.4.1...v4.4.2)
+
+* [BUGFIX] Add Workaround to ignore excluded files from reek
+
 # v4.4.1 / 2020-02-20 [(commits)](https://github.com/whitesmith/rubycritic/compare/v4.4.0...v4.4.1)
 
 * [CHANGE] Rewrite how churn is calculated to make it faster

--- a/lib/rubycritic/analysers/smells/reek.rb
+++ b/lib/rubycritic/analysers/smells/reek.rb
@@ -13,7 +13,7 @@ module RubyCritic
       end
 
       def run
-        @analysed_modules.each do |analysed_module|
+        relevant_paths.each do |analysed_module|
           add_smells_to(analysed_module)
           print green '.'
         end
@@ -25,6 +25,8 @@ module RubyCritic
       end
 
       private
+
+      attr_reader :analysed_modules
 
       def add_smells_to(analysed_module)
         Reek.new(analysed_module.pathname).smells.each do |smell|
@@ -47,6 +49,14 @@ module RubyCritic
         file_lines.uniq.map do |file_line|
           Location.new(file_path, file_line)
         end.sort
+      end
+
+      def relevant_paths
+        analysed_modules.reject { |path| configuration.path_excluded?(path.pathname) }
+      end
+
+      def configuration
+        @configuration ||= ::Reek::Configuration::AppConfiguration.from_default_path
       end
     end
   end

--- a/test/lib/rubycritic/analysers/smells/reek_test.rb
+++ b/test/lib/rubycritic/analysers/smells/reek_test.rb
@@ -29,4 +29,17 @@ describe RubyCritic::Analyser::ReekSmells do
       _(last_smell.message).must_equal 'has no descriptive comment'
     end
   end
+
+  context 'when analysing a excluded smelly file' do
+    before do
+      pathname = Pathname.new('test/samples/reek/excluded_smelly.rb')
+      @analysed_module = AnalysedModuleDouble.new(pathname: pathname, smells: [])
+      analysed_modules = [@analysed_module]
+      RubyCritic::Analyser::ReekSmells.new(analysed_modules).run
+    end
+
+    it 'dont analyse the file' do
+      _(@analysed_module.smells.length).must_equal 0
+    end
+  end
 end

--- a/test/lib/rubycritic/generators/lint_report_test.rb
+++ b/test/lib/rubycritic/generators/lint_report_test.rb
@@ -14,7 +14,9 @@ describe RubyCritic::Generator::LintReport do
     end
 
     it 'report file has data inside' do
-      sample_files = Dir['test/samples/**/*.rb'].reject { |f| File.zero?(f) }
+      sample_files = Dir['test/samples/**/*.rb'].reject do |f|
+        File.zero?(f) || f.include?('excluded')
+      end
       create_analysed_modules_collection
       generate_report
       lines = File.readlines('test/samples/lint.txt').map(&:strip).reject(&:empty?)

--- a/test/samples/reek/excluded_smelly.rb
+++ b/test/samples/reek/excluded_smelly.rb
@@ -1,0 +1,17 @@
+class Theon
+  def reeks?(reek = true)
+    reek
+  end
+
+  def flayed?(a)
+    a
+  end
+end
+
+# Reek should report
+# [1]:Theon has no descriptive comment (IrresponsibleModule)
+# [2]:Theon#reeks? has boolean parameter 'reek' (BooleanParameter)
+# This comment is below the module because otherwise Reek will interpret this
+# as a comment describing the module which would thus prevent
+# IrresponsibleModule from being reported.
+# It should ignore the UncommunicativeParameterName as it's on the .todo.reek


### PR DESCRIPTION
## Motivation

When using the key `excluded_files` in `.reek.yml`, the parameter have been ignored in the rubycritic

## Proposal

Looking in the Reek implementation, this filter is applied before he comes in the `Reek::Examiner`, so, a workaround for this issue is to filter the files before sending to Reek::Examiner.

I can add more test scenarios for corner cases if you can give me insights about this flow.

## Check list:
- [X] Add an entry to the [changelog](/CHANGELOG.md)
- [X] [Squash all commits into a single one](/CONTRIBUTING.md)
- [X] Describe your PR, link issues, etc.

Issue: #166 