### PR TITLE
Relax launchy version dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # master [(unreleased)](https://github.com/whitesmith/rubycritic/compare/v4.4.1...master)
 
+* [CHANGE] Relax `launchy` version dependency requirement
+
 # v4.4.1 / 2020-02-20 [(commits)](https://github.com/whitesmith/rubycritic/compare/v4.4.0...v4.4.1)
 
 * [CHANGE] Rewrite how churn is calculated to make it faster

--- a/rubycritic.gemspec
+++ b/rubycritic.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'flay', '~> 2.8'
   spec.add_runtime_dependency 'flog', '~> 4.4'
-  spec.add_runtime_dependency 'launchy', '2.4.3'
+  spec.add_runtime_dependency 'launchy', '> 2'
   spec.add_runtime_dependency 'parser', '>= 2.6.0'
   spec.add_runtime_dependency 'rainbow', '~> 3.0'
   spec.add_runtime_dependency 'reek', '~> 5.0', '< 6.0'


### PR DESCRIPTION
I have `'guard-rubycritic'` gem in my `:development` dependencies and `'launchy'` in my `:test` dependencies.

Since launchy is limited to explicitly version `2.4.3` in this gem's gemspec, I can't use version `2.5.0`.
And somehow it just so happened that bundler decided that launchy `2.5.0` should be used and found that rubycritic `1.1.1` (!) is compatible with it (rubycritic `1.1.1` doesn't specify launchy as its dependency).

Maybe I haven't seen many gemspec files, but I've never seen stricter version requirements. It's also for a test/dev gem. Unfortunately, ruby projects, setup with bundler and `Gemfile` or `*.gemspec` file, as far as I know, _cannot_ use more than one version of the same gem. This is a huge problem. I could be using launchy in production and this gem would prevent me from using the latest version.

I strongly recommend relaxing the version requirements. I'm not even sure that version restrictions like these do anything:

```ruby
spec.add_development_dependency 'aruba', '~> 0.12', '>= 0.12.0'
```

This looks like the equivalent of:

```ruby
spec.add_development_dependency 'aruba', '~> 0.12'
```

It could even be:

```ruby
spec.add_development_dependency 'aruba', '>= 0.12'
```

Check list:
- [x] Add an entry to the [changelog](/CHANGELOG.md)
- [x] [Squash all commits into a single one](/CONTRIBUTING.md)
- [x] Describe your PR, link issues, etc.