### PR TITLE
Fix: Allow matching 'launchy' 2.0.0 version

### DIFF
--- a/rubycritic.gemspec
+++ b/rubycritic.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'flay', '~> 2.8'
   spec.add_runtime_dependency 'flog', '~> 4.4'
-  spec.add_runtime_dependency 'launchy', '> 2'
+  spec.add_runtime_dependency 'launchy', '>= 2.0.0'
   spec.add_runtime_dependency 'parser', '>= 2.6.0'
   spec.add_runtime_dependency 'rainbow', '~> 3.0'
   spec.add_runtime_dependency 'reek', '~> 5.0', '< 6.0'


### PR DESCRIPTION
Related: https://github.com/whitesmith/rubycritic/pull/354

Check list:
- [ ] Add an entry to the [changelog](/CHANGELOG.md)
- [x] [Squash all commits into a single one](/CONTRIBUTING.md)
- [x] Describe your PR, link issues, etc.