### PR TITLE
Upgrade the parser gem to 2.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # master [(unreleased)](https://github.com/whitesmith/rubycritic/compare/v4.4.1...master)
 
+* [CHANGE] Upgrade parser to 2.7.0
+
 # v4.4.1 / 2020-02-20 [(commits)](https://github.com/whitesmith/rubycritic/compare/v4.4.0...v4.4.1)
 
 * [CHANGE] Rewrite how churn is calculated to make it faster

--- a/rubycritic.gemspec
+++ b/rubycritic.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'flay', '~> 2.8'
   spec.add_runtime_dependency 'flog', '~> 4.4'
   spec.add_runtime_dependency 'launchy', '2.4.3'
-  spec.add_runtime_dependency 'parser', '>= 2.6.0'
+  spec.add_runtime_dependency 'parser', '>= 2.7.0'
   spec.add_runtime_dependency 'rainbow', '~> 3.0'
   spec.add_runtime_dependency 'reek', '~> 5.0', '< 6.0'
   spec.add_runtime_dependency 'ruby_parser', '~> 3.8'


### PR DESCRIPTION
I'm having issues upgrading rubocop in many of our projects because it rubycritic requires an older version of the parser gem

```
rubocop (~> 0.80.1) was resolved to 0.80.1, which depends on
      parser (>= 2.7.0.1)
rubycritic was resolved to 4.3.1, which depends on
      parser (~> 2.6.0)
```

Check list:
- [✅] Add an entry to the [changelog](/CHANGELOG.md)
- [✅] Squash all commits into a single one](/CONTRIBUTING.md)
- [✅] Describe your PR, link issues, etc.
