### PR TITLE
Update reek dependency & drop support for ruby 2.3

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,7 @@ AllCops:
     - 'test/samples/**/*'
     - 'tmp/**/*'
     - 'vendor/**/*'
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.4
 
 Metrics/BlockLength:
   Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ before_install:
   - gem install bundler
 jobs:
   include:
-    - rvm: 2.3.0
-    - rvm: 2.3
     - rvm: 2.4
     - rvm: 2.5
     - rvm: 2.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # master [(unreleased)](https://github.com/whitesmith/rubycritic/compare/v4.4.1...master)
 
 * [CHANGE] Relax `launchy` version dependency requirement
+* [CHANGE] Drop support for ruby 2.3 (by [@joshrpowell][])
 * [CHANGE] Update Reek dependency to '~> 6.0', '< 7.0' (by [@joshrpowell][])
 
 # v4.4.1 / 2020-02-20 [(commits)](https://github.com/whitesmith/rubycritic/compare/v4.4.0...v4.4.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # master [(unreleased)](https://github.com/whitesmith/rubycritic/compare/v4.4.1...master)
 
 * [CHANGE] Relax `launchy` version dependency requirement
+* [CHANGE] Update Reek dependency to '~> 6.0', '< 7.0' (by [@joshrpowell][])
 
 # v4.4.1 / 2020-02-20 [(commits)](https://github.com/whitesmith/rubycritic/compare/v4.4.0...v4.4.1)
 

--- a/rubycritic.gemspec
+++ b/rubycritic.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'RubyCritic is a Ruby code quality reporter'
   spec.homepage      = 'https://github.com/whitesmith/rubycritic'
   spec.license       = 'MIT'
-  spec.required_ruby_version = '>= 2.3.0'
+  spec.required_ruby_version = '>= 2.4.0'
 
   spec.files = [
     'CHANGELOG.md',

--- a/rubycritic.gemspec
+++ b/rubycritic.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'launchy', '>= 2.0.0'
   spec.add_runtime_dependency 'parser', '>= 2.6.0'
   spec.add_runtime_dependency 'rainbow', '~> 3.0'
-  spec.add_runtime_dependency 'reek', '~> 5.0', '< 6.0'
+  spec.add_runtime_dependency 'reek', '~> 6.0', '< 7.0'
   spec.add_runtime_dependency 'ruby_parser', '~> 3.8'
   spec.add_runtime_dependency 'simplecov', '>= 0.17.0'
   spec.add_runtime_dependency 'tty-which', '~> 0.4.0'


### PR DESCRIPTION
- [x] Reek bump to 6.0 - https://github.com/troessner/reek/blob/master/CHANGELOG.md#600-2020-03-30

- [x] Drop support for ruby 2.3 [[now that ruby 2.4 maintenance ends March 2020](https://www.ruby-lang.org/en/news/2020/03/31/ruby-2-4-10-released/)]

Check list:
- [x] Add an entry to the [changelog](/CHANGELOG.md)
- [x] [Squash all commits into a single one](/CONTRIBUTING.md)
- [x] Describe your PR, link issues, etc.
