### PR TITLE
Update README for Reek 6.x bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,10 +216,10 @@ See [formatters](docs/formatters.md)
 
 RubyCritic is supporting Ruby versions:
 
-* 2.3
 * 2.4
 * 2.5
 * 2.6
+* 2.7
 
 ## Improving RubyCritic
 


### PR DESCRIPTION
This PR is an update to https://github.com/whitesmith/rubycritic/pull/358 (which I can't add to directly).

This PR:
- ~Bumps Reek to 6.0~
- ~Drops support for Ruby 2.3 (since it was EOL'd in March 2019 and was dropped in Reek 6.x)~
- ~Updates the docs accordingly~
- Updates the README with the supported ruby versions.

Check list:
- [x] Add an entry to the [changelog](/CHANGELOG.md)
- [x] [Squash all commits into a single one](/CONTRIBUTING.md)
- [x] Describe your PR, link issues, etc.

---

@nunosilva800 Sorry for creating a duplicate of #358. I wasn't able to add to it (I don't have write access to that fork) and this version bump is something I'd like to see done for a project I'm involved in.

Also, I'm not sure what the etiquette is around crediting the author in the changelog, but I can switch it to @joshRpowell, since he wrote the original PR.