### PR TITLE
Add `churn_after` option for git churn analyser

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -81,6 +81,7 @@ detectors:
     - RubyCritic::Configuration#threshold_score
     - RubyCritic::Configuration#base_branch_collection
     - RubyCritic::Configuration#feature_branch_collection
+    - RubyCritic::Configuration#churn_after
     - RubyCritic::RakeTask#name
     - RubyCritic::RakeTask#options
     - RubyCritic::RakeTask#paths

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # master [(unreleased)](https://github.com/whitesmith/rubycritic/compare/v4.5.0...master)
+* [FEATURE] Add --churn-after (only supports git) to limit churn analysis to recent history (by [@jackcasey][])
 
 # v4.5.0 / 2020-05-14 [(commits)](https://github.com/whitesmith/rubycritic/compare/v4.4.1...v4.5.0)
 
@@ -340,3 +341,4 @@
 [@GeoffTidey]: https://github.com/GeoffTidey
 [@lloydwatkin]: https://github.com/lloydwatkin
 [@Flink]: https://github.com/Flink
+[@jackcasey]: https://github.com/jackcasey

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # master [(unreleased)](https://github.com/whitesmith/rubycritic/compare/v4.5.0...master)
+
 * [FEATURE] Add --churn-after (only supports git) to limit churn analysis to recent history (by [@jackcasey][])
 
 # v4.5.0 / 2020-05-14 [(commits)](https://github.com/whitesmith/rubycritic/compare/v4.4.1...v4.5.0)

--- a/features/command_line_interface/options.feature
+++ b/features/command_line_interface/options.feature
@@ -40,6 +40,9 @@ Feature: RubyCritic can be controlled using command-line options
                                            Example: RubyCritic::MarkDown::Reporter
                                            Multiple formatters are supported.
           -s, --minimum-score [MIN_SCORE]  Set a minimum score
+              --churn-after [DATE]         Only count churn from a certain date.
+                                           The date is passed through to version control (currently git only).
+                                           Example: 2017-01-01
           -m, --mode-ci [BASE_BRANCH]      Use CI mode (faster, analyses diffs w.r.t base_branch (default: master))
               --deduplicate-symlinks       De-duplicate symlinks based on their final target
               --suppress-ratings           Suppress letter ratings

--- a/lib/rubycritic/cli/options/argv.rb
+++ b/lib/rubycritic/cli/options/argv.rb
@@ -70,6 +70,12 @@ module RubyCritic
               self.minimum_score = Float(min_score)
             end
 
+            opts.on('--churn-after [DATE]', 'Only count churn from a certain date.',
+                    'The date is passed through to version control (currently git only).',
+                    'Example: 2017-01-01') do |churn_after|
+              self.churn_after = churn_after
+            end
+
             opts.on('-m', '--mode-ci [BASE_BRANCH]',
                     'Use CI mode (faster, analyses diffs w.r.t base_branch (default: master))') do |branch|
               self.base_branch = branch || 'master'
@@ -110,6 +116,7 @@ module RubyCritic
             suppress_ratings: suppress_ratings,
             help_text: parser.help,
             minimum_score: minimum_score,
+            churn_after: churn_after,
             no_browser: no_browser,
             base_branch: base_branch,
             feature_branch: feature_branch,
@@ -121,7 +128,7 @@ module RubyCritic
         private
 
         attr_accessor :mode, :root, :formats, :formatters, :deduplicate_symlinks,
-                      :suppress_ratings, :minimum_score, :no_browser,
+                      :suppress_ratings, :minimum_score, :churn_after, :no_browser,
                       :parser, :base_branch, :feature_branch, :threshold_score
         def paths
           @argv unless @argv.empty?

--- a/lib/rubycritic/configuration.rb
+++ b/lib/rubycritic/configuration.rb
@@ -19,11 +19,15 @@ module RubyCritic
       self.suppress_ratings = options[:suppress_ratings]
       self.open_with = options[:open_with]
       self.no_browser = options[:no_browser]
+      self.threshold_score = options[:threshold_score].to_i
+      setup_version_control(options)
+      setup_formats(options)
+    end
+
+    def setup_version_control(options)
       self.base_branch = options[:base_branch]
       self.feature_branch = options[:feature_branch]
-      self.threshold_score = options[:threshold_score].to_i
       self.churn_after = options[:churn_after]
-      setup_formats(options)
     end
 
     def setup_formats(options)

--- a/lib/rubycritic/configuration.rb
+++ b/lib/rubycritic/configuration.rb
@@ -10,7 +10,7 @@ module RubyCritic
                   :feature_branch, :base_branch_score, :feature_branch_score,
                   :base_root_directory, :feature_root_directory,
                   :compare_root_directory, :threshold_score, :base_branch_collection,
-                  :feature_branch_collection
+                  :feature_branch_collection, :churn_after
 
     def set(options)
       self.mode = options[:mode] || :default
@@ -22,6 +22,7 @@ module RubyCritic
       self.base_branch = options[:base_branch]
       self.feature_branch = options[:feature_branch]
       self.threshold_score = options[:threshold_score].to_i
+      self.churn_after = options[:churn_after]
       setup_formats(options)
     end
 

--- a/lib/rubycritic/source_control_systems/git.rb
+++ b/lib/rubycritic/source_control_systems/git.rb
@@ -30,7 +30,7 @@ module RubyCritic
       end
 
       def churn
-        @churn ||= Churn.new
+        @churn ||= Churn.new(churn_after: Config.churn_after)
       end
 
       def revisions_count(path)

--- a/lib/rubycritic/source_control_systems/git/churn.rb
+++ b/lib/rubycritic/source_control_systems/git/churn.rb
@@ -21,10 +21,11 @@ module RubyCritic
       end
 
       class Churn
-        def initialize
+        def initialize(churn_after: nil)
           @renames = Renames.new
           @date = nil
           @stats = {}
+          @churn_after = churn_after
 
           call
         end
@@ -41,10 +42,15 @@ module RubyCritic
 
         def call
           Git
-            .git("log --all --date=iso --follow --format='format:date:%x09%ad' --name-status .")
+            .git(git_log_command)
             .split("\n")
             .reject(&:empty?)
             .each { |line| process_line(line) }
+        end
+
+        def git_log_command
+          after_clause = @churn_after ? "--after='#{@churn_after}' " : ''
+          "log --all --date=iso --follow --format='format:date:%x09%ad' --name-status #{after_clause}."
         end
 
         def process_line(line)

--- a/test/lib/rubycritic/source_control_systems/git/churn_test.rb
+++ b/test/lib/rubycritic/source_control_systems/git/churn_test.rb
@@ -79,6 +79,14 @@ describe RubyCritic::SourceControlSystem::Git::Churn do
     it 'returns 0 for an uncommited file' do
       _(churn.revisions_count('non_existant_file')).must_equal 0
     end
+
+    context 'with churn_after option specified' do
+      let(:churn) { RubyCritic::SourceControlSystem::Git::Churn.new(churn_after: '2015-01-01') }
+
+      it 'uses the option in the git command' do
+        _(churn.send(:git_log_command)).must_match /2015-01-01/
+      end
+    end
   end
 
   describe '#date_of_last_commit' do

--- a/test/lib/rubycritic/source_control_systems/git/churn_test.rb
+++ b/test/lib/rubycritic/source_control_systems/git/churn_test.rb
@@ -84,7 +84,7 @@ describe RubyCritic::SourceControlSystem::Git::Churn do
       let(:churn) { RubyCritic::SourceControlSystem::Git::Churn.new(churn_after: '2015-01-01') }
 
       it 'uses the option in the git command' do
-        _(churn.send(:git_log_command)).must_match /2015-01-01/
+        _(churn.send(:git_log_command)).must_match(/2015-01-01/)
       end
     end
   end


### PR DESCRIPTION
### NB:
This is a WIP and RFC. Feedback would be highly appreciated, hopefully I can get it to the point where it is acceptable.

We have a > 10 year old codebase and analysing churn back 10 years is much less valuable than seeing the last ~3 years (or 1 or 5). So I made this change for our own purposes.

Some issues with the PR currently:
- Only supports git
- No integration test ensuring the command line arg gets all the way to git and works
- Test for the `Churn` class tests a private method. (I am not familiar with minitest mocha mocks and couldn't achieve something better in my timebox). 

### PR Description

This allows a user to limit churn analysis to a recent subset of their
project's version history. This is useful to suppress churn rating for
files that changes a lot in the distant past but change significantly
less often in the more recent past.

Check list:
- [x] Add an entry to the [changelog](/CHANGELOG.md)
- [ ] [Squash all commits into a single one](/CONTRIBUTING.md)
- [x] Describe your PR, link issues, etc.
