### PR TITLE
Handle Copied operation of git --name-status when process the Churn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # master [(unreleased)](https://github.com/whitesmith/rubycritic/compare/v4.5.0...master)
 
+* [BUGFIX] Handle git --name-status Copied (C) operation (by [@rizalmuthi][])
+
 # v4.5.0 / 2020-05-14 [(commits)](https://github.com/whitesmith/rubycritic/compare/v4.4.1...v4.5.0)
 
 * [CHANGE] Relax `launchy` version dependency requirement

--- a/lib/rubycritic/source_control_systems/git/churn.rb
+++ b/lib/rubycritic/source_control_systems/git/churn.rb
@@ -53,7 +53,7 @@ module RubyCritic
           case operation
           when /^date:/
             process_date(*rest)
-          when /^R/
+          when /^[RC]/
             process_rename(*rest)
           else
             process_file(*rest)

--- a/test/lib/rubycritic/source_control_systems/git/churn_test.rb
+++ b/test/lib/rubycritic/source_control_systems/git/churn_test.rb
@@ -11,6 +11,9 @@ describe RubyCritic::SourceControlSystem::Git::Churn do
 
   let(:git_log) do
     <<~GIT_LOG
+      date:\t2020-06-29 03:03:03 -0500
+      C051\tROADMAP.md\tROADMAP.extend.md
+
       date:\t2020-01-31 08:01:07 -0500
       M\tCHANGELOG.md
       M\trubycritic.gemspec


### PR DESCRIPTION
Added Copied (C) operation on the case statement when processing the git log lines

Check list:
- [x] Add an entry to the [changelog](/CHANGELOG.md)
- [x] [Squash all commits into a single one](/CONTRIBUTING.md)
- [x] Issue: https://github.com/whitesmith/rubycritic/issues/364
