### PR TITLE
Fix issue 307 comparing files on two branches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
 * [BUGFIX] Fix directory structure of reports when comparing branches (by [@denny][])
 * [BUGFIX] Restrict simplecov to versions before data format changed (by [@denny][])
 
+* [BUGFIX] Handle missing comparison file in html template (by @lauratpa)
+
 # v4.5.2 / 2020-08-20 [(commits)](https://github.com/whitesmith/rubycritic/compare/v4.5.1...v4.5.2)
 
 * [BUGFIX] Handle simplecov v0.19 and install appraisal (by [@MZiserman][])

--- a/lib/rubycritic/generators/html/templates/code_index.html.erb
+++ b/lib/rubycritic/generators/html/templates/code_index.html.erb
@@ -25,7 +25,9 @@
                 <td class="center">
                   <% if Config.build_mode? %>
                     <% master_analysed_module = Config.base_branch_collection.find(analysed_module.pathname) %>
-                    <% if master_analysed_module.cost > analysed_module.cost %>
+                    <% if !master_analysed_module %>
+                      <span class="empty-span glyphicon"></span>
+                    <% elsif master_analysed_module.cost > analysed_module.cost %>
                       <span class="glyphicon glyphicon-arrow-up green-color"></span>
                     <% elsif master_analysed_module.cost < analysed_module.cost %>
                       <span class="glyphicon glyphicon-arrow-down red-color"></span>

--- a/test/lib/rubycritic/commands/compare_test.rb
+++ b/test/lib/rubycritic/commands/compare_test.rb
@@ -44,7 +44,6 @@ describe RubyCritic::Command::Compare do
         copy_proc = proc do |branch|
           FileUtils.cp "test/samples/#{branch}_file.rb", 'test/samples/compare_file.rb'
         end
-
         RubyCritic::SourceControlSystem::Git.stub(:switch_branch, copy_proc) do
           comparison = RubyCritic::Command::Compare.new(options)
           comparison.expects(:abort).once

--- a/test/lib/rubycritic/commands/compare_test.rb
+++ b/test/lib/rubycritic/commands/compare_test.rb
@@ -24,7 +24,6 @@ end
 
 describe RubyCritic::Command::Compare do
   before do
-    RubyCritic::Browser.any_instance.stubs(:open).returns(nil)
     RubyCritic::Reporter.stubs(:generate_report).returns(nil)
     RubyCritic::Command::Compare.any_instance.stubs(:build_details).returns(nil)
     RubyCritic::SourceControlSystem::Git.stubs(:modified_files).returns('test/samples/compare_file.rb')
@@ -45,6 +44,7 @@ describe RubyCritic::Command::Compare do
         copy_proc = proc do |branch|
           FileUtils.cp "test/samples/#{branch}_file.rb", 'test/samples/compare_file.rb'
         end
+
         RubyCritic::SourceControlSystem::Git.stub(:switch_branch, copy_proc) do
           comparison = RubyCritic::Command::Compare.new(options)
           comparison.expects(:abort).once

--- a/test/lib/rubycritic/generators/html_report_test.rb
+++ b/test/lib/rubycritic/generators/html_report_test.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'rubycritic/analysers_runner'
+require 'rubycritic/generators/html_report'
+require 'rubycritic/browser'
+require 'fakefs_helper'
+
+describe RubyCritic::Generator::HtmlReport do
+  describe '#generate_report' do
+    around do |example|
+      capture_output_streams do
+        with_cloned_fs(&example)
+      end
+    end
+
+    context 'when base branch does not contain the compared file' do
+      it 'still works' do
+        create_analysed_modules_collection
+
+        generate_report
+      end
+    end
+  end
+
+  def create_analysed_modules_collection
+    RubyCritic::Config.root = 'test/samples'
+    RubyCritic::Config.base_root_directory = 'test/samples'
+    RubyCritic::Config.feature_root_directory = 'test/samples'
+    RubyCritic::Config.compare_root_directory = 'test/samples'
+    RubyCritic::Config.source_control_system = RubyCritic::SourceControlSystem::Git.new
+    base_branch_collection = RubyCritic::AnalysedModulesCollection.new(['test/sample/base_branch_file.rb'])
+    RubyCritic::Config.base_branch_collection = base_branch_collection
+    RubyCritic::Config.mode = :compare_branches
+
+    analyser_runner = RubyCritic::AnalysersRunner.new('test/samples/feature_branch_file.rb')
+    @analysed_modules_collection = analyser_runner.run
+  end
+
+  def generate_report
+    report = RubyCritic::Generator::HtmlReport.new(@analysed_modules_collection)
+    report.generate_report
+  end
+end


### PR DESCRIPTION
fixes #307 
This bug occurs when a branch that is being compared contains a file that is not present on the other branch.
In this template the files are being compared to one another, but not all files have to have corresponding file on the second branch.

I would have wanted to add a test for this bug, but there seem to be no existing
tests for the template files.
