### PR TITLE
Fix compare file structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * [CHANGE] Fix rubocop offenses (by [@sl4vr][])
 * [CHANGE] Make Github Linguist ignore vendored files (by [@sl4vr][])
+* [BUGFIX] Fix directory structure of reports when comparing branches (by [@denny][])
 
 # v4.5.2 / 2020-08-20 [(commits)](https://github.com/whitesmith/rubycritic/compare/v4.5.1...v4.5.2)
 

--- a/lib/rubycritic/commands/compare.rb
+++ b/lib/rubycritic/commands/compare.rb
@@ -13,6 +13,7 @@ module RubyCritic
     class Compare < Default
       def initialize(options)
         super
+        @original_config_root = Config.root
         @build_number = 0
       end
 
@@ -57,7 +58,7 @@ module RubyCritic
       def analyse_modified_files
         modified_files = Config.feature_branch_collection.where(SourceControlSystem::Git.modified_files)
         analysed_modules = AnalysedModulesCollection.new(modified_files.map(&:path), modified_files)
-        Config.root = "#{Config.root}/compare"
+        Config.root = Config.compare_root_directory
         report(analysed_modules)
       end
 
@@ -85,7 +86,7 @@ module RubyCritic
       end
 
       def branch_directory(branch)
-        "#{Config.root}/compare/#{Config.send(branch)}"
+        "#{@original_config_root}/compare/#{Config.send(branch)}"
       end
 
       # create a txt file with the branch score details


### PR DESCRIPTION
This PR fixes issue #287; the reports for both branches and the diff report all end up where the top-of-page links expect them to be (which is also where humans expect them to be, going by the comments on that issue).