### PR TITLE
Restrict simplecov version to 'before 0.21'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * [CHANGE] Fix rubocop offenses (by [@sl4vr][])
 * [CHANGE] Make Github Linguist ignore vendored files (by [@sl4vr][])
 * [BUGFIX] Fix directory structure of reports when comparing branches (by [@denny][])
+* [BUGFIX] Restrict simplecov to versions before data format changed (by [@denny][])
 
 # v4.5.2 / 2020-08-20 [(commits)](https://github.com/whitesmith/rubycritic/compare/v4.5.1...v4.5.2)
 

--- a/rubycritic.gemspec
+++ b/rubycritic.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'rainbow', '~> 3.0'
   spec.add_runtime_dependency 'reek', '~> 6.0', '< 7.0'
   spec.add_runtime_dependency 'ruby_parser', '~> 3.8'
-  spec.add_runtime_dependency 'simplecov', '>= 0.17.0'
+  spec.add_runtime_dependency 'simplecov', '>= 0.17.0', '< 0.21'
   spec.add_runtime_dependency 'tty-which', '~> 0.4.0'
   spec.add_runtime_dependency 'virtus', '~> 1.0'
 


### PR DESCRIPTION
The data format simplecov expects/uses for coverage data changed from an array to a hash at version 0.21; this conflicts with the mocking in the Ruby Critic test suite.

In the long run the test suite mocking should be fixed to match the newer simplecov versions, but for now this restriction gets the failing test to pass again.

```bash
denny@rocinante:~/code/denny/rubycritic$ grep simplecov Gemfile.lock | head -2 | tail -1
    simplecov (0.20.0)
denny@rocinante:~/code/denny/rubycritic$ rake test
[...]
Fabulous run in 3.252445s, 46.1191 runs/s, 78.0951 assertions/s.

150 runs, 254 assertions, 0 failures, 0 errors, 0 skips

denny@rocinante:~/code/denny/rubycritic$ bundle update simplecov
denny@rocinante:~/code/denny/rubycritic$ grep simplecov Gemfile.lock | head -2 | tail -1
    simplecov (0.21.2)
denny@rocinante:~/code/denny/rubycritic$ rake test
[...]
Fabulous run in 3.196683s, 46.9236 runs/s, 79.1445 assertions/s.

  1) Error:
RubyCritic::Analyser::Coverage::#run::when analysing a file with some test coverage#test_0001_calculates its test coverage:
TypeError: no implicit conversion of String into Integer
    /home/denny/.rvm/gems/ruby-2.7.2/gems/simplecov-0.21.2/lib/simplecov/source_file.rb:224:in `build_lines'
    /home/denny/.rvm/gems/ruby-2.7.2/gems/simplecov-0.21.2/lib/simplecov/source_file.rb:43:in `lines'
    /home/denny/.rvm/gems/ruby-2.7.2/gems/simplecov-0.21.2/lib/simplecov/source_file.rb:241:in `lines_strength'
    /home/denny/.rvm/gems/ruby-2.7.2/gems/simplecov-0.21.2/lib/simplecov/source_file.rb:333:in `line_coverage_statistics'
    /home/denny/.rvm/gems/ruby-2.7.2/gems/simplecov-0.21.2/lib/simplecov/source_file.rb:35:in `coverage_statistics'
    /home/denny/.rvm/gems/ruby-2.7.2/gems/simplecov-0.21.2/lib/simplecov/source_file.rb:81:in `covered_percent'
    /home/denny/code/denny/rubycritic/lib/rubycritic/analysers/coverage.rb:38:in `find_coverage_percentage'
    /home/denny/code/denny/rubycritic/lib/rubycritic/analysers/coverage.rb:21:in `block in run'
    /home/denny/code/denny/rubycritic/lib/rubycritic/analysers/coverage.rb:20:in `each'
    /home/denny/code/denny/rubycritic/lib/rubycritic/analysers/coverage.rb:20:in `run'
    /home/denny/code/denny/rubycritic/test/lib/rubycritic/analysers/coverage_test.rb:28:in `block (3 levels) in <top (required)>'

150 runs, 253 assertions, 0 failures, 1 errors, 0 skips
rake aborted!
Command failed with status (1)
```