### PR TITLE
Add basic test for HTML report generation

### DIFF
--- a/test/lib/rubycritic/generators/html_report_test.rb
+++ b/test/lib/rubycritic/generators/html_report_test.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'rubycritic/analysers_runner'
+require 'rubycritic/generators/html_report'
+require 'fakefs_helper'
+
+describe RubyCritic::Generator::HtmlReport do
+  describe '#generate_report' do
+    around do |example|
+      capture_output_streams do
+        with_cloned_fs(&example)
+      end
+    end
+
+    it 'creates the HTML report files' do
+      sample_files = Dir['test/samples/**/*.rb']
+      create_analysed_modules_collection
+      generate_report
+      assert File.file? 'test/samples/overview.html'
+      overview = File.read 'test/samples/overview.html'
+      assert overview.match? '<title>Ruby Critic - Home</title>'
+      assert File.file? 'test/samples/code_index.html'
+      code_index = File.read 'test/samples/code_index.html'
+      sample_files.each do |filename|
+        assert code_index.match? filename.sub('.rb', '.html')
+      end
+    end
+  end
+
+  def create_analysed_modules_collection
+    RubyCritic::Config.root = 'test/samples'
+    RubyCritic::Config.source_control_system = RubyCritic::SourceControlSystem::Git.new
+    analyser_runner = RubyCritic::AnalysersRunner.new('test/samples/')
+    @analysed_modules_collection = analyser_runner.run
+  end
+
+  def generate_report
+    report = RubyCritic::Generator::HtmlReport.new(@analysed_modules_collection)
+    report.generate_report
+  end
+end


### PR DESCRIPTION
This is a naive copy-and-adapt of the existing `json_report_test.rb`; I created it to see if I could work up a test for #372, but I think I'm going to have to concede defeat on that - there's too much mocking going on that I don't understand properly - but I thought this file might at least be a starting point for somebody else to use as a base for adding that test in the future?

Let me know if this looks useful, and if so I'll squash it and do the CHANGELOG thing - probably after you do your imminent release.