### PR TITLE
CI: Drop rbx-3 from matrix, does not install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,11 +15,9 @@ jobs:
     - rvm: ruby-head
     - rvm: jruby-9.1.17.0
       env: JRUBY_OPTS='--debug' # get more accurate coverage data
-    - rvm: rbx-3
   allow_failures:
     - rvm: ruby-head
     - rvm: jruby-9.1.17.0
-    - rvm: rbx-3
   fast_finish: true
 
 script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * [CHANGE] Make Github Linguist ignore vendored files (by [@sl4vr][])
 * [BUGFIX] Fix directory structure of reports when comparing branches (by [@denny][])
 * [BUGFIX] Restrict simplecov to versions before data format changed (by [@denny][])
+* [CHANGE] CI: Drop rbx-3 from matrix, does not install (by [@olleolleolle][])
 
 # v4.5.2 / 2020-08-20 [(commits)](https://github.com/whitesmith/rubycritic/compare/v4.5.1...v4.5.2)
 


### PR DESCRIPTION
This PR changes the CI matrix by removing a not-installable Ruby version (rbx-3).

Inspired by #385.


