### PR TITLE
Include files which have a ruby shebang

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -150,6 +150,7 @@ detectors:
     - RubyCritic::Command::Compare#build_details
     - RubyCritic::Command::Compare#threshold_reached?
     - RubyCritic::Command::Compare#threshold_values_set?
+    - RubyCritic::SourceLocator#ruby_file?
   TooManyInstanceVariables:
     exclude:
     - RubyCritic::Generator::Html::CodeFile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # main [(unreleased)](https://github.com/whitesmith/rubycritic/compare/v4.6.1...main)
 
+* [CHANGE] Include files which have a ruby shebang (by [@stufro][])
+
 # v4.6.1 / 2021-01-28 [(commits)](https://github.com/whitesmith/rubycritic/compare/v4.6.0...v4.6.1)
 
 * [CHANGE] CI: Drop rbx-3 from matrix, does not install (by [@olleolleolle][])

--- a/lib/rubycritic/source_locator.rb
+++ b/lib/rubycritic/source_locator.rb
@@ -7,6 +7,7 @@ module RubyCritic
   class SourceLocator
     RUBY_EXTENSION = '.rb'.freeze
     RUBY_FILES = File.join('**', "*#{RUBY_EXTENSION}")
+    RUBY_SHEBANG = '#!/usr/bin/env ruby'.freeze
 
     def initialize(paths)
       @initial_paths = Array(paths)
@@ -39,7 +40,7 @@ module RubyCritic
       path_list = @initial_paths.flat_map do |path|
         if File.directory?(path)
           Pathname.glob(File.join(path, RUBY_FILES))
-        elsif File.exist?(path) && File.extname(path) == RUBY_EXTENSION
+        elsif File.exist?(path) && ruby_file?(path)
           Pathname.new(path)
         end
       end.compact
@@ -47,6 +48,10 @@ module RubyCritic
       deduplicate_symlinks(path_list) if Config.deduplicate_symlinks
 
       path_list.map(&:cleanpath)
+    end
+
+    def ruby_file?(path)
+      File.extname(path) == RUBY_EXTENSION || File.open(path, &:gets).to_s.match?(RUBY_SHEBANG)
     end
   end
 end

--- a/test/lib/rubycritic/source_locator_test.rb
+++ b/test/lib/rubycritic/source_locator_test.rb
@@ -32,6 +32,11 @@ describe RubyCritic::SourceLocator do
       _(RubyCritic::SourceLocator.new(initial_paths).paths).must_match_array final_paths
     end
 
+    it 'finds files which have a ruby shebang' do
+      paths = ['file_with_ruby_shebang']
+      _(RubyCritic::SourceLocator.new(paths).paths).must_equal paths
+    end
+
     context 'when configured to deduplicate symlinks' do
       it 'favors a file over a symlink if they both point to the same target' do
         RubyCritic::Config.stubs(:deduplicate_symlinks).returns(true)

--- a/test/samples/location/file_with_ruby_shebang
+++ b/test/samples/location/file_with_ruby_shebang
@@ -1,0 +1,1 @@
+#!/usr/bin/env ruby 


### PR DESCRIPTION
Check list:
- [x] Add an entry to the [changelog](/CHANGELOG.md)
- [x] [Squash all commits into a single one](/CONTRIBUTING.md)
- [x] Describe your PR, link issues, etc.

-----
Issue #308 

Implemented by checking the first line of the file for a ruby shebang, it will only check for shebang if the file does not have a .rb file extension.

I added the new private method I created to the .reek.yml to ignore the UtilityFunction warning. I couldn't think of a way to do this that didn't seem like overkill, I'm open to ideas if there's a better way.
