### PR TITLE
Allow the Rake task to accept a custom description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # main [(unreleased)](https://github.com/whitesmith/rubycritic/compare/v4.6.1...main)
 
+* [FEATURE] Allow the Rake task generator to accept a description (by [@anicholson][])
+
 # v4.6.1 / 2021-01-28 [(commits)](https://github.com/whitesmith/rubycritic/compare/v4.6.0...v4.6.1)
 
 * [CHANGE] CI: Drop rbx-3 from matrix, does not install (by [@olleolleolle][])

--- a/README.md
+++ b/README.md
@@ -208,6 +208,22 @@ RubyCritic::RakeTask.new do |task|
 end
 ```
 
+If you wish to create multiple Rake tasks (e.g., for local & for ci-specific configuration), you can do so!
+If you decide to do this, you should provide a clearer description for each task:
+
+```ruby
+# for local
+RubyCritic::RakeTask.new("local", "Run RubyCritic (local configuration)" do |task|
+  # ...
+end
+
+# for CI
+RubyCritic::RakeTask.new("ci", "Run RubyCritic (CI configuration)" do |task|
+  task.options = "--mode-ci"
+  # ...
+end
+```
+
 ## Formatters
 
 See [formatters](docs/formatters.md)

--- a/lib/rubycritic/rake_task.rb
+++ b/lib/rubycritic/rake_task.rb
@@ -36,11 +36,12 @@ module RubyCritic
     # "-p / --path" since that is set separately. Defaults to ''.
     attr_writer :options
 
-    def initialize(name = :rubycritic)
-      @name    = name
-      @paths   = FileList['.']
-      @options = ''
-      @verbose = false
+    def initialize(name = :rubycritic, description = 'Run RubyCritic')
+      @name           = name
+      @description    = description
+      @paths          = FileList['.']
+      @options        = ''
+      @verbose        = false
 
       yield self if block_given?
       define_task
@@ -48,10 +49,10 @@ module RubyCritic
 
     private
 
-    attr_reader :name, :paths, :verbose, :options
+    attr_reader :name, :description, :paths, :verbose, :options
 
     def define_task
-      desc 'Run RubyCritic'
+      desc description
       task(name) { run_task }
     end
 


### PR DESCRIPTION
I want to have multiple Rake tasks in my app: one for local mode and one for ci mode.
Unfortunately, the Rake task class doesn't accept a description, so they both display "Run RubyCritic" in the output of `rake -T`.

This fixes that problem by adding the description as a param to the initializer.

Co-Authored-By: Andy Nicholson <andrew@anicholson.net>

Check list:
- [x] Add an entry to the [changelog](/CHANGELOG.md)
- [x] [Squash all commits into a single one](/CONTRIBUTING.md)
- [x] Describe your PR, link issues, etc.
