### PR TITLE
Drop support for JRuby 9.1.x

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,8 +51,7 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true
-      - name: bundle install
-        run: bundle install
+          cache-version: 1
       - name: Run Cucumber
         run: bundle exec cucumber features --format progress --color
 
@@ -87,8 +86,7 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true
-      - name: bundle install
-        run: bundle install
+          cache-version: 1
       - name: Run Rubocop
         run: bundle exec rubocop
 
@@ -123,8 +121,7 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true
-      - name: bundle install
-        run: bundle install
+          cache-version: 1
       - name: Run Reek
         run: bundle exec rake reek
 
@@ -160,8 +157,7 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true
-      - name: bundle install
-        run: bundle install
+          cache-version: 1
       - name: Run Unit tests
         run: bundle exec rake test
 
@@ -176,7 +172,6 @@ jobs:
         with:
           ruby-version: 3.0
           bundler-cache: true
-      - name: bundle install
-        run: bundle install
+          cache-version: 1
       - name: Run markdownlint
         run: bundle exec mdl .

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,8 +38,6 @@ jobs:
         include:
           - ruby-version: ruby-head
             experimental: true
-          - ruby-version: jruby-9.1.17.0
-            experimental: true
           - ruby-version: jruby-9.2
             experimental: true
           - ruby-version: jruby-9.3
@@ -72,8 +70,6 @@ jobs:
         experimental: [false]
         include:
           - ruby-version: ruby-head
-            experimental: true
-          - ruby-version: jruby-9.1.17.0
             experimental: true
           - ruby-version: jruby-9.2
             experimental: true
@@ -108,8 +104,6 @@ jobs:
         include:
           - ruby-version: ruby-head
             experimental: true
-          - ruby-version: jruby-9.1.17.0
-            experimental: true
           - ruby-version: jruby-9.2
             experimental: true
           - ruby-version: jruby-9.3
@@ -142,8 +136,6 @@ jobs:
         experimental: [false]
         include:
           - ruby-version: ruby-head
-            experimental: true
-          - ruby-version: jruby-9.1.17.0
             experimental: true
           - ruby-version: jruby-9.2
             experimental: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * [FEATURE] Allow the Rake task generator to accept a description (by [@anicholson][])
 * [CHANGE] Replace travis-ci with Github Actions for contributors (by [@RyanSnodgrass][])
+* [CHANGE] Drop support for JRuby 9.1.x (by [@RyanSnodgrass][])
 
 # v4.6.1 / 2021-01-28 [(commits)](https://github.com/whitesmith/rubycritic/compare/v4.6.0...v4.6.1)
 
@@ -369,3 +370,4 @@
 [@jackcasey]: https://github.com/jackcasey
 [@sl4vr]: https://github.com/sl4vr
 [@denny]: https://github.com/denny
+[@RyanSnodgrass]: https://github.com/RyanSnodgrass

--- a/rubycritic.gemspec
+++ b/rubycritic.gemspec
@@ -44,7 +44,11 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'appraisal'
   spec.add_development_dependency 'aruba', '~> 0.12', '>= 0.12.0'
   spec.add_development_dependency 'bundler', '~> 2.0', '>= 2.0.0'
-  spec.add_development_dependency 'byebug', '~> 11.0', '>= 10.0'
+  if RUBY_PLATFORM == 'java'
+    spec.add_development_dependency 'pry-debugger-jruby'
+  else
+    spec.add_development_dependency 'byebug', '~> 11.0', '>= 10.0'
+  end
   spec.add_development_dependency 'cucumber', '~> 3.0', '>= 2.2.0'
   spec.add_development_dependency 'diff-lcs', '~> 1.3'
   spec.add_development_dependency 'fakefs', '~> 1.3.2', '< 2.0.0'


### PR DESCRIPTION
While cleaning up a possible bug in Github Actions I've made some more updates:

- Dropping support for JRuby 9.1.x. It evaluates to Ruby 2.3.3 which we don't support anymore and won't `bundle install`
- [Byebug is incompatible with JRuby](https://github.com/deivid-rodriguez/byebug/issues/179#issuecomment-152727003). Install an appropriate debugger if on MRI or JVM
- With the appropriate debugger, JRuby builds 9.2 and 9.3 all pass except one now! We're down to only 2 failing builds 🍾 

Check list:
- [x] Add an entry to the [changelog](/CHANGELOG.md)
- [ ] [Squash all commits into a single one](/CONTRIBUTING.md)
- [x] Describe your PR, link issues, etc.

If you want these commits squashed let me know. I felt like they were all separate ideas so I left them.