### PR TITLE
Bugfix: Exit with 0 or 1 from Rake Task

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -156,6 +156,7 @@ detectors:
     - RubyCritic::Generator::Html::CodeFile
     - RubyCritic::Generator::Html::Overview
     - RubyCritic::Generator::Html::SmellsIndex
+    - RubyCritic::RakeTask
   ControlParameter:
     exclude:
     - RubyCritic::CommandFactory#self.command_class

--- a/.reek.yml
+++ b/.reek.yml
@@ -86,6 +86,7 @@ detectors:
     - RubyCritic::RakeTask#options
     - RubyCritic::RakeTask#paths
     - RubyCritic::RakeTask#verbose
+    - RubyCritic::RakeTask#fail_on_error
   DuplicateMethodCall:
     exclude:
     - RubyCritic::Analyser::Churn#run

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * [FEATURE] Allow the Rake task generator to accept a description (by [@anicholson][])
 * [CHANGE] Replace travis-ci with Github Actions for contributors (by [@RyanSnodgrass][])
+* [BUGFIX] Exit with 0 or 1 from Rake Task. Fixes #214 (by [@RyanSnodgrass][])
 
 # v4.6.1 / 2021-01-28 [(commits)](https://github.com/whitesmith/rubycritic/compare/v4.6.0...v4.6.1)
 
@@ -369,3 +370,4 @@
 [@jackcasey]: https://github.com/jackcasey
 [@sl4vr]: https://github.com/sl4vr
 [@denny]: https://github.com/denny
+[@RyanSnodgrass]: https://github.com/RyanSnodgrass

--- a/README.md
+++ b/README.md
@@ -196,6 +196,9 @@ RubyCritic::RakeTask.new do |task|
 
   # Defaults to false
   task.verbose = true
+
+  # Fail the Rake task if RubyCritic doesn't pass. Defaults to true
+  task.fail_on_error = true
 end
 ```
 

--- a/features/rake_task.feature
+++ b/features/rake_task.feature
@@ -63,3 +63,20 @@ Feature: RubyCritic can be run via Rake task
       """
       Score (93.19) is below the minimum 95
       """
+    And the exit status indicates an error
+
+  Scenario: 'fail_on_error' when false will exit 0 even when RubyCritic fails
+    Given the smelly file 'smelly.rb'
+    When I run rake rubycritic with:
+      """
+      RubyCritic::RakeTask.new do |t|
+        t.paths = FileList['smelly.*']
+        t.fail_on_error = false
+        t.options = '--no-browser -f console --minimum-score 95'
+      end
+      """
+    Then the output should contain:
+      """
+      Score (93.19) is below the minimum 95
+      """
+    And the exit status indicates a success

--- a/lib/rubycritic/rake_task.rb
+++ b/lib/rubycritic/rake_task.rb
@@ -37,12 +37,17 @@ module RubyCritic
     # "-p / --path" since that is set separately. Defaults to ''.
     attr_writer :options
 
+    # Whether or not to fail Rake task when RubyCritic does not pass.
+    # Defaults to true.
+    attr_writer :fail_on_error
+
     def initialize(name = :rubycritic, description = 'Run RubyCritic')
       @name           = name
       @description    = description
       @paths          = FileList['.']
       @options        = ''
       @verbose        = false
+      @fail_on_error  = true
 
       yield self if block_given?
       define_task
@@ -50,7 +55,7 @@ module RubyCritic
 
     private
 
-    attr_reader :name, :description, :paths, :verbose, :options
+    attr_reader :name, :description, :paths, :verbose, :options, :fail_on_error
 
     def define_task
       desc description
@@ -58,12 +63,16 @@ module RubyCritic
     end
 
     def run_task
-      if verbose
-        puts "\n\n!!! Running `#{name}` rake command\n"
-        puts "!!! Inspecting #{paths} #{options.empty? ? '' : "with options #{options}"}\n\n"
-      end
+      print_starting_up_output if verbose
       application = RubyCritic::Cli::Application.new(options_as_arguments + paths)
-      application.execute
+      return unless application.execute.nonzero? && fail_on_error
+
+      abort('RubyCritic did not pass - exiting!')
+    end
+
+    def print_starting_up_output
+      puts "\n\n!!! Running `#{name}` rake command\n"
+      puts "!!! Inspecting #{paths} #{options.empty? ? '' : "with options #{options}"}\n\n"
     end
 
     def options_as_arguments

--- a/lib/rubycritic/rake_task.rb
+++ b/lib/rubycritic/rake_task.rb
@@ -21,7 +21,6 @@ module RubyCritic
   #     task.paths = FileList['lib/**/*.rb', 'spec/**/*.rb']
   #   end
   #
-  # @quality :reek:TooManyInstanceVariables { max_instance_variables: 5 }
   class RakeTask < ::Rake::TaskLib
     # Name of RubyCritic task. Defaults to :rubycritic.
     attr_writer :name


### PR DESCRIPTION
Fixes #214

The rake task always returns a success `0` code even when it fails. I need it to return a `1` when my code doesn't meet the minimum score for CI purposes.

This will break the rake task behavior for the "it's not a bug, it's a feature" people relying on this. I've added a `fail_on_error` attribute to provide backwards compatibility. If they set that to `false` then the rake task reports that the minimum score wasn't met, but still exits with a success.

This matches how [rubocop](https://github.com/rubocop/rubocop/blob/master/lib/rubocop/rake_task.rb#L43) and [reek](https://github.com/troessner/reek/blob/master/lib/reek/rake/task.rb#L108) handle this.

Included is a cucumber spec detailing this change.

Check list:
- [x] Add an entry to the [changelog](/CHANGELOG.md)
- [x] [Squash all commits into a single one](/CONTRIBUTING.md)
- [x] Describe your PR, link issues, etc.
