### PR TITLE
Prepare v4.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
-# main [(unreleased)](https://github.com/whitesmith/rubycritic/compare/v4.6.1...main)
+# main [(unreleased)](https://github.com/whitesmith/rubycritic/compare/v4.7.0...main)
+
+# v4.7.0 / 2022-05-06 [(commits)](https://github.com/whitesmith/rubycritic/compare/v4.6.1...v4.7.0)
 
 * [FEATURE] Allow the Rake task generator to accept a description (by [@anicholson][])
 * [CHANGE] Replace travis-ci with Github Actions for contributors (by [@RyanSnodgrass][])

--- a/lib/rubycritic/version.rb
+++ b/lib/rubycritic/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RubyCritic
-  VERSION = '4.6.1'.freeze
+  VERSION = '4.7.0'.freeze
 end


### PR DESCRIPTION
Check list:
- [x] Add an entry to the [changelog](/CHANGELOG.md)
- [x] [Squash all commits into a single one](/CONTRIBUTING.md)
- [x] Describe your PR, link issues, etc.

This PR closes https://github.com/whitesmith/rubycritic/issues/404.

We updated the changelog and rubycritic/version in preparation for the v4.70 release.