### PR TITLE
Fix some typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * [CHANGE] Drop support for Ruby 2.4.x (by [@rishijain][])
 * [FEATURE] Add ruby_extensions configuration option (by [@stufro][])
 * [CHANGE] Include files which have a ruby shebang (by [@stufro][])
+* [CHANGE] Fix some typos (by [@ydah][])
 
 # v4.7.0 / 2022-05-06 [(commits)](https://github.com/whitesmith/rubycritic/compare/v4.6.1...v4.7.0)
 
@@ -382,3 +383,4 @@
 [@sl4vr]: https://github.com/sl4vr
 [@denny]: https://github.com/denny
 [@RyanSnodgrass]: https://github.com/RyanSnodgrass
+[@ydah]: https://github.com/ydah

--- a/docs/formatters.md
+++ b/docs/formatters.md
@@ -1,7 +1,7 @@
 # Concept of formatters
 
 The formatters goal is to allow to extract the logic around the representation of each rubycritic run from the gathering of results.
-By delegating to a formatter you can write your own *custom* report for rubycritic and being indepedent on the logic.
+By delegating to a formatter you can write your own *custom* report for rubycritic and being independent on the logic.
 
 ## Formatters interface
 
@@ -57,9 +57,9 @@ See the [Rakefile](https://github.com/MarcGrimme/repo-small-badge/blob/master/Ra
 
 ### With classname and classpath
 
-When *rubycritic* is called outside of the structure that has to be **criticed** with just calling the command.
+When *rubycritic* is called outside of the structure that has to be **criticized** with just calling the command.
 The path to load as well, as the fully qualified classname of the formatter, have to be passed.
-This happens with the `--formater` option followed by the path to require (*requirepath*) a `:` as a separator and the fully qualified *classname*.
+This happens with the `--formatter` option followed by the path to require (*requirepath*) a `:` as a separator and the fully qualified *classname*.
 An example could look as follows:
 
 ``` shell

--- a/features/command_line_interface/options.feature
+++ b/features/command_line_interface/options.feature
@@ -34,7 +34,7 @@ Feature: RubyCritic can be controlled using command-line options
                                            Instantiate a given class as formatter and call report for reporting.
                                            Two ways are possible to load the formatter.
                                            If the class is not autorequired the REQUIREPATH can be given together
-                                           with the CLASSNAME to be loaded seperated by a :.
+                                           with the CLASSNAME to be loaded separated by a :.
                                            Example: rubycritic/markdown/reporter.rb:RubyCritic::MarkDown::Reporter
                                            or if the file is already required the CLASSNAME is enough
                                            Example: RubyCritic::MarkDown::Reporter

--- a/lib/rubycritic/cli/options/argv.rb
+++ b/lib/rubycritic/cli/options/argv.rb
@@ -57,7 +57,7 @@ module RubyCritic
               'Instantiate a given class as formatter and call report for reporting.',
               'Two ways are possible to load the formatter.',
               'If the class is not autorequired the REQUIREPATH can be given together',
-              'with the CLASSNAME to be loaded seperated by a :.',
+              'with the CLASSNAME to be loaded separated by a :.',
               'Example: rubycritic/markdown/reporter.rb:RubyCritic::MarkDown::Reporter',
               'or if the file is already required the CLASSNAME is enough',
               'Example: RubyCritic::MarkDown::Reporter',
@@ -130,6 +130,7 @@ module RubyCritic
         attr_accessor :mode, :root, :formats, :formatters, :deduplicate_symlinks,
                       :suppress_ratings, :minimum_score, :churn_after, :no_browser,
                       :parser, :base_branch, :feature_branch, :threshold_score
+
         def paths
           @argv unless @argv.empty?
         end

--- a/test/lib/rubycritic/source_control_systems/git/churn_test.rb
+++ b/test/lib/rubycritic/source_control_systems/git/churn_test.rb
@@ -80,7 +80,7 @@ describe RubyCritic::SourceControlSystem::Git::Churn do
     end
 
     it 'returns 0 for an uncommited file' do
-      _(churn.revisions_count('non_existant_file')).must_equal 0
+      _(churn.revisions_count('non_existent_file')).must_equal 0
     end
 
     context 'with churn_after option specified' do
@@ -116,7 +116,7 @@ describe RubyCritic::SourceControlSystem::Git::Churn do
     end
 
     it 'returns nil for an uncommited file' do
-      assert_nil(churn.date_of_last_commit('non_existant_file'))
+      assert_nil(churn.date_of_last_commit('non_existent_file'))
     end
   end
 end


### PR DESCRIPTION
This PR is fix some typos:

- "formater" -> "formatter"
- "criticed" -> "criticized"
- "indepedent" -> "independent"
- "seperated" -> "separated"
- "existant" -> "existent"

Commits are separated for clarity of differences, but will be squashed if necessary.

Check list:
- [x] Add an entry to the [changelog](/CHANGELOG.md)
- [x] [Squash all commits into a single one](/CONTRIBUTING.md)
- [x] Describe your PR, link issues, etc.
