### PR TITLE
Add Ruby 3.1 to the test matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,6 +64,7 @@ jobs:
           - '2.6'
           - '2.7'
           - '3.0'
+          - '3.1'
         experimental: [false]
         include:
           - ruby-version: 'ruby-head'
@@ -95,6 +96,7 @@ jobs:
           - '2.6'
           - '2.7'
           - '3.0'
+          - '3.1'
         experimental: [false]
         include:
           - ruby-version: 'ruby-head'
@@ -126,6 +128,7 @@ jobs:
           - '2.6'
           - '2.7'
           - '3.0'
+          - '3.1'
         experimental: [false]
         include:
           - ruby-version: 'ruby-head'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # main [(unreleased)](https://github.com/whitesmith/rubycritic/compare/v4.7.0...main)
 
+* [CHORE] Test gem with Ruby 3.1 (by [@etagwerker][])
 * [CHANGE] Drop support for Ruby 2.5.x (by [@cleicar][])
 * [CHANGE] Drop support for Ruby 2.4.x (by [@rishijain][])
 * [FEATURE] Add ruby_extensions configuration option (by [@stufro][])


### PR DESCRIPTION
We want to test with Ruby 3.1 to make sure that everything works as expected.

Check list:
- [ ] Add an entry to the [changelog](/CHANGELOG.md)
- [x] [Squash all commits into a single one](/CONTRIBUTING.md)
- [x] Describe your PR, link issues, etc.
