### PR TITLE
[FIX] Restore missing smell status label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * [CHANGE] Include files which have a ruby shebang (by [@stufro][])
 * [CHANGE] Fix some typos (by [@ydah][])
 * [CHANGE] Remove wrong Rubocop reference in contributing file (by [@itsmeurbi]: https://github.com/itsmeurbi)
+* [BUGFIX] Restore missing smell status label (by [@itsmeurbi]: https://github.com/itsmeurbi)
 
 # v4.7.0 / 2022-05-06 [(commits)](https://github.com/whitesmith/rubycritic/compare/v4.6.1...v4.7.0)
 

--- a/lib/rubycritic/core/smell.rb
+++ b/lib/rubycritic/core/smell.rb
@@ -12,7 +12,7 @@ module RubyCritic
     attribute :locations, Array, default: []
     attribute :message
     attribute :score
-    attribute :status
+    attribute :status, Symbol, default: :new
     attribute :type
     attribute :analyser
 

--- a/lib/rubycritic/generators/html/templates/smells_index.html.erb
+++ b/lib/rubycritic/generators/html/templates/smells_index.html.erb
@@ -32,7 +32,7 @@
                 <% if @show_status %>
                   <ul class="nav nav-pills">
                     <li role="presentation">
-                      <td class="centered-cell"><span class="status-<%= smell.status %> circled-text circle"><%= smell.status %></span></td>
+                      <span class="status-<%= smell.status %> circled-text circle"><%= smell.status %></span>
                     </li>
                   </ul>
                 <% end %>

--- a/test/lib/rubycritic/core/smell_test.rb
+++ b/test/lib/rubycritic/core/smell_test.rb
@@ -102,4 +102,16 @@ describe RubyCritic::Smell do
       assert_raises { smell.doc_url }
     end
   end
+
+  describe 'default attributes' do
+    it 'has :new for status' do
+      smell = RubyCritic::Smell.new
+      _(smell.status).must_equal(:new)
+    end
+
+    it 'is has an empty array for locations' do
+      smell = RubyCritic::Smell.new
+      _(smell.locations).must_equal([])
+    end
+  end
 end


### PR DESCRIPTION
This PR will resolve issue https://github.com/whitesmith/rubycritic/issues/146

Check list:
- [x] Add an entry to the [changelog](/CHANGELOG.md)
- [ ] [Squash all commits into a single one](/CONTRIBUTING.md)
- [x] Describe your PR, link issues, etc.

## Issue description:
Introducen [here](https://github.com/whitesmith/rubycritic/pull/115/files#diff-feea086d0ffc4a6b0de3a916f4aa8bdc2e7c0b423e5deab46857b21e7548d092R18%E2%80%A8)

 `RevisionComparator#statuses=` is skipping `SmellsStatusSetter` if no modules were analyzed before.
As the class name indicates, `SmellsStatusSetter` is responsible for setting the `status` field to smell objects. So because this step is being skipped first time you run rubycritic, `smells` status is always `nil`

## Proposal:
My first thought was to remove the early return and make `analysed_modules_before` an empty array when rubycritics is run for the first time. BUT I believe there was a reason for skipping this step, so I come up with this: 
Consider all new Smell instances as :new(i.e make `status = :new` by default,)


## Screensthots:

Before:
￼
<img width="1552" alt="Screen Shot 2022-10-23 at 12 04 54" src="https://user-images.githubusercontent.com/26292224/197417095-a171a2e8-2380-47c2-a803-add881a7b48e.png">


After:
<img width="1552" alt="Screen Shot 2022-10-23 at 12 03 27" src="https://user-images.githubusercontent.com/26292224/197417107-fa64c687-d89d-4529-8b3c-4adbe2fcfd96.png">

￼

Notes:
I’m also fixing an issue I found in `lib/rubycritic/generators/html/templates/smells_index.html.erb`. Basically I removed an extra-no-needed `td` that was creating a new cell