### PR TITLE
[FIX] Remove wrong Rubocop reference from contributing file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [FEATURE] Add ruby_extensions configuration option (by [@stufro][])
 * [CHANGE] Include files which have a ruby shebang (by [@stufro][])
 * [CHANGE] Fix some typos (by [@ydah][])
+* [CHANGE] Remove wrong Rubocop reference in contributing file (by [@itsmeurbi]: https://github.com/itsmeurbi)
 
 # v4.7.0 / 2022-05-06 [(commits)](https://github.com/whitesmith/rubycritic/compare/v4.6.1...v4.7.0)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,4 +90,4 @@ Here are a few examples:
 * Start with the change type BUGFIX / CHANGE / FEATURE.
 * Describe the brief of the change.
 * At the end of the entry, add an implicit link to your GitHub user page as `([@username][])`.
-* If this is your first contribution to RuboCop project, add a link definition for the implicit link to the bottom of the changelog as `[@username]: https://github.com/username`.
+* If this is your first contribution to RubyCritic project, add a link definition for the implicit link to the bottom of the changelog as `[@username]: https://github.com/username`.


### PR DESCRIPTION
This PR will solve issue https://github.com/whitesmith/rubycritic/issues/417

Check list:
- [x] Add an entry to the [changelog](/CHANGELOG.md)
- [x] [Squash all commits into a single one](/CONTRIBUTING.md)
- [x] Describe your PR, link issues, etc.


## Description:
[CONTRIBUTING.md](https://github.com/whitesmith/rubycritic/blob/main/CONTRIBUTING.md) has a reference to Rubocop that I believe should be RubyCritic instead