### PR TITLE
Scope churn calculation to provided paths

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -69,6 +69,7 @@ detectors:
     - RubyCritic::Configuration#mode
     - RubyCritic::Configuration#no_browser
     - RubyCritic::Configuration#open_with
+    - RubyCritic::Configuration#paths
     - RubyCritic::Configuration#source_control_system
     - RubyCritic::Configuration#suppress_ratings
     - RubyCritic::Configuration#base_branch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * [CHORE] Test gem with Ruby 3.2 (by [@etagwerker][])
 * [CHORE] Test gem with Ruby 3.1 (by [@etagwerker][])
+* [CHANGE] Scope churn calculation to provided paths (by [@Fito][])
 * [CHANGE] Drop support for Ruby 2.5.x (by [@cleicar][])
 * [CHANGE] Drop support for Ruby 2.4.x (by [@rishijain][])
 * [FEATURE] Add ruby_extensions configuration option (by [@stufro][])

--- a/README.md
+++ b/README.md
@@ -94,7 +94,8 @@ current directory:
 $ rubycritic
 ```
 
-Alternatively you can pass `rubycritic` a list of files and directories to check:
+Alternatively you can pass `rubycritic` a list of files and directories.
+The analysis will be scoped to the provided files and directories:
 
 ```bash
 $ rubycritic app lib/foo.rb
@@ -146,7 +147,7 @@ no_browser: true # default is false
 formats: # Available values are: html, json, console, lint. Default value is html.
   - console
 minimum_score: 95 # default is 0
-paths: # Files to analyse.
+paths: # Files to analyse. Churn calculation is scoped to these files when using Git SCM.
   - 'app/controllers/'
   - 'app/models/'
 ```

--- a/lib/rubycritic/configuration.rb
+++ b/lib/rubycritic/configuration.rb
@@ -10,7 +10,7 @@ module RubyCritic
                   :feature_branch, :base_branch_score, :feature_branch_score,
                   :base_root_directory, :feature_root_directory,
                   :compare_root_directory, :threshold_score, :base_branch_collection,
-                  :feature_branch_collection, :churn_after, :ruby_extensions
+                  :feature_branch_collection, :churn_after, :ruby_extensions, :paths
 
     def set(options)
       self.mode = options[:mode] || :default
@@ -20,9 +20,14 @@ module RubyCritic
       self.open_with = options[:open_with]
       self.no_browser = options[:no_browser]
       self.threshold_score = options[:threshold_score].to_i
-      self.ruby_extensions = options[:ruby_extensions] || %w[.rb .rake .thor]
+      setup_analysis_targets(options)
       setup_version_control(options)
       setup_formats(options)
+    end
+
+    def setup_analysis_targets(options)
+      self.paths = options[:paths] || ['.']
+      self.ruby_extensions = options[:ruby_extensions] || %w[.rb .rake .thor]
     end
 
     def setup_version_control(options)

--- a/lib/rubycritic/source_control_systems/git.rb
+++ b/lib/rubycritic/source_control_systems/git.rb
@@ -30,7 +30,7 @@ module RubyCritic
       end
 
       def churn
-        @churn ||= Churn.new(churn_after: Config.churn_after)
+        @churn ||= Churn.new(churn_after: Config.churn_after, paths: Config.paths)
       end
 
       def revisions_count(path)

--- a/test/lib/rubycritic/source_control_systems/git_test.rb
+++ b/test/lib/rubycritic/source_control_systems/git_test.rb
@@ -11,4 +11,24 @@ describe RubyCritic::SourceControlSystem::Git do
       RubyCritic::SourceControlSystem::Git.switch_branch('_branch_')
     end
   end
+
+  describe '#churn' do
+    let(:git) { RubyCritic::SourceControlSystem::Git.new }
+    let(:churn_after) { 'churn_after_date' }
+    let(:paths) { ['path/1', 'path/2'] }
+
+    before do
+      RubyCritic::SourceControlSystem::Git.stubs(:git).returns('')
+      RubyCritic::Config.stubs(:churn_after).returns(churn_after)
+      RubyCritic::Config.stubs(:paths).returns(paths)
+    end
+
+    it 'should pass the churn_after and path options to new Churn objects' do
+      RubyCritic::SourceControlSystem::Git::Churn.expects(:new).with(
+        churn_after: churn_after, paths: paths
+      )
+
+      git.churn
+    end
+  end
 end


### PR DESCRIPTION
The churn calculation was hard-coded to `.`
This meant that `rubycritic` would run a `git log` command for the entire repository regardless of the paths specified with running the `rubycritic` command.

Running `git log` for large codebases with many years of commits can take over 30 minutes. This is particularly wasteful in mono-repositories with distinct projects that might be better analyzed separately (large parts of the repository might not even be Ruby code!)

The time to generate a report decreases significantly when scoping churn to the paths provided to the `rubycritic` command.

Other things to note:
- Git log's --follow option can only handle a single path at a time. Therefore we need to run multiple git log commands when multiple path arguments are provided. The results are still merged together.

- The initializer for SourceControlSystem::Git::Churn was already at the maximum number of statements allowed. I extracted `renames` into a memoized method to make room for the new parameter.

- Added tests for SourceControlSystem::Git#churn to ensure SourceControlSystem::Git::Churn is instantiated with the correct options. This also adds a bit of coverage on Config.paths needing to exist.

Check list:
- [x] Add an entry to the [changelog](/CHANGELOG.md)
- [x] [Squash all commits into a single one](/CONTRIBUTING.md)
- [x] Describe your PR, link issues, etc.
