### PR TITLE
Configurable coverage path

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -3,6 +3,9 @@ detectors:
   InstanceVariableAssumption:
     exclude:
       - RubyCritic::Analyser::Coverage
+  TooManyMethods:
+    exclude:
+      - RubyCritic::Cli::Options::File
   IrresponsibleModule:
     exclude:
     - RubyCritic::Analyser::Attributes
@@ -68,6 +71,7 @@ detectors:
     - RubyCritic::Configuration#format
     - RubyCritic::Configuration#mode
     - RubyCritic::Configuration#no_browser
+    - RubyCritic::Configuration#coverage_path
     - RubyCritic::Configuration#open_with
     - RubyCritic::Configuration#source_control_system
     - RubyCritic::Configuration#suppress_ratings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [CHANGE] Fix some typos (by [@ydah][])
 * [CHANGE] Remove wrong Rubocop reference in contributing file (by [@itsmeurbi]: https://github.com/itsmeurbi)
 * [BUGFIX] Restore missing smell status label (by [@itsmeurbi]: https://github.com/itsmeurbi)
+* [FEATURE] Add coverage_path configuration option (by [@exoego][])
 
 # v4.7.0 / 2022-05-06 [(commits)](https://github.com/whitesmith/rubycritic/compare/v4.6.1...v4.7.0)
 
@@ -386,3 +387,4 @@
 [@denny]: https://github.com/denny
 [@RyanSnodgrass]: https://github.com/RyanSnodgrass
 [@ydah]: https://github.com/ydah
+[@exoego]: https://github.com/exoego

--- a/README.md
+++ b/README.md
@@ -108,19 +108,20 @@ For a full list of the command-line options run:
 $ rubycritic --help
 ```
 
-| Command flag                        | Description                                                     |
-|-------------------------------------|-----------------------------------------------------------------|
-| `-v` / `--version`                  | Displays the current version and exits                          |
-| `-p` / `--path`                     | Set path where report will be saved (tmp/rubycritic by default) |
-| `-f` / `--format`                   | Report smells in the given format(s)<sup>1</sup>                |
-| `--custom-format path:classname`    | Load and instantiate custom formatter(s)<sup>2</sup>            |
-| `-s` / `--minimum-score`            | Set a minimum score (FLOAT: ex: 96.28), default: 0              |
-| `-m` / `--mode-ci`                  | Use CI mode<sup>3</sup>                                         |
-| `-b` / `--branch`                   | Set branch to compare                                           |
-| `-t` / `--maximum-decrease`         | Threshold for score difference between two branches<sup>4</sup> |
-| `--deduplicate-symlinks`            | De-duplicate symlinks based on their final target               |
-| `--suppress-ratings`                | Suppress letter ratings                                         |
-| `--no-browser`                      | Do not open html report with browser                            |
+| Command flag                     | Description                                                     |
+|----------------------------------|-----------------------------------------------------------------|
+| `-v` / `--version`               | Displays the current version and exits                          |
+| `-p` / `--path`                  | Set path where report will be saved (tmp/rubycritic by default) |
+| `--coverage-path`                | Set path where SimpleCov will be saved (./coverage by default)  |
+| `-f` / `--format`                | Report smells in the given format(s)<sup>1</sup>                |
+| `--custom-format path:classname` | Load and instantiate custom formatter(s)<sup>2</sup>            |
+| `-s` / `--minimum-score`         | Set a minimum score (FLOAT: ex: 96.28), default: 0              |
+| `-m` / `--mode-ci`               | Use CI mode<sup>3</sup>                                         |
+| `-b` / `--branch`                | Set branch to compare                                           |
+| `-t` / `--maximum-decrease`      | Threshold for score difference between two branches<sup>4</sup> |
+| `--deduplicate-symlinks`         | De-duplicate symlinks based on their final target               |
+| `--suppress-ratings`             | Suppress letter ratings                                         |
+| `--no-browser`                   | Do not open html report with browser                            |
 
 1. Available output formats:
 - `html` (default; will open in a browser)
@@ -141,6 +142,7 @@ mode_ci:
   branch: 'production' # default is master
 branch: 'production' # default is master
 path: '/tmp/mycustompath' # Set path where report will be saved (tmp/rubycritic by default)
+coverage_path: '/tmp/coverage' # Set path where SimpleCov coverage will be saved (./coverage by default)
 threshold_score: 10 # default is 0
 deduplicate_symlinks: true # default is false
 suppress_ratings: true # default is false

--- a/features/command_line_interface/options.feature
+++ b/features/command_line_interface/options.feature
@@ -47,6 +47,7 @@ Feature: RubyCritic can be controlled using command-line options
               --deduplicate-symlinks       De-duplicate symlinks based on their final target
               --suppress-ratings           Suppress letter ratings
               --no-browser                 Do not open html report with browser
+              --coverage-path [PATH]       SimpleCov coverage will be saved (./coverage by default)
           -v, --version                    Show gem's version
           -h, --help                       Show this message
 

--- a/lib/rubycritic/analysers/coverage.rb
+++ b/lib/rubycritic/analysers/coverage.rb
@@ -48,6 +48,9 @@ module RubyCritic
 
       # The path to the cache file
       def resultset_path
+        if (cp = Config.coverage_path)
+          SimpleCov.coverage_dir(cp)
+        end
         File.join(SimpleCov.coverage_path, RESULTSET_FILENAME)
       end
 

--- a/lib/rubycritic/cli/options/argv.rb
+++ b/lib/rubycritic/cli/options/argv.rb
@@ -95,6 +95,10 @@ module RubyCritic
               self.no_browser = true
             end
 
+            opts.on('--coverage-path [PATH]', 'SimpleCov coverage will be saved (./coverage by default)') do |path|
+              @coverage_path = path
+            end
+
             opts.on_tail('-v', '--version', "Show gem's version") do
               self.mode = :version
             end
@@ -129,7 +133,7 @@ module RubyCritic
 
         attr_accessor :mode, :root, :formats, :formatters, :deduplicate_symlinks,
                       :suppress_ratings, :minimum_score, :churn_after, :no_browser,
-                      :parser, :base_branch, :feature_branch, :threshold_score
+                      :parser, :base_branch, :feature_branch, :threshold_score, :coverage_path
 
         def paths
           @argv unless @argv.empty?

--- a/lib/rubycritic/cli/options/file.rb
+++ b/lib/rubycritic/cli/options/file.rb
@@ -22,6 +22,7 @@ module RubyCritic
           {
             mode: mode,
             root: root,
+            coverage_path: coverage_path,
             formats: formats,
             deduplicate_symlinks: deduplicate_symlinks,
             paths: paths,
@@ -57,6 +58,10 @@ module RubyCritic
 
         def root
           options['path']
+        end
+
+        def coverage_path
+          options['coverage_path']
         end
 
         def threshold_score

--- a/lib/rubycritic/configuration.rb
+++ b/lib/rubycritic/configuration.rb
@@ -6,7 +6,7 @@ module RubyCritic
   class Configuration
     attr_reader :root
     attr_accessor :source_control_system, :mode, :formats, :formatters, :deduplicate_symlinks,
-                  :suppress_ratings, :open_with, :no_browser, :base_branch,
+                  :suppress_ratings, :open_with, :no_browser, :base_branch, :coverage_path,
                   :feature_branch, :base_branch_score, :feature_branch_score,
                   :base_root_directory, :feature_root_directory,
                   :compare_root_directory, :threshold_score, :base_branch_collection,
@@ -19,6 +19,7 @@ module RubyCritic
       self.suppress_ratings = options[:suppress_ratings]
       self.open_with = options[:open_with]
       self.no_browser = options[:no_browser]
+      self.coverage_path = options[:coverage_path]
       self.threshold_score = options[:threshold_score].to_i
       self.ruby_extensions = options[:ruby_extensions] || %w[.rb .rake .thor]
       setup_version_control(options)


### PR DESCRIPTION
Addresses https://github.com/whitesmith/rubycritic/issues/402#issuecomment-1337312162
This PR adds `--coverage-path PATH` option that is passed to `SimpleCov.coverage_dir(cp)`. 

Check list:
- [x] Add an entry to the [changelog](/CHANGELOG.md)
- [x] [Squash all commits into a single one](/CONTRIBUTING.md)
- [x] Describe your PR, link issues, etc.
