### PR TITLE
Support a branch in detached HEAD state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [CHANGE] Fix some typos (by [@ydah][])
 * [CHANGE] Remove wrong Rubocop reference in contributing file (by [@itsmeurbi]: https://github.com/itsmeurbi)
 * [BUGFIX] Restore missing smell status label (by [@itsmeurbi]: https://github.com/itsmeurbi)
+* [FEATURE] Support a branch in 'detached HEAD' state (by [@h-r-k-matsumoto]: https://github.com/h-r-k-matsumoto)
 
 # v4.7.0 / 2022-05-06 [(commits)](https://github.com/whitesmith/rubycritic/compare/v4.6.1...v4.7.0)
 

--- a/lib/rubycritic/source_control_systems/git.rb
+++ b/lib/rubycritic/source_control_systems/git.rb
@@ -81,7 +81,9 @@ module RubyCritic
 
       def self.current_branch
         branch_list = `git branch`
-        branch_list.match(/\*.*$/)[0].gsub('* ', '')
+        branch = branch_list.match(/\*.*$/)[0].gsub('* ', '')
+        branch = branch.gsub(/\(HEAD detached at (.*)\)$/, '\1') if branch =~ /\(HEAD detached at (.*)\)$/
+        branch
       end
 
       private


### PR DESCRIPTION
This PR would resolve issue #346

The code below has a problem if check out a branch in the state of `detached HEAD`.
https://github.com/whitesmith/rubycritic/blob/main/lib/rubycritic/source_control_systems/git.rb#L82-L85

Even in that case, it can be run successfully with this change.

Check list:
- [x] Add an entry to the [changelog](/CHANGELOG.md)
- [x] [Squash all commits into a single one](/CONTRIBUTING.md)
- [x] Describe your PR, link issues, etc.
