### PR TITLE
Add ruby 3.2 to Github Action matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,6 +33,7 @@ jobs:
           - '2.7'
           - '3.0'
           - '3.1'
+          - '3.2'
         experimental: [false]
         include:
           - ruby-version: 'ruby-head'
@@ -64,6 +65,8 @@ jobs:
           - '2.6'
           - '2.7'
           - '3.0'
+          - '3.1'
+          - '3.2'
         experimental: [false]
         include:
           - ruby-version: 'ruby-head'
@@ -95,6 +98,8 @@ jobs:
           - '2.6'
           - '2.7'
           - '3.0'
+          - '3.1'
+          - '3.2'
         experimental: [false]
         include:
           - ruby-version: 'ruby-head'
@@ -126,6 +131,8 @@ jobs:
           - '2.6'
           - '2.7'
           - '3.0'
+          - '3.1'
+          - '3.2'
         experimental: [false]
         include:
           - ruby-version: 'ruby-head'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # main [(unreleased)](https://github.com/whitesmith/rubycritic/compare/v4.7.0...main)
 
+* [CHANGE] Run test suite with Ruby 3.2 (by [@Zhong-z][])
 * [CHANGE] Drop support for Ruby 2.5.x (by [@cleicar][])
 * [CHANGE] Drop support for Ruby 2.4.x (by [@rishijain][])
 * [FEATURE] Add ruby_extensions configuration option (by [@stufro][])
@@ -386,3 +387,4 @@
 [@denny]: https://github.com/denny
 [@RyanSnodgrass]: https://github.com/RyanSnodgrass
 [@ydah]: https://github.com/ydah
+[@Zhong-z]: https://github.com/Zhong-z


### PR DESCRIPTION
Check list:
- [x] Add an entry to the [changelog](/CHANGELOG.md)
- [x] [Squash all commits into a single one](/CONTRIBUTING.md)

Ruby 3.2 has been released. Enable ruby 3.2 in the Github Action Matrix and add ruby 3.1 in the missing matrix
