### PR TITLE
Fix rubocop using ruby-head

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -30,3 +30,8 @@ Style/RedundantFreeze:
     - 'lib/rubycritic/source_control_systems/perforce.rb'
     - 'lib/rubycritic/source_locator.rb'
     - 'lib/rubycritic/version.rb'
+
+Layout/BlockAlignment:
+  Enabled: false
+  Exclude:
+    - 'features/step_definitions/rake_task_steps.rb'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [CHANGE] Fix some typos (by [@ydah][])
 * [CHANGE] Remove wrong Rubocop reference in contributing file (by [@itsmeurbi]: https://github.com/itsmeurbi)
 * [BUGFIX] Restore missing smell status label (by [@itsmeurbi]: https://github.com/itsmeurbi)
+* [BUGFIX] Fix rubocop using ruby-head (by [@juanvqz][])
 
 # v4.7.0 / 2022-05-06 [(commits)](https://github.com/whitesmith/rubycritic/compare/v4.6.1...v4.7.0)
 


### PR DESCRIPTION
[The master build is failing](https://github.com/whitesmith/rubycritic/actions/runs/3568792565/jobs/5998057073)

```
An error occurred while Layout/BlockAlignment cop was inspecting /home/runner/work/rubycritic/rubycritic/features/step_definitions/rake_task_steps.rb:3:0.
```

Provisional Solution:
    This change is ignoring the cop in the specific file where this issue came.

Real Solution:
    I wonder if you want a real solution, the issues linked below said we should
    update Rubocop to at least version 1.22 or something like so.
    Is it okay if I try to update Rubocop?

Related Links:
    - [Layout/BlockAlignment search](https://github.com/rubocop/rubocop/issues?q=is%3Aissue+Layout%2FBlockAlignment)
    - [Reference issue](https://github.com/rubocop/rubocop/issues/10664)

Checklist:
- [x] Add an entry to the [changelog](/CHANGELOG.md)
- [x] [Squash all commits into a single one](/CONTRIBUTING.md)
- [x] Describe your PR, link issues, etc.
