### PR TITLE
Fix CI Markdownlinter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@
 * [FEATURE] Add ruby_extensions configuration option (by [@stufro][])
 * [CHANGE] Include files which have a ruby shebang (by [@stufro][])
 * [CHANGE] Fix some typos (by [@ydah][])
-* [CHANGE] Remove wrong Rubocop reference in contributing file (by [@itsmeurbi]: https://github.com/itsmeurbi)
-* [BUGFIX] Restore missing smell status label (by [@itsmeurbi]: https://github.com/itsmeurbi)
+* [CHANGE] Remove wrong Rubocop reference in contributing file (by [@itsmeurbi][])
+* [BUGFIX] Restore missing smell status label (by [@itsmeurbi][])
+* [BUGFIX] Fix CI markdownlint (by [@juanvqz][])
 
 # v4.7.0 / 2022-05-06 [(commits)](https://github.com/whitesmith/rubycritic/compare/v4.6.1...v4.7.0)
 
@@ -386,3 +387,5 @@
 [@denny]: https://github.com/denny
 [@RyanSnodgrass]: https://github.com/RyanSnodgrass
 [@ydah]: https://github.com/ydah
+[@itsmeurbi]: https://github.com/itsmeurbi
+[@juanvqz]: https://github.com/juanvqz


### PR DESCRIPTION
Fix Markdownlint workflow for the main branch

[Actual Error](https://github.com/whitesmith/rubycritic/actions/runs/3568792565/jobs/5998055347)

Related https://github.com/whitesmith/rubycritic/issues/427

Check list:
- [x] Add an entry to the [changelog](/CHANGELOG.md)
- [x] [Squash all commits into a single one](/CONTRIBUTING.md)
- [x] Describe your PR, link issues, etc.
