### PR TITLE
Fix CI Rubocop using ruby-head

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -30,3 +30,8 @@ Style/RedundantFreeze:
     - 'lib/rubycritic/source_control_systems/perforce.rb'
     - 'lib/rubycritic/source_locator.rb'
     - 'lib/rubycritic/version.rb'
+
+Layout/BlockAlignment:
+  Enabled: false
+  Exclude:
+    - 'features/step_definitions/rake_task_steps.rb'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [CHANGE] Fix some typos (by [@ydah][])
 * [CHANGE] Remove wrong Rubocop reference in contributing file (by [@itsmeurbi]: https://github.com/itsmeurbi)
 * [BUGFIX] Restore missing smell status label (by [@itsmeurbi]: https://github.com/itsmeurbi)
+* [BUGFIX] Fix CI rubocop using ruby-head (by [@juanvqz][])
 
 # v4.7.0 / 2022-05-06 [(commits)](https://github.com/whitesmith/rubycritic/compare/v4.6.1...v4.7.0)
 


### PR DESCRIPTION
Reference https://github.com/whitesmith/rubycritic/issues/427

[Actual error](https://github.com/whitesmith/rubycritic/actions/runs/3568792565/jobs/5998057073) 


Using ruby-head
```bash
➜  rubycritic git:(fix-ci-rubocop-using-ruby-head) ✗ ruby --version
ruby 3.3.0dev (2023-01-28T13:00:08Z master 21dced8b01) [x86_64-linux]
```

BEFORE
```bash
➜  rubycritic git:(fix-ci-rubocop-using-ruby-head) ✗ be rubocop features/step_definitions/rake_task_steps.rb
Inspecting 1 file
An error occurred while Layout/BlockAlignment cop was inspecting /home/ombu/code/ombu/rubycritic/features/step_definitions/rake_task_steps.rb:3:0.
To see the complete backtrace run rubocop -d.
.

1 file inspected, no offenses detected

1 error occurred:
An error occurred while Layout/BlockAlignment cop was inspecting /home/ombu/code/ombu/rubycritic/features/step_definitions/rake_task_steps.rb:3:0.
Errors are usually caused by RuboCop bugs.
Please, report your problems to RuboCop's issue tracker.
https://github.com/rubocop-hq/rubocop/issues

Mention the following information in the issue report:
0.65.0 (using Parser 3.2.0.0, running on ruby 3.3.0 x86_64-linux)
```

AFTER
```bash
➜  rubycritic git:(fix-ci-rubocop-using-ruby-head) ✗ be rubocop features/step_definitions/rake_task_steps.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
```

Check list:
- [x] Add an entry to the [changelog](/CHANGELOG.md)
- [x] [Squash all commits into a single one](/CONTRIBUTING.md)
- [x] Describe your PR, link issues, etc.
