### PR TITLE
Fix CI use Config.set to use default configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [CHANGE] Fix some typos (by [@ydah][])
 * [CHANGE] Remove wrong Rubocop reference in contributing file (by [@itsmeurbi]: https://github.com/itsmeurbi)
 * [BUGFIX] Restore missing smell status label (by [@itsmeurbi]: https://github.com/itsmeurbi)
+* [BUGFIX] Fix CI, test didn't include the ruby_extensions (by [@aisayo][] and [@juanvqz][])
 
 # v4.7.0 / 2022-05-06 [(commits)](https://github.com/whitesmith/rubycritic/compare/v4.6.1...v4.7.0)
 
@@ -386,3 +387,4 @@
 [@denny]: https://github.com/denny
 [@RyanSnodgrass]: https://github.com/RyanSnodgrass
 [@ydah]: https://github.com/ydah
+[@aisayo]: https://github.com/aisayo

--- a/test/lib/rubycritic/generators/html_report_test.rb
+++ b/test/lib/rubycritic/generators/html_report_test.rb
@@ -24,7 +24,7 @@ describe RubyCritic::Generator::HtmlReport do
   end
 
   def create_analysed_modules_collection
-    RubyCritic::Config.root = 'test/samples'
+    RubyCritic::Config.set(root: 'test/samples')
     RubyCritic::Config.base_root_directory = 'test/samples'
     RubyCritic::Config.feature_root_directory = 'test/samples'
     RubyCritic::Config.compare_root_directory = 'test/samples'


### PR DESCRIPTION
Related https://github.com/whitesmith/rubycritic/issues/427

```ruby
RubyCritic::Generator::HtmlReport::#generate_report::when base branch does not contain the compared file#test_0001_still works:
NoMethodError: undefined method `include?' for nil:NilClass
```

[This is the actual failing test](https://github.com/whitesmith/rubycritic/actions/runs/3568792565/jobs/5998056319)

Check list:
- [x] Add an entry to the [changelog](/CHANGELOG.md)
- [x] [Squash all commits into a single one](/CONTRIBUTING.md)
- [x] Describe your PR, link issues, etc.
