### PR TITLE
Update jruby CI configuration

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,9 +37,9 @@ jobs:
         include:
           - ruby-version: 'ruby-head'
             experimental: true
-          - ruby-version: 'jruby-9.2'
-            experimental: true
           - ruby-version: 'jruby-9.3'
+            experimental: true
+          - ruby-version: 'jruby-9.4'
             experimental: true
     steps:
       - uses: actions/checkout@v2
@@ -68,9 +68,9 @@ jobs:
         include:
           - ruby-version: 'ruby-head'
             experimental: true
-          - ruby-version: 'jruby-9.2'
-            experimental: true
           - ruby-version: 'jruby-9.3'
+            experimental: true
+          - ruby-version: 'jruby-9.4'
             experimental: true
     steps:
       - uses: actions/checkout@v2
@@ -99,9 +99,9 @@ jobs:
         include:
           - ruby-version: 'ruby-head'
             experimental: true
-          - ruby-version: 'jruby-9.2'
-            experimental: true
           - ruby-version: 'jruby-9.3'
+            experimental: true
+          - ruby-version: 'jruby-9.4'
             experimental: true
     steps:
       - uses: actions/checkout@v2
@@ -130,9 +130,9 @@ jobs:
         include:
           - ruby-version: 'ruby-head'
             experimental: true
-          - ruby-version: 'jruby-9.2'
-            experimental: true
           - ruby-version: 'jruby-9.3'
+            experimental: true
+          - ruby-version: 'jruby-9.4'
             experimental: true
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [BUGFIX] Fix CI rubocop using ruby-head (by [@juanvqz][])
 * [BUGFIX] Fix CI Update FakeFs to use ruby-head (by [@juanvqz][])
 * [BUGFIX] Fix CI, test didn't include the ruby_extensions (by [@aisayo][] and [@juanvqz][])
+* [BUGFIX] Fix CI, tests did not work with JRuby (by [@etagwerker][] and [@@h-r-k-matsumoto][])
 
 # v4.7.0 / 2022-05-06 [(commits)](https://github.com/whitesmith/rubycritic/compare/v4.6.1...v4.7.0)
 

--- a/README.md
+++ b/README.md
@@ -36,23 +36,24 @@ This gem provides features such as:
   ![RubyCritic smells index screenshot](https://github.com/whitesmith/rubycritic/raw/main/images/smells.png)
 
 4. When analysing code like the following:
-    ```ruby
-    class Dirty
-      def awful(x, y)
-        if y
-          @screen = widgets.map {|w| w.each {|key| key += 3}}
-        end
+
+  ```ruby
+  class Dirty
+    def awful(x, y)
+      if y
+        @screen = widgets.map {|w| w.each {|key| key += 3}}
       end
     end
-    ```
+  end
+  ```
 
-    It basically turns something like this:
+  It basically turns something like this:
 
-    ![Reek output screenshot](https://github.com/whitesmith/rubycritic/raw/main/images/reek.png)
+  ![Reek output screenshot](https://github.com/whitesmith/rubycritic/raw/main/images/reek.png)
 
-    Into something like this:
+  Into something like this:
 
-    ![RubyCritic file code screenshot](https://github.com/whitesmith/rubycritic/raw/main/images/smell-details.png)
+  ![RubyCritic file code screenshot](https://github.com/whitesmith/rubycritic/raw/main/images/smell-details.png)
 
 5. It uses your source control system (only Git, Mercurial and Perforce
   are currently supported) to compare your currently uncommitted

--- a/test/fakefs_helper.rb
+++ b/test/fakefs_helper.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'etc'
 require 'fakefs/safe'
 
 module FakeFS
@@ -9,3 +10,10 @@ module FakeFS
     end
   end
 end
+
+module FakeFSPatch
+  def home(user = Etc.getlogin)
+    RealDir.home(user)
+  end
+end
+::FakeFS::Dir.singleton_class.prepend(FakeFSPatch)


### PR DESCRIPTION
Check list:
- [ ] Add an entry to the [changelog](https://github.com/whitesmith/rubycritic/blob/main/CHANGELOG.md)
- [x] [Squash all commits into a single one](https://github.com/whitesmith/rubycritic/blob/main/CONTRIBUTING.md)
- [x] Describe your PR, link issues, etc.

I'm pretty sure RubyCritic no longer works with jruby-9.2 due to recent required ruby version changes to the gem's configuration. So this is an attempt to update jruby's configuration (experimental) in CI. 