### PR TITLE
Drop support for 2.6.x

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version:
-          - '2.6'
           - '2.7'
           - '3.0'
           - '3.1'
@@ -37,8 +36,6 @@ jobs:
         experimental: [false]
         include:
           - ruby-version: 'ruby-head'
-            experimental: true
-          - ruby-version: 'jruby-9.3'
             experimental: true
           - ruby-version: 'jruby-9.4'
             experimental: true
@@ -62,15 +59,13 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version:
-          - '2.6'
           - '2.7'
           - '3.0'
           - '3.1'
+          - '3.2'
         experimental: [false]
         include:
           - ruby-version: 'ruby-head'
-            experimental: true
-          - ruby-version: 'jruby-9.3'
             experimental: true
           - ruby-version: 'jruby-9.4'
             experimental: true
@@ -94,15 +89,13 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version:
-          - '2.6'
           - '2.7'
           - '3.0'
           - '3.1'
+          - '3.2'
         experimental: [false]
         include:
           - ruby-version: 'ruby-head'
-            experimental: true
-          - ruby-version: 'jruby-9.3'
             experimental: true
           - ruby-version: 'jruby-9.4'
             experimental: true
@@ -126,15 +119,13 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version:
-          - '2.6'
           - '2.7'
           - '3.0'
           - '3.1'
+          - '3.2'
         experimental: [false]
         include:
           - ruby-version: 'ruby-head'
-            experimental: true
-          - ruby-version: 'jruby-9.3'
             experimental: true
           - ruby-version: 'jruby-9.4'
             experimental: true
@@ -159,7 +150,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.0'
+          ruby-version: '3.2'
           bundler-cache: true
           cache-version: 1
       - name: Run markdownlint

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,7 +5,7 @@ AllCops:
     - 'tmp/**/*'
     - 'vendor/**/*'
     - 'gemfiles/*'
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 2.7
 
 Metrics/BlockLength:
   Enabled: false
@@ -35,3 +35,9 @@ Layout/BlockAlignment:
   Enabled: false
   Exclude:
     - 'features/step_definitions/rake_task_steps.rb'
+
+Naming/RescuedExceptionsVariableName:
+  Exclude:
+    - 'lib/rubycritic/analysers/coverage.rb'
+    - 'lib/rubycritic/cli/application.rb'
+    - 'lib/rubycritic/reporter.rb'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * [CHORE] Test gem with Ruby 3.2 (by [@etagwerker][])
 * [CHORE] Test gem with Ruby 3.1 (by [@etagwerker][])
+* [CHANGE] Drop support for JRuby 9.3.x (by [@faisal][])
+* [CHANGE] Drop support for Ruby 2.6.x (by [@faisal][])
 * [CHANGE] Drop support for Ruby 2.5.x (by [@cleicar][])
 * [CHANGE] Drop support for Ruby 2.4.x (by [@rishijain][])
 * [FEATURE] Add ruby_extensions configuration option (by [@stufro][])
@@ -13,8 +15,8 @@
 * [BUGFIX] Fix CI rubocop using ruby-head (by [@juanvqz][])
 * [BUGFIX] Fix CI Update FakeFs to use ruby-head (by [@juanvqz][])
 * [BUGFIX] Fix CI, test didn't include the ruby_extensions (by [@aisayo][] and [@juanvqz][])
-* [FEATURE] Support a branch in 'detached HEAD' state (by [@h-r-k-matsumoto]: https://github.com/h-r-k-matsumoto)
-* [BUGFIX] Fix CI, tests did not work with JRuby (by [@etagwerker][] and [@@h-r-k-matsumoto][])
+* [FEATURE] Support a branch in 'detached HEAD' state (by [@h-r-k-matsumoto][])
+* [BUGFIX] Fix CI, tests did not work with JRuby (by [@etagwerker][] and [@h-r-k-matsumoto][])
 
 # v4.7.0 / 2022-05-06 [(commits)](https://github.com/whitesmith/rubycritic/compare/v4.6.1...v4.7.0)
 

--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ RubyCritic is supporting Ruby versions:
 | - | - |
 | 2.4 | [v4.7.0](https://github.com/whitesmith/rubycritic/tree/v4.7.0) |
 | 2.5 | [v4.7.0](https://github.com/whitesmith/rubycritic/tree/v4.7.0) |
-| 2.6 | latest |
+| 2.6 | [v4.7.0](https://github.com/whitesmith/rubycritic/tree/v4.7.0) |
 | 2.7 | latest |
 | 3.0 | latest |
 | 3.1 | latest |

--- a/rubycritic.gemspec
+++ b/rubycritic.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'RubyCritic is a Ruby code quality reporter'
   spec.homepage      = 'https://github.com/whitesmith/rubycritic'
   spec.license       = 'MIT'
-  spec.required_ruby_version = '>= 2.6.0'
+  spec.required_ruby_version = '>= 2.7.0'
 
   spec.files = [
     'CHANGELOG.md',
@@ -58,5 +58,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'mocha', '~> 1.1', '>= 1.1.0'
   spec.add_development_dependency 'rake', '~> 12.0', '>= 11.0.0'
   spec.add_development_dependency 'rexml', '>= 3.2.0'
-  spec.add_development_dependency 'rubocop', '~> 0.65.0'
+  spec.add_development_dependency 'rubocop', '~> 0.75.0'
 end


### PR DESCRIPTION
Closes https://github.com/whitesmith/rubycritic/issues/441

Check list:
- [X] Add an entry to the [changelog](https://github.com/whitesmith/rubycritic/blob/main/CHANGELOG.md)
- [x] [Squash all commits into a single one](https://github.com/whitesmith/rubycritic/blob/main/CONTRIBUTING.md)
- [x] Describe your PR, link issues, etc.
