### PR TITLE
Continuous integration status badge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 * [BUGFIX] Fix CI rubocop using ruby-head (by [@juanvqz][])
 * [BUGFIX] Fix CI Update FakeFs to use ruby-head (by [@juanvqz][])
 * [BUGFIX] Fix CI, test didn't include the ruby_extensions (by [@aisayo][] and [@juanvqz][])
-* [FEATURE] Support a branch in 'detached HEAD' state (by [@h-r-k-matsumoto]: https://github.com/h-r-k-matsumoto)
+* [FEATURE] Support a branch in 'detached HEAD' state (by [@h-r-k-matsumoto][])
 * [BUGFIX] Fix CI, tests did not work with JRuby (by [@etagwerker][] and [@@h-r-k-matsumoto][])
 
 # v4.7.0 / 2022-05-06 [(commits)](https://github.com/whitesmith/rubycritic/compare/v4.6.1...v4.7.0)
@@ -407,3 +407,4 @@
 [@itsmeurbi]: https://github.com/itsmeurbi
 [@kcamcam]: https://github.com/kcamcam
 [@aisayo]: https://github.com/aisayo
+[@h-r-k-matsumoto]: https://github.com/h-r-k-matsumoto

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * [BUGFIX] Fix CI, test didn't include the ruby_extensions (by [@aisayo][] and [@juanvqz][])
 * [FEATURE] Support a branch in 'detached HEAD' state (by [@h-r-k-matsumoto][])
 * [BUGFIX] Fix CI, tests did not work with JRuby (by [@etagwerker][] and [@@h-r-k-matsumoto][])
+* [CHANGE] Add continuous integration status badge to README (by [@kcamcam][])
 
 # v4.7.0 / 2022-05-06 [(commits)](https://github.com/whitesmith/rubycritic/compare/v4.6.1...v4.7.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 * [BUGFIX] Fix CI Update FakeFs to use ruby-head (by [@juanvqz][])
 * [BUGFIX] Fix CI, test didn't include the ruby_extensions (by [@aisayo][] and [@juanvqz][])
 * [FEATURE] Support a branch in 'detached HEAD' state (by [@h-r-k-matsumoto][])
-* [BUGFIX] Fix CI, tests did not work with JRuby (by [@etagwerker][] and [@@h-r-k-matsumoto][])
+* [BUGFIX] Fix CI, tests did not work with JRuby (by [@etagwerker][] and [@h-r-k-matsumoto][])
 * [CHANGE] Add continuous integration status badge to README (by [@kcamcam][])
 
 # v4.7.0 / 2022-05-06 [(commits)](https://github.com/whitesmith/rubycritic/compare/v4.6.1...v4.7.0)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # RubyCritic
 
 [![Gem Version](https://badge.fury.io/rb/rubycritic.svg)](http://badge.fury.io/rb/rubycritic)
+[![Continuous Integration](https://github.com/whitesmith/rubycritic/actions/workflows/main.yml/badge.svg?branch=main)](https://github.com/whitesmith/rubycritic/actions/workflows/main.yml)
 [![Build Status](https://travis-ci.org/whitesmith/rubycritic.svg?branch=master)](https://travis-ci.org/whitesmith/rubycritic)
 [![Code Climate](https://codeclimate.com/github/whitesmith/rubycritic/badges/gpa.svg)](https://codeclimate.com/github/whitesmith/rubycritic)
 


### PR DESCRIPTION
This pull request adds a continuous integration stats badge to the project README in order to offer better visibility into the current state of the `main` branch. For example, it is currently failing due to a linting error on the CHANGELOG.md file that was introduced in #424. This pull request also fixes that linting error.

<img width="930" alt="Screenshot 2023-05-05 at 3 14 55 PM" src="https://user-images.githubusercontent.com/16027312/236549786-37027a2e-e56b-48d2-b52c-ec1793789aa5.png">

Check list:
- [x] Add an entry to the [changelog](https://github.com/whitesmith/rubycritic/blob/main/CHANGELOG.md)
- [ ] [Squash all commits into a single one](https://github.com/whitesmith/rubycritic/blob/main/CONTRIBUTING.md)
- [x] Describe your PR, link issues, etc.
