### PR TITLE
[BUGFIX] Fixed CHANGELOG.md's user references.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # main [(unreleased)](https://github.com/whitesmith/rubycritic/compare/v4.7.0...main)
 
+* [CHORE] Fix syntax of contributor references in this file
 * [CHORE] Test gem with Ruby 3.2 (by [@etagwerker][])
 * [CHORE] Test gem with Ruby 3.1 (by [@etagwerker][])
 * [CHANGE] Drop support for Ruby 2.5.x (by [@cleicar][])
@@ -13,8 +14,8 @@
 * [BUGFIX] Fix CI rubocop using ruby-head (by [@juanvqz][])
 * [BUGFIX] Fix CI Update FakeFs to use ruby-head (by [@juanvqz][])
 * [BUGFIX] Fix CI, test didn't include the ruby_extensions (by [@aisayo][] and [@juanvqz][])
-* [FEATURE] Support a branch in 'detached HEAD' state (by [@h-r-k-matsumoto]: https://github.com/h-r-k-matsumoto)
-* [BUGFIX] Fix CI, tests did not work with JRuby (by [@etagwerker][] and [@@h-r-k-matsumoto][])
+* [FEATURE] Support a branch in 'detached HEAD' state (by [@h-r-k-matsumoto][])
+* [BUGFIX] Fix CI, tests did not work with JRuby (by [@etagwerker][] and [@h-r-k-matsumoto][])
 
 # v4.7.0 / 2022-05-06 [(commits)](https://github.com/whitesmith/rubycritic/compare/v4.6.1...v4.7.0)
 
@@ -36,8 +37,7 @@
 * [CHANGE] Make Github Linguist ignore vendored files (by [@sl4vr][])
 * [BUGFIX] Fix directory structure of reports when comparing branches (by [@denny][])
 * [BUGFIX] Restrict simplecov to versions before data format changed (by [@denny][])
-
-* [BUGFIX] Handle missing comparison file in html template (by @lauratpa)
+* [BUGFIX] Handle missing comparison file in html template (by [@lauratpa][])
 
 # v4.5.2 / 2020-08-20 [(commits)](https://github.com/whitesmith/rubycritic/compare/v4.5.1...v4.5.2)
 
@@ -46,7 +46,6 @@
 # v4.5.1 / 2020-06-29 [(commits)](https://github.com/whitesmith/rubycritic/compare/v4.5.0...v4.5.1)
 
 * [BUGFIX] Handle git --name-status Copied (C) operation (by [@rizalmuthi][])
-
 * [FEATURE] Add --churn-after (only supports git) to limit churn analysis to recent history (by [@jackcasey][])
 
 # v4.5.0 / 2020-05-14 [(commits)](https://github.com/whitesmith/rubycritic/compare/v4.4.1...v4.5.0)
@@ -115,8 +114,8 @@
 
 # 4.0.0 / 2019-02-27 [(commits)](https://github.com/whitesmith/rubycritic/compare/v3.5.1...v4.0.0)
 
-* [FEATURE] Allow generating reports in multiple formats in one run (by [@katafrakt])
-* [FEATURE] Allow to accept a config file (by [@mfbmina])
+* [FEATURE] Allow generating reports in multiple formats in one run (by [@katafrakt][])
+* [FEATURE] Allow to accept a config file (by [@mfbmina][])
 * [CHANGE] Update `reek` to 5.3 (by [@taitran19][] and [@onumis][])
 * [CHANGE] Update `parser` to 2.6.0 (by [@onumis][])
 * [CHANGE] Update `tty-which` to 0.4.0 (by [@onumis][])
@@ -407,3 +406,9 @@
 [@itsmeurbi]: https://github.com/itsmeurbi
 [@kcamcam]: https://github.com/kcamcam
 [@aisayo]: https://github.com/aisayo
+[@h-r-k-matsumoto]: https://github.com/h-r-k-matsumoto
+[@juanvqz]: https://github.com/juanvqz
+[@eitoball]: https://github.com/eitoball
+[@marcgrimme]: https://github.com/marcgrimme
+[@katafrakt]: https://github.com/katafrakt
+[@faisal]: https://github.com/faisal


### PR DESCRIPTION
Fix the user references links in CHANGELOG.md so the page renders correctly, and so the `bundle exec mdl .` workflow step doesn't fail in unrelated PRs (e.g. https://github.com/whitesmith/rubycritic/actions/runs/4896765877/jobs/8743975161?pr=437, https://github.com/whitesmith/rubycritic/actions/runs/4906259106/jobs/8779124376?pr=419).

Check list:
- [x] Add an entry to the [changelog](https://github.com/whitesmith/rubycritic/blob/main/CHANGELOG.md)
- [x] [Squash all commits into a single one](https://github.com/whitesmith/rubycritic/blob/main/CONTRIBUTING.md)
- [x] Describe your PR, link issues, etc.
