### PR TITLE
Bump rubocop dependency

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,11 @@
+require:
+  - rubocop-minitest
+  - rubocop-performance
+  - rubocop-rake
+
 AllCops:
   DisplayCopNames: true
+  NewCops: enable
   Exclude:
     - 'test/samples/**/*'
     - 'tmp/**/*'
@@ -10,7 +16,7 @@ AllCops:
 Metrics/BlockLength:
   Enabled: false
 
-Metrics/LineLength:
+Layout/LineLength:
   Max: 120
 
 Style/Documentation:
@@ -41,3 +47,41 @@ Naming/RescuedExceptionsVariableName:
     - 'lib/rubycritic/analysers/coverage.rb'
     - 'lib/rubycritic/cli/application.rb'
     - 'lib/rubycritic/reporter.rb'
+
+Lint/EmptyClass:
+  Exclude:
+    - 'test/lib/rubycritic/reporter_test.rb'
+
+Lint/ConstantDefinitionInBlock:
+  Exclude:
+    - 'test/lib/rubycritic/reporter_test.rb'
+
+Style/OpenStructUse:
+  Exclude:
+    - 'test/lib/rubycritic/generators/turbulence_test.rb'
+    - 'test/lib/rubycritic/generators/console_report_test.rb'
+    - 'test/lib/rubycritic/core/analysed_module_test.rb'
+    - 'test/analysers_test_helper.rb'
+
+Lint/MissingSuper:
+  Exclude:
+    - 'test/analysers_test_helper.rb'
+    - 'lib/rubycritic/generators/html/overview.rb'
+    - 'lib/rubycritic/generators/html/simple_cov_index.rb'
+    - 'lib/rubycritic/generators/html/smells_index.rb'
+    - 'lib/rubycritic/rake_task.rb'
+    - 'lib/rubycritic/generators/html/code_file.rb'
+    - 'lib/rubycritic/generators/html/code_index.rb'
+    - 'lib/rubycritic/generators/html/line.rb'
+
+Gemspec/DevelopmentDependencies:
+  Exclude:
+    - 'rubycritic.gemspec'
+
+Lint/StructNewOverride:
+  Exclude:
+    - 'lib/rubycritic/source_control_systems/git/churn.rb'
+
+Metrics/AbcSize:
+  Exclude:
+    - 'lib/rubycritic/configuration.rb'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # main [(unreleased)](https://github.com/whitesmith/rubycritic/compare/v4.8.0...main)
 
+* [CHANGE] Update rubocop to use current version (~1.51.0) and relevant plugins (by [@faisal][]])
 * [BUGFIX] Fix sort and filters on the coverage page (by [@kcamcam][])
 
 # v4.8.0 / 2023-05-12 [(commits)](https://github.com/whitesmith/rubycritic/compare/v4.7.0...v4.8.0)

--- a/lib/rubycritic/analysers/helpers/ast_node.rb
+++ b/lib/rubycritic/analysers/helpers/ast_node.rb
@@ -13,12 +13,12 @@ module Parser
         count
       end
 
-      def recursive_children
+      def recursive_children(&block)
         children.each do |child|
           next unless child.is_a?(Parser::AST::Node)
 
           yield child
-          child.recursive_children { |grand_child| yield grand_child }
+          child.recursive_children(&block)
         end
       end
 

--- a/lib/rubycritic/cli/options/file.rb
+++ b/lib/rubycritic/cli/options/file.rb
@@ -77,8 +77,9 @@ module RubyCritic
 
         def formats
           formats = Array(options['formats'])
+          formats_to_check = %w[html json console lint]
           formats.select do |format|
-            %w[html json console lint].include?(format)
+            formats_to_check.include?(format)
           end.map(&:to_sym)
         end
 

--- a/lib/rubycritic/commands/compare.rb
+++ b/lib/rubycritic/commands/compare.rb
@@ -91,9 +91,9 @@ module RubyCritic
 
       # create a txt file with the branch score details
       def build_details
-        details = "Base branch (#{Config.base_branch}) score: #{Config.base_branch_score} \n"\
+        details = "Base branch (#{Config.base_branch}) score: #{Config.base_branch_score} \n" \
                   "Feature branch (#{Config.feature_branch}) score: #{Config.feature_branch_score} \n"
-        File.open("#{Config.compare_root_directory}/build_details.txt", 'w') { |file| file.write(details) }
+        File.write("#{Config.compare_root_directory}/build_details.txt", details)
       end
 
       # store the analysed moduled collection based on the branch

--- a/lib/rubycritic/commands/status_reporter.rb
+++ b/lib/rubycritic/commands/status_reporter.rb
@@ -4,6 +4,7 @@ module RubyCritic
   module Command
     class StatusReporter
       attr_reader :status, :status_message, :score
+
       SUCCESS = 0
       SCORE_BELOW_MINIMUM = 1
 

--- a/lib/rubycritic/commands/version.rb
+++ b/lib/rubycritic/commands/version.rb
@@ -7,6 +7,7 @@ module RubyCritic
   module Command
     class Version < Base
       attr_reader :status_reporter
+
       def execute
         puts "RubyCritic #{VERSION}"
         status_reporter

--- a/lib/rubycritic/core/analysed_module.rb
+++ b/lib/rubycritic/core/analysed_module.rb
@@ -41,7 +41,7 @@ module RubyCritic
     end
 
     def cost
-      @cost ||= smells.map(&:cost).inject(0.0, :+) +
+      @cost ||= smells.sum(0.0, &:cost) +
                 (complexity / COMPLEXITY_FACTOR)
     end
 

--- a/lib/rubycritic/core/analysed_modules_collection.rb
+++ b/lib/rubycritic/core/analysed_modules_collection.rb
@@ -46,7 +46,7 @@ module RubyCritic
 
     def score
       if @modules.any?
-        (MAX_SCORE - average_limited_cost * COST_MULTIPLIER).round(2)
+        (MAX_SCORE - (average_limited_cost * COST_MULTIPLIER)).round(2)
       else
         0.0
       end
@@ -69,7 +69,7 @@ module RubyCritic
     def average_cost
       num_modules = @modules.size
       if num_modules.positive?
-        map { |mod| limited_cost_for(mod) }.reduce(:+) / num_modules.to_f
+        sum { |mod| limited_cost_for(mod) } / num_modules.to_f
       else
         0.0
       end

--- a/lib/rubycritic/core/rating.rb
+++ b/lib/rubycritic/core/rating.rb
@@ -7,7 +7,8 @@ module RubyCritic
       elsif cost <= 4  then new('B')
       elsif cost <= 8  then new('C')
       elsif cost <= 16 then new('D')
-      else new('F')
+      else
+        new('F')
       end
     end
 

--- a/lib/rubycritic/core/smell.rb
+++ b/lib/rubycritic/core/smell.rb
@@ -20,7 +20,7 @@ module RubyCritic
     FLOG_DOCS_URL = 'http://docs.seattlerb.org/flog/'.freeze
 
     def at_location?(other_location)
-      locations.any? { |location| location == other_location }
+      locations.any?(other_location)
     end
 
     def multiple_locations?

--- a/lib/rubycritic/generators/html/line.rb
+++ b/lib/rubycritic/generators/html/line.rb
@@ -19,7 +19,7 @@ module RubyCritic
         end
 
         def render
-          template.result(binding).delete("\n") + "\n"
+          "#{template.result(binding).delete("\n")}\n"
         end
 
         private

--- a/lib/rubycritic/generators/html_report.rb
+++ b/lib/rubycritic/generators/html_report.rb
@@ -33,9 +33,7 @@ module RubyCritic
       def create_directories_and_files
         Array(generators).each do |generator|
           FileUtils.mkdir_p(generator.file_directory)
-          File.open(generator.file_pathname, 'w+') do |file|
-            file.write(generator.render)
-          end
+          File.write(generator.file_pathname, generator.render)
         end
       end
 

--- a/lib/rubycritic/generators/json_report.rb
+++ b/lib/rubycritic/generators/json_report.rb
@@ -11,9 +11,7 @@ module RubyCritic
 
       def generate_report
         FileUtils.mkdir_p(generator.file_directory)
-        File.open(generator.file_pathname, 'w+') do |file|
-          file.write(generator.render)
-        end
+        File.write(generator.file_pathname, generator.render)
       end
 
       private

--- a/lib/rubycritic/generators/lint_report.rb
+++ b/lib/rubycritic/generators/lint_report.rb
@@ -11,9 +11,7 @@ module RubyCritic
 
       def generate_report
         FileUtils.mkdir_p(generator.file_directory)
-        File.open(generator.file_pathname, 'w+') do |file|
-          file.write(reports.join("\n"))
-        end
+        File.write(generator.file_pathname, reports.join("\n"))
       end
 
       def generator

--- a/lib/rubycritic/source_control_systems/base.rb
+++ b/lib/rubycritic/source_control_systems/base.rb
@@ -21,9 +21,9 @@ module RubyCritic
         if supported_system
           supported_system.new
         else
-          puts 'RubyCritic can provide more feedback if you use '\
-                "a #{connected_system_names} repository. "\
-                'Churn will not be calculated.'
+          puts 'RubyCritic can provide more feedback if you use ' \
+               "a #{connected_system_names} repository. " \
+               'Churn will not be calculated.'
           Double.new
         end
       end

--- a/lib/rubycritic/source_control_systems/git.rb
+++ b/lib/rubycritic/source_control_systems/git.rb
@@ -71,18 +71,18 @@ module RubyCritic
 
       def self.modified_files
         modified_files = `git diff --name-status #{Config.base_branch} #{Config.feature_branch}`
-        modified_files.split("\n").map do |line|
+        modified_files.split("\n").filter_map do |line|
           next if line.start_with?('D')
 
           file_name = line.split("\t")[1]
           file_name
-        end.compact
+        end
       end
 
       def self.current_branch
         branch_list = `git branch`
         branch = branch_list.match(/\*.*$/)[0].gsub('* ', '')
-        branch = branch.gsub(/\(HEAD detached at (.*)\)$/, '\1') if branch =~ /\(HEAD detached at (.*)\)$/
+        branch = branch.gsub(/\(HEAD detached at (.*)\)$/, '\1') if /\(HEAD detached at (.*)\)$/.match?(branch)
         branch
       end
 

--- a/lib/rubycritic/source_control_systems/perforce.rb
+++ b/lib/rubycritic/source_control_systems/perforce.rb
@@ -88,7 +88,7 @@ module RubyCritic
       end
 
       def self.compute_cache_lines(lines)
-        perforce_lines = Hash[*lines.map { |line| line.split[1..-1] }.flatten]
+        perforce_lines = Hash[*lines.map { |line| line.split[1..] }.flatten]
         PerforceStats.new(
           Perforce.normalized_file_path(perforce_lines['clientFile']),
           perforce_lines['headRev'],

--- a/rubycritic.gemspec
+++ b/rubycritic.gemspec
@@ -9,8 +9,8 @@ Gem::Specification.new do |spec|
   spec.version       = RubyCritic::VERSION
   spec.authors       = ['Guilherme Simoes']
   spec.email         = ['guilherme.rdems@gmail.com']
-  spec.description   = 'RubyCritic is a tool that wraps around various static analysis gems '\
-    'to provide a quality report of your Ruby code.'
+  spec.description   = 'RubyCritic is a tool that wraps around various static analysis gems ' \
+                       'to provide a quality report of your Ruby code.'
   spec.summary       = 'RubyCritic is a Ruby code quality reporter'
   spec.homepage      = 'https://github.com/whitesmith/rubycritic'
   spec.license       = 'MIT'
@@ -58,5 +58,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'mocha', '~> 1.1', '>= 1.1.0'
   spec.add_development_dependency 'rake', '~> 12.0', '>= 11.0.0'
   spec.add_development_dependency 'rexml', '>= 3.2.0'
-  spec.add_development_dependency 'rubocop', '~> 0.75.0'
+  spec.add_development_dependency 'rubocop', '~> 1.51.0'
+  spec.add_development_dependency 'rubocop-minitest'
+  spec.add_development_dependency 'rubocop-performance'
+  spec.add_development_dependency 'rubocop-rake'
+  spec.metadata['rubygems_mfa_required'] = 'true'
 end

--- a/test/fakefs_helper.rb
+++ b/test/fakefs_helper.rb
@@ -16,4 +16,4 @@ module FakeFSPatch
     RealDir.home(user)
   end
 end
-::FakeFS::Dir.singleton_class.prepend(FakeFSPatch)
+FakeFS::Dir.singleton_class.prepend(FakeFSPatch)

--- a/test/lib/rubycritic/core/analysed_modules_collection_test.rb
+++ b/test/lib/rubycritic/core/analysed_modules_collection_test.rb
@@ -24,7 +24,7 @@ describe RubyCritic::AnalysedModulesCollection do
 
       it 'registers one AnalysedModule element per existent file' do
         _(subject.count).must_equal 2
-        _(subject.all? { |a| a.is_a?(RubyCritic::AnalysedModule) }).must_equal true
+        _(subject.all?(RubyCritic::AnalysedModule)).must_equal true
       end
     end
 

--- a/test/lib/rubycritic/core/smell_test.rb
+++ b/test/lib/rubycritic/core/smell_test.rb
@@ -99,7 +99,7 @@ describe RubyCritic::Smell do
 
     it 'raises an error for unknown analysers' do
       smell = RubyCritic::Smell.new(type: 'FooSmell', analyser: 'foo')
-      assert_raises { smell.doc_url }
+      assert_raises(RuntimeError) { smell.doc_url }
     end
   end
 

--- a/test/lib/rubycritic/generators/console_report_test.rb
+++ b/test/lib/rubycritic/generators/console_report_test.rb
@@ -17,11 +17,12 @@ describe RubyCritic::Generator::ConsoleReport do
     end
 
     it 'outputs the report to the stdout' do
-      assert !@output.empty?, 'expected report to be output to stdout'
+      refute_empty @output, 'expected report to be output to stdout'
     end
 
     it "starts the report with the module's name" do
       lines = @output.split("\n")
+
       assert lines[0][/#{mock_analysed_module.name}/]
     end
 

--- a/test/lib/rubycritic/generators/json_report_test.rb
+++ b/test/lib/rubycritic/generators/json_report_test.rb
@@ -20,6 +20,7 @@ describe RubyCritic::Generator::JsonReport do
       generate_report
       data = JSON.parse(File.read('test/samples/report.json'))
       analysed_files = data['analysed_modules'].map { |h| h['path'] }.uniq
+
       assert_matched_arrays analysed_files, sample_files
     end
   end

--- a/test/lib/rubycritic/generators/lint_report_test.rb
+++ b/test/lib/rubycritic/generators/lint_report_test.rb
@@ -14,11 +14,12 @@ describe RubyCritic::Generator::LintReport do
     end
 
     it 'report file has data inside' do
-      sample_files = Dir['test/samples/**/*.rb'].reject { |f| File.zero?(f) }
+      sample_files = Dir['test/samples/**/*.rb'].reject { |f| File.empty?(f) }
       create_analysed_modules_collection
       generate_report
       lines = File.readlines('test/samples/lint.txt').map(&:strip).reject(&:empty?)
       analysed_files = lines.map { |line| line.split(':').first }.uniq
+
       assert_matched_arrays analysed_files, sample_files
     end
   end

--- a/test/lib/rubycritic/reporter_test.rb
+++ b/test/lib/rubycritic/reporter_test.rb
@@ -14,10 +14,10 @@ describe RubyCritic::Reporter do
     create_analysed_modules_collection
     RubyCritic::Reporter.generate_report(@analysed_modules_collection)
 
-    assert(File.exist?('test/samples/report.json'))
-    assert(File.exist?('test/samples/lint.txt'))
-    assert(File.exist?('test/samples/overview.html'))
-    assert(File.exist?('test/samples/simple_cov_index.html'))
+    assert_path_exists('test/samples/report.json')
+    assert_path_exists('test/samples/lint.txt')
+    assert_path_exists('test/samples/overview.html')
+    assert_path_exists('test/samples/simple_cov_index.html')
   end
 
   it 'creates a dummy formatter' do
@@ -27,6 +27,7 @@ describe RubyCritic::Reporter do
     formatter.expects(:generate_report).returns(true)
     DummyFormatter.expects(:new).once.returns(formatter)
     create_analysed_modules_collection
+
     assert RubyCritic::Reporter.generate_report(@analysed_modules_collection)
   end
 
@@ -39,12 +40,14 @@ describe RubyCritic::Reporter do
     formatter.expects(:generate_report).returns(true)
     MyTest::DummyFormatter.expects(:new).once.returns(formatter)
     create_analysed_modules_collection
+
     assert RubyCritic::Reporter.generate_report(@analysed_modules_collection)
   end
 
   it 'creates and loads a dummy formatter' do
     RubyCritic::Config.stubs(:formatters).returns(['./test/samples/dummy_formatter.rb:Test::DummyFormatter'])
     create_analysed_modules_collection
+
     assert RubyCritic::Reporter.generate_report(@analysed_modules_collection)
   end
 

--- a/test/lib/rubycritic/source_control_systems/perforce_test.rb
+++ b/test/lib/rubycritic/source_control_systems/perforce_test.rb
@@ -11,7 +11,7 @@ describe RubyCritic::SourceControlSystem::Perforce do
   describe RubyCritic::SourceControlSystem::Perforce do
     describe '::supported?' do
       let(:path) do
-        ['/some/path', File::PATH_SEPARATOR, '/perforce/path/p4', File::PATH_SEPARATOR + '/other/useless_path'].join
+        "/some/path#{File::PATH_SEPARATOR}/perforce/path/p4#{File::PATH_SEPARATOR}/other/useless_path"
       end
       let(:p4_client) { 'UNIT_TEST_CLIENT' }
 
@@ -151,7 +151,7 @@ describe RubyCritic::SourceControlSystem::Perforce do
       end
 
       it 'retrieves the date of the last commit of the ruby files' do
-        oldtz = ENV['TZ']
+        oldtz = ENV.fetch('TZ', nil)
         ENV['TZ'] = 'utc'
         Dir.stubs(:getwd).returns('/path/to/client')
         RubyCritic::SourceControlSystem::Perforce.stubs(:`).once.returns(p4_stats)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -14,8 +14,8 @@ require 'mocha/minitest'
 require 'ostruct'
 require 'diff/lcs'
 
-def context(*args, &block)
-  describe(*args, &block)
+def context(...)
+  describe(...)
 end
 
 def capture_output_streams
@@ -45,8 +45,7 @@ end
 module PathHelper
   class << self
     def reek_schema_path
-      reek_path = Gem.loaded_specs['reek'].full_gem_path
-      reek_path + '/lib/reek/configuration/schema.yml'
+      "#{Gem.loaded_specs['reek'].full_gem_path}/lib/reek/configuration/schema.yml"
     end
 
     def project_path
@@ -65,11 +64,14 @@ module MiniTest
 
     def assert_matched_arrays(exp, act)
       exp_ary = exp.to_ary
+
       assert_kind_of Array, exp_ary
       act_ary = act.to_ary
+
       assert_kind_of Array, act_ary
       diffs = Diff::LCS.sdiff(act_ary.sort, exp_ary.sort).reject(&:unchanged?)
-      assert diffs.empty?, "There are diffs between expected and actual values:\n#{diffs.map(&:inspect).join("\n")}"
+
+      assert_empty diffs, "There are diffs between expected and actual values:\n#{diffs.map(&:inspect).join("\n")}"
     end
   end
 


### PR DESCRIPTION
This PR updates the Rubocop version and config, and updates various rubycritic based on Rubocop's analysis. _Note that this  PR currently includes (and thus should hold landing) https://github.com/whitesmith/rubycritic/pull/442._

Check list:
- [X] Add an entry to the [changelog](https://github.com/whitesmith/rubycritic/blob/main/CHANGELOG.md)
- [ ] [Squash all commits into a single one](https://github.com/whitesmith/rubycritic/blob/main/CONTRIBUTING.md)
- [X] Describe your PR, link issues, etc.
