### PR TITLE
Bump test dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # main [(unreleased)](https://github.com/whitesmith/rubycritic/compare/v4.8.0...main)
 
+* [CHANGE] Update testing gems to current versions (by [@faisal][])
 * [BUGFIX] Fix sort and filters on the coverage page (by [@kcamcam][])
 
 # v4.8.0 / 2023-05-12 [(commits)](https://github.com/whitesmith/rubycritic/compare/v4.7.0...v4.8.0)

--- a/features/step_definitions/sample_file_steps.rb
+++ b/features/step_definitions/sample_file_steps.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Given(/^the smelly file 'smelly.rb'/) do
-  contents = <<-RUBY.strip_heredoc
+  contents = <<~RUBY
     class AllTheMethods
       def method_missing(method, *args, &block)
         message = "I"
@@ -18,7 +18,7 @@ Given(/^the smelly file 'smelly.rb'/) do
 end
 
 Given(/^the clean file 'clean.rb'/) do
-  contents = <<-RUBY.strip_heredoc
+  contents = <<~RUBY
     # Explanatory comment
     class Clean
       def foo; end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -25,7 +25,7 @@ class RubyCriticWorld
   end
 
   def rake(name, task_def)
-    header = <<-RUBY.strip_heredoc
+    header = <<~RUBY
       require 'rubycritic'
       require 'rubycritic/rake_task'
 

--- a/rubycritic.gemspec
+++ b/rubycritic.gemspec
@@ -41,22 +41,20 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'tty-which', '~> 0.4.0'
   spec.add_runtime_dependency 'virtus', '~> 1.0'
 
-  spec.add_development_dependency 'appraisal'
-  spec.add_development_dependency 'aruba', '~> 0.12', '>= 0.12.0'
-  spec.add_development_dependency 'bundler', '~> 2.0', '>= 2.0.0'
+  spec.add_development_dependency 'aruba', '~> 2.1.0'
+  spec.add_development_dependency 'bundler', '>= 2.0.0'
   if RUBY_PLATFORM == 'java'
     spec.add_development_dependency 'pry-debugger-jruby'
   else
     spec.add_development_dependency 'byebug', '~> 11.0', '>= 10.0'
   end
-  spec.add_development_dependency 'cucumber', '~> 3.0', '>= 2.2.0'
-  spec.add_development_dependency 'diff-lcs', '~> 1.3'
-  spec.add_development_dependency 'fakefs', '~> 1.4.1', '< 2.0.0'
+  spec.add_development_dependency 'cucumber', '~> 8.0.0'
+  spec.add_development_dependency 'fakefs', '~> 2.4.0'
   spec.add_development_dependency 'mdl', '~> 0.5.0'
   spec.add_development_dependency 'minitest', '>= 5.3.0'
   spec.add_development_dependency 'minitest-around', '~> 0.5.0', '>= 0.4.0'
-  spec.add_development_dependency 'mocha', '~> 1.1', '>= 1.1.0'
-  spec.add_development_dependency 'rake', '~> 12.0', '>= 11.0.0'
+  spec.add_development_dependency 'mocha', '~> 2.0.2'
+  spec.add_development_dependency 'rake', '~> 13.0.6', '>= 11.0.0'
   spec.add_development_dependency 'rexml', '>= 3.2.0'
   spec.add_development_dependency 'rubocop', '~> 0.75.0'
 end


### PR DESCRIPTION
This PR updates the test gem dependencies to modern versions, and fixes one of the feature step files to current Ruby syntax. _Note that this  PR currently includes (and thus should hold landing) https://github.com/whitesmith/rubycritic/pull/442._

Check list:
- [X] Add an entry to the [changelog](https://github.com/whitesmith/rubycritic/blob/main/CHANGELOG.md)
- [x] [Squash all commits into a single one](https://github.com/whitesmith/rubycritic/blob/main/CONTRIBUTING.md)
- [X] Describe your PR, link issues, etc.
