### PR TITLE
Bump mdl version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # main [(unreleased)](https://github.com/whitesmith/rubycritic/compare/v4.8.0...main)
 
+* [CHANGE] Update the mdl development_dependency from 0.5 to 0.12 (by [@faisal][])
 * [BUGFIX] Fix sort and filters on the coverage page (by [@kcamcam][])
 
 # v4.8.0 / 2023-05-12 [(commits)](https://github.com/whitesmith/rubycritic/compare/v4.7.0...v4.8.0)

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ RubyCritic is a gem that wraps around static analysis gems such as [Reek][1], [F
 - [Overview](#overview)
 - [Getting Started](#getting-started)
 - [Usage](#usage)
-  + [Analyzer Configuration](#analyzer-configuration)
-  + [Alternative Usage Methods](#alternative-usage-methods)
-  + [Rake Task](#rake-task)
+   + [Analyzer Configuration](#analyzer-configuration)
+   + [Alternative Usage Methods](#alternative-usage-methods)
+   + [Rake Task](#rake-task)
 - [Formatters](#formatters)
 - [Compatibility](#compatibility)
 - [Improving RubyCritic](#improving-rubyCritic)
@@ -159,9 +159,9 @@ paths: # Files to analyse.
   project root and `RubyCritic` will respect this configuration.
 * [`flay`](https://github.com/seattlerb/flay): We use `flay`'s default configuration.
 * [`flog`](https://github.com/seattlerb/flog): We use `flog`'s default configuration with a couple of [smaller tweaks](https://github.com/whitesmith/rubycritic/blob/main/lib/rubycritic/analysers/helpers/flog.rb#L5):
-  * `all`: Forces `flog` to report scores on all classes and methods. Without this option `flog` will only give results up to a certain threshold.
-  * `continue`: Makes it so that `flog` does not abort when a ruby file cannot be parsed.
-  * `methods`: Configures `flog` to skip code outside of methods. It prevents `flog` from reporting on the "methods" `private` and `protected`. It also prevents `flog` from reporting on Rails methods like `before_action` and `has_many`.
+   * `all`: Forces `flog` to report scores on all classes and methods. Without this option `flog` will only give results up to a certain threshold.
+   * `continue`: Makes it so that `flog` does not abort when a ruby file cannot be parsed.
+   * `methods`: Configures `flog` to skip code outside of methods. It prevents `flog` from reporting on the "methods" `private` and `protected`. It also prevents `flog` from reporting on Rails methods like `before_action` and `has_many`.
 
 ### Alternative Usage Methods
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,9 +6,9 @@ These are more nice-to-haves than promises. We can always dream. But this is wha
 
 - [ ] Improve how modules are graded. Each module is awarded a score, depending on:
 
-  * Its complexity, based off of this [post by Jake Scruggs](http://jakescruggs.blogspot.pt/2008/08/whats-good-flog-score.html), creator of the MetricFu gem. For every 25 points of complexity (as calculated by Flog), the score increases by 1.
+   * Its complexity, based off of this [post by Jake Scruggs](http://jakescruggs.blogspot.pt/2008/08/whats-good-flog-score.html), creator of the MetricFu gem. For every 25 points of complexity (as calculated by Flog), the score increases by 1.
 
-  * Its duplication mass, based off of observations of a few Code Climate repos. For every 25 points of mass (as calculated by Flay), the score increases by 1.
+   * Its duplication mass, based off of observations of a few Code Climate repos. For every 25 points of mass (as calculated by Flay), the score increases by 1.
 
   Finally, this score is translated to a grade like [this](https://github.com/whitesmith/rubycritic/blob/43005e7b76dd0c648c7715133e42afdd6ea9a065/lib/rubycritic/core/rating.rb), based off of a [Code Climate blog post](http://blog.codeclimate.com/blog/2012/10/17/7-ways-to-decompose-fat-activerecord-models/#value-objects).
 
@@ -21,36 +21,36 @@ These are more nice-to-haves than promises. We can always dream. But this is wha
 - [ ] Make the gem configurable using a dotfile like .rubycritic.yml. #30
       Here are some possible settings:
 
-  - [ ] Quiet mode. As of right now, any Ruby code that is unparsable will be reported three times (one time by Flog, another by Flay and another by Reek). Only Flog implements a quiet option, which means we have to implement that quiet option on Flay and on Reek before we can add it to RubyCritic. Or we could just do `$stderr = StringIO.new`... I wonder if that's really really smart or really really stupid.
+   - [ ] Quiet mode. As of right now, any Ruby code that is unparsable will be reported three times (one time by Flog, another by Flay and another by Reek). Only Flog implements a quiet option, which means we have to implement that quiet option on Flay and on Reek before we can add it to RubyCritic. Or we could just do `$stderr = StringIO.new`... I wonder if that's really really smart or really really stupid.
 
-  - [ ] Verbose mode. #61
+   - [ ] Verbose mode. #61
 
-  - [ ] Ignoring/excluding files. #11
+   - [ ] Ignoring/excluding files. #11
 
-  - [ ] Allow configuring date range of Churn calculation. #37 Right now, they are limited to the last year. #39
+   - [ ] Allow configuring date range of Churn calculation. #37 Right now, they are limited to the last year. #39
 
 - [ ] Highlight blocks of duplicated code instead of just the start of the block. This will probably require rewriting Flay with [parser](https://github.com/whitequark/parser) instead of ruby_parser.
 
 - [ ] Integrate other gems, like:
 
-  - [x] [Simplecov](https://github.com/colszowka/simplecov) to provide code coverage. #319
+   - [x] [Simplecov](https://github.com/colszowka/simplecov) to provide code coverage. #319
 
-  - [ ] [Rubocop](https://github.com/bbatsov/rubocop/) to provide style issues
+   - [ ] [Rubocop](https://github.com/bbatsov/rubocop/) to provide style issues
 
-  - [ ] [Brakeman](https://github.com/presidentbeef/brakeman) to provide security issues (Rails-only feature)
+   - [ ] [Brakeman](https://github.com/presidentbeef/brakeman) to provide security issues (Rails-only feature)
 
-  - [ ] [Rails Best Practices](https://github.com/railsbp/rails_best_practices) to provide Rails smells (Rails-only feature) #14
+   - [ ] [Rails Best Practices](https://github.com/railsbp/rails_best_practices) to provide Rails smells (Rails-only feature) #14
 
-  - [ ] [SandiMeter](https://github.com/makaroni4/sandi_meter) #15
+   - [ ] [SandiMeter](https://github.com/makaroni4/sandi_meter) #15
 
 - [ ] Improve UI.
 
-  - [ ] Make it beautiful.
+   - [ ] Make it beautiful.
 
-  - [ ] Figure out where the "suggestions to fix code smells" should be presented.
+   - [ ] Figure out where the "suggestions to fix code smells" should be presented.
 
-  - [ ] Create some kind of toggle option between various types of issues. Just like we can toggle between "Smells" and "Coverage" in Code Climate:
+   - [ ] Create some kind of toggle option between various types of issues. Just like we can toggle between "Smells" and "Coverage" in Code Climate:
 
-    ![Code Climate Toggle Option](https://camo.githubusercontent.com/d97fc62dae6ebef1f35bda91942d4a6bacc445b2/687474703a2f2f626c6f672e636f6465636c696d6174652e636f6d2f696d616765732f706f7374732f74657374696e672e676966)
+     ![Code Climate Toggle Option](https://camo.githubusercontent.com/d97fc62dae6ebef1f35bda91942d4a6bacc445b2/687474703a2f2f626c6f672e636f6465636c696d6174652e636f6d2f696d616765732f706f7374732f74657374696e672e676966)
 
-    Having an option to toggle between "Smells", "Security" (Brakeman) and "Style" (Rubocop) would be great. But that's already assuming we can integrate those gems into RubyCritic.
+     Having an option to toggle between "Smells", "Security" (Brakeman) and "Style" (Rubocop) would be great. But that's already assuming we can integrate those gems into RubyCritic.

--- a/rubycritic.gemspec
+++ b/rubycritic.gemspec
@@ -52,7 +52,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'cucumber', '~> 3.0', '>= 2.2.0'
   spec.add_development_dependency 'diff-lcs', '~> 1.3'
   spec.add_development_dependency 'fakefs', '~> 1.4.1', '< 2.0.0'
-  spec.add_development_dependency 'mdl', '~> 0.5.0'
+  spec.add_development_dependency 'mdl', '~> 0.12.0'
   spec.add_development_dependency 'minitest', '>= 5.3.0'
   spec.add_development_dependency 'minitest-around', '~> 0.5.0', '>= 0.4.0'
   spec.add_development_dependency 'mocha', '~> 1.1', '>= 1.1.0'


### PR DESCRIPTION
This PR updates the mdl dependency to the current version, and updates some `.md` files based on mdl's analysis. _Note that this  PR currently includes (and thus should hold landing) https://github.com/whitesmith/rubycritic/pull/442._

Check list:
- [X] Add an entry to the [changelog](https://github.com/whitesmith/rubycritic/blob/main/CHANGELOG.md)
- [x] [Squash all commits into a single one](https://github.com/whitesmith/rubycritic/blob/main/CONTRIBUTING.md)
- [X] Describe your PR, link issues, etc.
