### PR TITLE
Update simple_cov_index.html as generated by template

### DIFF
--- a/test/samples/simple_cov_index.html
+++ b/test/samples/simple_cov_index.html
@@ -51,7 +51,7 @@
       </div>
       <!--End Page Title -->
       <div class="Content_Wrapper">
-        <table id="js-index-table" class="table coverage-index-table index-table sortable-table">
+        <table id="coverageTable" class="table index-table sortable-table tablesorter">
           <thead>
             <tr>
               


### PR DESCRIPTION
Fixes https://github.com/whitesmith/rubycritic/issues/456.

95e71058c6e1a0cd99cc60cc0b66bdacbcd3569b updated the lib/rubycritic/generators/html/templates/simple_cov_index.html.erb template, but not the test/samples/simple_cov_index.html generated from that template after running `rake test`. As a result, running `rake test` leaves the repo in a dirty state. This commit includes the updated test sample.

Check list:
- [X] Add an entry to the [changelog](https://github.com/whitesmith/rubycritic/blob/main/CHANGELOG.md)
- [X] [Squash all commits into a single one](https://github.com/whitesmith/rubycritic/blob/main/CONTRIBUTING.md)
- [X] Describe your PR, link issues, etc.
