### PR TITLE
Remove Ruby 2.7 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version:
-          - '2.7'
           - '3.0'
           - '3.1'
           - '3.2'
@@ -59,7 +58,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version:
-          - '2.7'
           - '3.0'
           - '3.1'
           - '3.2'
@@ -89,7 +87,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version:
-          - '2.7'
           - '3.0'
           - '3.1'
           - '3.2'
@@ -119,7 +116,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version:
-          - '2.7'
           - '3.0'
           - '3.1'
           - '3.2'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,7 +11,7 @@ AllCops:
     - 'tmp/**/*'
     - 'vendor/**/*'
     - 'gemfiles/*'
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3
 
 Metrics/BlockLength:
   Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # v4.8.1 / 2023-05-17 [(commits)](https://github.com/whitesmith/rubycritic/compare/v4.8.0...v4.8.1)
 
+* [CHANGE] Drop support for Ruby 2.7.x (by [@faisal][])
 * [CHANGE] Update runtime dependencies to current versions of analysis gems (by [@faisal][])
 * [CHANGE] Update the mdl development_dependency from 0.5 to 0.12 (by [@faisal][])
 * [CHANGE] Update rubocop to use current version (~1.51.0) and relevant plugins (by [@faisal][]])

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ RubyCritic is supporting Ruby versions:
 | 2.4 | [v4.7.0](https://github.com/whitesmith/rubycritic/tree/v4.7.0) |
 | 2.5 | [v4.7.0](https://github.com/whitesmith/rubycritic/tree/v4.7.0) |
 | 2.6 | [v4.7.0](https://github.com/whitesmith/rubycritic/tree/v4.7.0) |
-| 2.7 | latest |
+| 2.7 | [v4.7.0](https://github.com/whitesmith/rubycritic/tree/v4.7.0) |
 | 3.0 | latest |
 | 3.1 | latest |
 

--- a/rubycritic.gemspec
+++ b/rubycritic.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'RubyCritic is a Ruby code quality reporter'
   spec.homepage      = 'https://github.com/whitesmith/rubycritic'
   spec.license       = 'MIT'
-  spec.required_ruby_version = '>= 2.7.0'
+  spec.required_ruby_version = '>= 3.0.0'
 
   spec.files = [
     'CHANGELOG.md',


### PR DESCRIPTION
This is for the move to Ruby 3, for when we're ready to do that.

- Remove Ruby 2.7 support.
- Set Rubocop to target Ruby 3. Exclude lib/rubycritic/configuration.rb from Metrics/AbcSize cop.

Check list:
- [X] Add an entry to the [changelog](https://github.com/whitesmith/rubycritic/blob/main/CHANGELOG.md)
- [X] [Squash all commits into a single one](https://github.com/whitesmith/rubycritic/blob/main/CONTRIBUTING.md)
- [X] Describe your PR, link issues, etc.
