### PR TITLE
WIP: Address test warning by declaring cucumber_opts using %w[] instead of…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # main [(unreleased)](https://github.com/whitesmith/rubycritic/compare/v4.8.1...main)
 
+* [CHANGE] Fix test warning related to `cucumber_opts` declaration (by [@faisal][])
 * [BUGFIX] Stop using long-deprecated MiniTest module name, removed in 5.19.0 (by [@faisal][])
 
 # v4.8.1 / 2023-05-17 [(commits)](https://github.com/whitesmith/rubycritic/compare/v4.8.0...v4.8.1)

--- a/Rakefile
+++ b/Rakefile
@@ -14,7 +14,7 @@ Rake::TestTask.new do |task|
 end
 
 Cucumber::Rake::Task.new(:features) do |t|
-  t.cucumber_opts = 'features --format progress --color'
+  t.cucumber_opts = %w[features --format progress --color]
 end
 
 RuboCop::RakeTask.new


### PR DESCRIPTION
Check list:
- [X] Add an entry to the [changelog](https://github.com/whitesmith/rubycritic/blob/main/CHANGELOG.md)
- [X] [Squash all commits into a single one](https://github.com/whitesmith/rubycritic/blob/main/CONTRIBUTING.md)
- [X] Describe your PR, link issues, etc.

This is a minor change in the Rakefile, clearing a test warning (see [465](https://github.com/whitesmith/rubycritic/issues/465)) by declaring `cucumber_opts` using `%w[]` syntax instead of a raw string.