### PR TITLE
BUGFIX: use Minitest rather than deprecated MiniTest constant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # main [(unreleased)](https://github.com/whitesmith/rubycritic/compare/v4.8.1...main)
 
+* [BUGFIX] Stop using long-deprecated MiniTest module name, removed in 5.19.0 (by [@faisal][])
+
 # v4.8.1 / 2023-05-17 [(commits)](https://github.com/whitesmith/rubycritic/compare/v4.8.0...v4.8.1)
 
 * [CHANGE] Update runtime dependencies to current versions of analysis gems (by [@faisal][])

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -10,7 +10,7 @@ require 'minitest/spec'
 # Provides runner methods used in the cucumber steps.
 #
 class RubyCriticWorld
-  extend MiniTest::Assertions
+  extend Minitest::Assertions
   attr_accessor :assertions
 
   def initialize

--- a/rubycritic.gemspec
+++ b/rubycritic.gemspec
@@ -54,7 +54,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'mdl', '~> 0.12.0'
   spec.add_development_dependency 'minitest', '>= 5.3.0'
   spec.add_development_dependency 'minitest-around', '~> 0.5.0', '>= 0.4.0'
-  spec.add_development_dependency 'mocha', '~> 2.0.2'
+  spec.add_development_dependency 'mocha', '~> 2.1.0'
   spec.add_development_dependency 'rake', '~> 13.0.6', '>= 11.0.0'
   spec.add_development_dependency 'rexml', '>= 3.2.0'
   spec.add_development_dependency 'rubocop', '~> 1.51.0'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -54,7 +54,7 @@ module PathHelper
   end
 end
 
-module MiniTest
+module Minitest
   module Assertions
     ##
     # Fails unless <tt>exp</tt> and <tt>act</tt> are both arrays and
@@ -77,7 +77,7 @@ module MiniTest
 
   module Expectations
     ##
-    # See MiniTest::Assertions#assert_matched_arrays
+    # See Minitest::Assertions#assert_matched_arrays
     #
     #     [1,2,3].must_match_array [3,2,1]
     #


### PR DESCRIPTION
Minitest 5.19.0 only loads the legacy compatibility layer if you have the MT_COMPAT environment variable set -- https://github.com/minitest/minitest/commit/a2c6c18570f6f0a1bf6af70fe3b6d9599a13fdd6. This causes use of the MiniTest module name to fail, as well as the bundled older mocha. Fix our code to use the correct Minitest name, and update to a fixed mocha.

Check list:
- [X] Add an entry to the [changelog](https://github.com/whitesmith/rubycritic/blob/main/CHANGELOG.md)
- [X] [Squash all commits into a single one](https://github.com/whitesmith/rubycritic/blob/main/CONTRIBUTING.md)
- [X] Describe your PR, link issues, etc.
