### PR TITLE
ISSUE-456: Disable VERBOSE warnings in test stubs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * [CHANGE] Fix test warning related to `cucumber_opts` declaration (by [@faisal][])
 * [BUGFIX] Stop using long-deprecated MiniTest module name, removed in 5.19.0 (by [@faisal][])
+* [CHANGE] Disable VERBOSE warnings in test stubs (by [@fbuys][])
 
 # v4.8.1 / 2023-05-17 [(commits)](https://github.com/whitesmith/rubycritic/compare/v4.8.0...v4.8.1)
 

--- a/test/fakefs_helper.rb
+++ b/test/fakefs_helper.rb
@@ -5,9 +5,13 @@ require 'fakefs/safe'
 
 module FakeFS
   class File < StringIO
+    # $VERBOSE = nil to suppress warnings when we overrie flock.
+    original_verbose = $VERBOSE
+    $VERBOSE = nil
     def flock(*)
       true
     end
+    $VERBOSE = original_verbose
   end
 end
 

--- a/test/lib/rubycritic/commands/compare_test.rb
+++ b/test/lib/rubycritic/commands/compare_test.rb
@@ -9,9 +9,13 @@ require 'rubycritic/source_control_systems/git'
 module RubyCritic
   module SourceControlSystem
     class Git < Base
+      # $VERBOSE = nil to suppress warnings when we overrie self.current_branch.
+      original_verbose = $VERBOSE
+      $VERBOSE = nil
       def self.current_branch
         'feature_branch'
       end
+      $VERBOSE = original_verbose
     end
   end
 


### PR DESCRIPTION
To prevent warning during tests while we deliberately override certain methods.

Warnings include:
rubycritic/test/fakefs_helper.rb:8: warning: method redefined; discarding old flock rubycritic/.bundle/ruby/3.2.0/gems/fakefs-2.4.0/lib/fakefs/file.rb:586: warning: previous definition of flock was here rubycritic/test/lib/rubycritic/commands/compare_test.rb:12: warning: method redefined; discarding old current_branch rubycritic/lib/rubycritic/source_control_systems/git.rb:82: warning: previous definition of current_branch was here

See: https://github.com/whitesmith/rubycritic/issues/465

An alternative would be to turn warning completely off during test, but I believe warnings to play an important role.
In this case turning them off temporarily seems like a good idea because we are overriding methods specifically for tests.

Check list:
- [x] Add an entry to the [changelog](https://github.com/whitesmith/rubycritic/blob/main/CHANGELOG.md)
- [x] [Squash all commits into a single one](https://github.com/whitesmith/rubycritic/blob/main/CONTRIBUTING.md)
- [x] Describe your PR, link issues, etc.
