### PR TITLE
ISSUE-462: Add rexml dependency for Ruby 3.0.0+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * [CHANGE] Fix test warning related to `cucumber_opts` declaration (by [@faisal][])
 * [BUGFIX] Stop using long-deprecated MiniTest module name, removed in 5.19.0 (by [@faisal][])
 * [CHANGE] Disable VERBOSE warnings in test stubs (by [@fbuys][])
+* [CHANGE] Add rexml dependency for Ruby 3.0.0+ support (by [@fbuys][])
 
 # v4.8.1 / 2023-05-17 [(commits)](https://github.com/whitesmith/rubycritic/compare/v4.8.0...v4.8.1)
 
@@ -433,3 +434,4 @@
 [@faisal]: https://github.com/faisal
 [@96RadhikaJadhav]: https://github.com/96RadhikaJadhav
 [@Fito]: https://github.com/Fito
+[@fbuys]: https://github.com/fbuys

--- a/rubycritic.gemspec
+++ b/rubycritic.gemspec
@@ -36,6 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'parser', '>= 3.2.2.1'
   spec.add_runtime_dependency 'rainbow', '~> 3.1.1'
   spec.add_runtime_dependency 'reek', '~> 6.0', '< 7.0'
+  spec.add_runtime_dependency 'rexml'
   spec.add_runtime_dependency 'ruby_parser', '~> 3.20'
   spec.add_runtime_dependency 'simplecov', '>= 0.22.0'
   spec.add_runtime_dependency 'tty-which', '~> 0.5.0'


### PR DESCRIPTION
We add rexml as a runtime dependency for environments that make use of Ruby 3 and up.

See: https://stackoverflow.com/a/65480744
Issue: https://github.com/whitesmith/rubycritic/issues/462

rexml does not add any additional dependencies: https://rubygems.org/gems/rexml.

I did test that this works with Ruby 3.2.2 and Ruby 2.7.8.

Check list:
- [x] Add an entry to the [changelog](https://github.com/whitesmith/rubycritic/blob/main/CHANGELOG.md)
- [x] [Squash all commits into a single one](https://github.com/whitesmith/rubycritic/blob/main/CONTRIBUTING.md)
- [x] Describe your PR, link issues, etc.
