### PR TITLE
Issue 461 - Fix for churn score when accessed from a sub-directory

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -145,6 +145,7 @@ detectors:
     - RubyCritic::SourceControlSystem::Git#head_reference
     - RubyCritic::SourceControlSystem::Git#revisions_count
     - RubyCritic::SourceControlSystem::Git#stashes_count
+    - RubyCritic::SourceControlSystem::Git::Churn#filename_for_subdirectory
     - RubyCritic::SourceControlSystem::Mercurial#date_of_last_commit
     - RubyCritic::SourceControlSystem::Mercurial#revisions_count
     - RubyCritic::ViewHelpers#code_index_path
@@ -180,3 +181,6 @@ detectors:
     exclude:
     - RubyCritic::Config#self.method_missing
     - RubyCritic::Config#self.respond_to_missing?
+  TooManyMethods:
+    exclude:
+    - RubyCritic::SourceControlSystem::Git::Churn

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [CHANGE] Disable VERBOSE warnings in test stubs (by [@fbuys][])
 * [CHANGE] Add rexml dependency for Ruby 3.0.0+ support (by [@fbuys][])
 * [BUGFIX] Raise error when the same branches are compared (by [@rishijain][])
+* [BUGFIX] Churn score was always 0 when rubycritic was executed from a sub-directory (by [@rishijain][])
 
 # v4.8.1 / 2023-05-17 [(commits)](https://github.com/whitesmith/rubycritic/compare/v4.8.0...v4.8.1)
 

--- a/lib/rubycritic/source_control_systems/git/churn.rb
+++ b/lib/rubycritic/source_control_systems/git/churn.rb
@@ -73,6 +73,7 @@ module RubyCritic
           when /^[RC]/
             process_rename(*rest)
           else
+            rest = filename_for_subdirectory(rest[0])
             process_file(*rest)
           end
         end
@@ -84,6 +85,15 @@ module RubyCritic
         def process_rename(from, to)
           renames.renamed(from, to)
           process_file(to)
+        end
+
+        def filename_for_subdirectory(filename)
+          git_path = Git.git('rev-parse --show-toplevel')
+          cd_path = Dir.pwd
+          if cd_path.length > git_path.length
+            filename = filename.sub(/^#{Regexp.escape("#{File.basename(cd_path)}/")}/, '')
+          end
+          [filename]
         end
 
         def process_file(filename)


### PR DESCRIPTION
This is a fix for https://github.com/whitesmith/rubycritic/issues/461.

From my research, I understood that there are 2 ways to fix this. 
1) When the score is already set for the paths, so when you are trying to fetch the churn score of a file, adjust the path of the file to match the file name that is being stored in the @stats variable.

2) Adjust the filename when the score is being set, and then fetch the score of the file without any manipulation.

I decided to go with 2nd approach as it seems more cleaner way of solving this.

Check list:
- [x] Add an entry to the [changelog](https://github.com/whitesmith/rubycritic/blob/main/CHANGELOG.md)
- [x] [Squash all commits into a single one](https://github.com/whitesmith/rubycritic/blob/main/CONTRIBUTING.md)
- [x] Describe your PR, link issues, etc.
