### PR TITLE
Issue 469 - Fallback to overview.html when pages do not exist for compare option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * [CHANGE] Add rexml dependency for Ruby 3.0.0+ support (by [@fbuys][])
 * [BUGFIX] Raise error when the same branches are compared (by [@rishijain][])
 * [BUGFIX] Churn score was always 0 when rubycritic was executed from a sub-directory (by [@rishijain][])
+* [BUGFIX] Use overview.html as the fallback path when files does not exist during compare option (by [@rishijain][])
 
 # v4.8.1 / 2023-05-17 [(commits)](https://github.com/whitesmith/rubycritic/compare/v4.8.0...v4.8.1)
 

--- a/lib/rubycritic/generators/html/view_helpers.rb
+++ b/lib/rubycritic/generators/html/view_helpers.rb
@@ -24,7 +24,10 @@ module RubyCritic
     end
 
     def code_index_path(root_directory, file_name)
-      file_path("#{File.expand_path(root_directory)}/#{file_name}")
+      root_directory_path = File.expand_path(root_directory)
+      index_path = "#{root_directory_path}/#{file_name}"
+      index_path = "#{root_directory_path}/overview.html" unless File.exist?(index_path)
+      file_path(index_path)
     end
 
     private


### PR DESCRIPTION
Check list:
- [ x ] Add an entry to the [changelog](https://github.com/whitesmith/rubycritic/blob/main/CHANGELOG.md)
- [ x ] [Squash all commits into a single one](https://github.com/whitesmith/rubycritic/blob/main/CONTRIBUTING.md)
- [ x ] Describe your PR, link issues, etc.

Description: This fixes issue #469 .