### PR TITLE
Issue 377 - Raise error when same branches are compared

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * [CHANGE] Fix test warning related to `cucumber_opts` declaration (by [@faisal][])
 * [BUGFIX] Stop using long-deprecated MiniTest module name, removed in 5.19.0 (by [@faisal][])
 * [CHANGE] Disable VERBOSE warnings in test stubs (by [@fbuys][])
+* [BUGFIX] Raise error when the same branches are compared (by [@rishijain][])
 
 # v4.8.1 / 2023-05-17 [(commits)](https://github.com/whitesmith/rubycritic/compare/v4.8.0...v4.8.1)
 

--- a/lib/rubycritic/commands/compare.rb
+++ b/lib/rubycritic/commands/compare.rb
@@ -18,6 +18,10 @@ module RubyCritic
       end
 
       def execute
+        if Config.send(:base_branch) == Config.send(:feature_branch)
+          raise('The branch you are on and are comparing with are the same.
+          Please switch to a different branch or choose a different branch to compare.')
+        end
         compare_branches
         status_reporter.score = Config.feature_branch_score
         status_reporter

--- a/test/lib/rubycritic/commands/compare_test.rb
+++ b/test/lib/rubycritic/commands/compare_test.rb
@@ -33,6 +33,22 @@ describe RubyCritic::Command::Compare do
     RubyCritic::SourceControlSystem::Git.stubs(:modified_files).returns('test/samples/compare_file.rb')
   end
 
+  describe 'comparing the branches with the compare option' do
+    context 'when same branches are compared' do
+      it 'it aborts with the error message' do
+        options = ['-b', 'feature_branch']
+        options = RubyCritic::Cli::Options.new(options).parse.to_h
+        RubyCritic::Config.set(options)
+        comparison = RubyCritic::Command::Compare.new(options)
+
+        assert_raises('The branch you are on and are comparing with are the same.
+        Please switch to a different branch or choose a different branch to compare.') do
+          comparison.execute
+        end
+      end
+    end
+  end
+
   describe 'comparing the same file for two different branches' do
     after do
       # clear file contents after tests
@@ -65,6 +81,7 @@ describe RubyCritic::Command::Compare do
         options = ['-b', 'feature_branch', '-t', '0', 'test/samples/compare_file.rb']
         options = RubyCritic::Cli::Options.new(options).parse.to_h
         RubyCritic::Config.set(options)
+        RubyCritic::Config.set(base_branch: 'base_branch')
         copy_proc = proc do |_|
           FileUtils.cp 'test/samples/base_branch_file.rb', 'test/samples/compare_file.rb'
         end


### PR DESCRIPTION
Check list:
- [ x ] Add an entry to the [changelog](https://github.com/whitesmith/rubycritic/blob/main/CHANGELOG.md)
- [ x ] [Squash all commits into a single one](https://github.com/whitesmith/rubycritic/blob/main/CONTRIBUTING.md)
- [ x ] Describe your PR, link issues, etc.

Description: This fixes the issue reported in #377 
<img width="1413" alt="Screenshot 2023-10-17 at 5 38 32 PM" src="https://github.com/whitesmith/rubycritic/assets/946527/51d7f0b1-1e1a-4f68-ac1f-eb63cd55616d">

