### PR TITLE
used name from file path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [BUGFIX] Raise error when the same branches are compared (by [@rishijain][])
 * [BUGFIX] Churn score was always 0 when rubycritic was executed from a sub-directory (by [@rishijain][])
 * [BUGFIX] Use overview.html as the fallback path when files does not exist during compare option (by [@rishijain][])
+* [BUGFIX] Use name from the file path instead of fetching name from the parser (by [@rishijain][])
 
 # v4.8.1 / 2023-05-17 [(commits)](https://github.com/whitesmith/rubycritic/compare/v4.8.0...v4.8.1)
 

--- a/lib/rubycritic/analysers/helpers/modules_locator.rb
+++ b/lib/rubycritic/analysers/helpers/modules_locator.rb
@@ -9,7 +9,7 @@ module RubyCritic
     end
 
     def first_name
-      names.first
+      name_from_path.first
     end
 
     def names


### PR DESCRIPTION
Check list:
- [x] Add an entry to the [changelog](https://github.com/whitesmith/rubycritic/blob/main/CHANGELOG.md)
- [x] [Squash all commits into a single one](https://github.com/whitesmith/rubycritic/blob/main/CONTRIBUTING.md)
- [x] Describe your PR, link issues, etc.

Description: It fixes [this](https://github.com/whitesmith/rubycritic/issues/154) issue.

For a file `foo.rb` which has code:
```
module Foo
  class Jj; end
  def bar(x,y,z); end
  class Wtf; end
end
```

if we run `rubycritic foo.rb`, all the smells it reports is labelled under file `Foo::Jj`. Which is not right. For example: for smells reported for `def bar(x,y,z)` should not be listed under `Foo:Jj` as that class is closed. It should show `Foo`.

Snapshot of what it was before and after the change when we run `rubycritic foo.rb`
Before:
<img width="1305" alt="Screenshot 2023-10-18 at 10 55 53 PM" src="https://github.com/whitesmith/rubycritic/assets/946527/c0612352-d586-4d78-b209-e6e08bdc7e6b">


After:
<img width="1297" alt="Screenshot 2023-10-18 at 10 57 03 PM" src="https://github.com/whitesmith/rubycritic/assets/946527/d8bcd626-1f4c-4602-95c2-e4f6fdffcdc0">

I think it makes more sense to show the class/module name extracted from the file name rather than showing a sub-class within that file for all the smells.
