### PR TITLE
add coverage data to compare view

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -85,3 +85,7 @@ Lint/StructNewOverride:
 Metrics/AbcSize:
   Exclude:
     - 'lib/rubycritic/configuration.rb'
+
+Metrics/MethodLength:
+  Exclude:
+    - 'lib/rubycritic/core/analysed_modules_collection.rb'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # main [(unreleased)](https://github.com/whitesmith/rubycritic/compare/v4.9.0...main)
 
+* [BUGFIX] Pass coverage data for compare branch mode (by [@rishijain][])
+
 # v4.9.0 / 2023-10-18 [(commits)](https://github.com/whitesmith/rubycritic/compare/v4.8.1...v4.9.0)
 
 * [CHANGE] Bump aruba, cucumber, fakefs, flog, mdl, minitest, and rubocop dependencies (by [@faisal][])

--- a/lib/rubycritic/core/analysed_module.rb
+++ b/lib/rubycritic/core/analysed_module.rb
@@ -82,7 +82,7 @@ module RubyCritic
         name: name, path: path, smells: smells,
         churn: churn, committed_at: committed_at, complexity: complexity,
         duplication: duplication, methods_count: methods_count, cost: cost,
-        rating: rating
+        rating: rating, coverage: coverage
       }
     end
 

--- a/lib/rubycritic/core/analysed_modules_collection.rb
+++ b/lib/rubycritic/core/analysed_modules_collection.rb
@@ -88,7 +88,8 @@ module RubyCritic
         committed_at: analysed_module.committed_at,
         complexity: analysed_module.complexity,
         duplication: analysed_module.duplication,
-        methods_count: analysed_module.methods_count
+        methods_count: analysed_module.methods_count,
+        coverage: analysed_module.coverage
       )
     end
   end

--- a/test/lib/rubycritic/core/analysed_modules_collection_test.rb
+++ b/test/lib/rubycritic/core/analysed_modules_collection_test.rb
@@ -49,7 +49,7 @@ describe RubyCritic::AnalysedModulesCollection do
       let(:analysed_modules) do
         [RubyCritic::AnalysedModule.new(pathname: Pathname.new('test/samples/empty.rb'), name: 'Name', smells: [],
                                         churn: 2, committed_at: Time.now, complexity: 2, duplication: 0,
-                                        methods_count: 2)]
+                                        methods_count: 2, coverage: 70.0)]
       end
 
       it 'registers one AnalysedModule element per existent file' do
@@ -61,6 +61,7 @@ describe RubyCritic::AnalysedModulesCollection do
         _(analysed_module.complexity).must_equal 2
         _(analysed_module.duplication).must_equal 0
         _(analysed_module.methods_count).must_equal 2
+        _(analysed_module.coverage).must_equal 70.0
       end
     end
   end


### PR DESCRIPTION
Check list:
- [x] Add an entry to the [changelog](https://github.com/whitesmith/rubycritic/blob/main/CHANGELOG.md)
- [x] [Squash all commits into a single one](https://github.com/whitesmith/rubycritic/blob/main/CONTRIBUTING.md)
- [x] Describe your PR, link issues, etc.


This fixes issue: https://github.com/whitesmith/rubycritic/issues/423
I noticed that we are not passing any coverage data and the default value of it being 0, it shows 0% against all the files for compare build view.