### PR TITLE
[Issue - 413 ] Support for wildcard in paths options

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -92,9 +92,11 @@ detectors:
   DuplicateMethodCall:
     exclude:
     - RubyCritic::Analyser::Churn#run
+    - RubyCritic::Configuration#set
     - Parser::AST::Node#module_name
   TooManyStatements:
     exclude:
+    - RubyCritic::Configuration#find_directories
     - RubyCritic::RakeTask#initialize
     - RubyCritic::Analyser::Complexity#run
     - RubyCritic::Analyser::Coverage#synchronize_resultset
@@ -118,6 +120,7 @@ detectors:
     - RubyCritic::ViewHelpers#smell_location_path
     - RubyCritic::Generator::HtmlReport#create_directories_and_files
     - RubyCritic::SourceLocator#deduplicate_symlinks
+    - RubyCritic::Configuration#setup_paths_for_targets
   NestedIterators:
     exclude:
     - Parser::AST::Node#recursive_children
@@ -125,8 +128,10 @@ detectors:
     - RubyCritic::Cli::Options::Argv#parse
     - RubyCritic::Generator::HtmlReport#create_directories_and_files
     - RubyCritic::AnalysedModulesCollection#initialize
+    - RubyCritic::Configuration#find_directories
   UtilityFunction:
     exclude:
+    - RubyCritic::Configuration#find_directories
     - RubyCritic::Analyser::Coverage#resultset_path
     - RubyCritic::Analyser::Coverage#resultset_writelock
     - RubyCritic::Analyser::FlaySmells#cost

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -85,3 +85,11 @@ Lint/StructNewOverride:
 Metrics/AbcSize:
   Exclude:
     - 'lib/rubycritic/configuration.rb'
+
+Metrics/MethodLength:
+  Exclude:
+    - 'lib/rubycritic/configuration.rb'
+
+Style/RedundantAssignment:
+  Exclude:
+    - 'lib/rubycritic/configuration.rb'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # main [(unreleased)](https://github.com/whitesmith/rubycritic/compare/v4.9.0...main)
 
+* [CHANGE] Add support for wildcard entries to the paths option in rubycritic.yml (by [@rishiain][])
+
 # v4.9.0 / 2023-10-18 [(commits)](https://github.com/whitesmith/rubycritic/compare/v4.8.1...v4.9.0)
 
 * [CHANGE] Bump aruba, cucumber, fakefs, flog, mdl, minitest, and rubocop dependencies (by [@faisal][])

--- a/lib/rubycritic/configuration.rb
+++ b/lib/rubycritic/configuration.rb
@@ -20,9 +20,14 @@ module RubyCritic
       self.open_with = options[:open_with]
       self.no_browser = options[:no_browser]
       self.threshold_score = options[:threshold_score].to_i
+      setup_paths_for_targets(options) if options[:paths]
       setup_analysis_targets(options)
       setup_version_control(options)
       setup_formats(options)
+    end
+
+    def setup_paths_for_targets(options)
+      options[:paths] = find_directories(options[:paths])
     end
 
     def setup_analysis_targets(options)
@@ -49,6 +54,20 @@ module RubyCritic
     def source_control_present?
       source_control_system &&
         !source_control_system.is_a?(SourceControlSystem::Double)
+    end
+
+    private
+
+    def find_directories(paths)
+      expanded_paths = paths.flat_map do |path|
+        if path.include?('**')
+          search_pattern = File.join(path)
+          Dir.glob(search_pattern).select { |tmp_path| File.directory?(tmp_path) && !tmp_path.start_with?('tmp') }
+        else
+          path
+        end
+      end
+      expanded_paths
     end
   end
 


### PR DESCRIPTION
Check list:
- [x] Add an entry to the [changelog](https://github.com/whitesmith/rubycritic/blob/main/CHANGELOG.md)
- [x] [Squash all commits into a single one](https://github.com/whitesmith/rubycritic/blob/main/CONTRIBUTING.md)
- [x] Describe your PR, link issues, etc.

### Description:
This PR adds support for passing **(wildcard) paths to the .rubycritic.yml file. So now someone can do something like:

```
paths:
  - app
  - packs/*/app
```

This was requested [here](https://github.com/whitesmith/rubycritic/issues/413).

The way I have implemented is to basically find all the valid directories that the ** expands to, so for example:
if user passes `packs/*/app` and in the app, `packs` has 3 sub-directories in it but only 2 of them has `app` inside those sub-directories, I am resetting the options[:paths] to `['app', 'packs/pack1/app', 'packs/pack2/app' ]`.