### PR TITLE
Fix some typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # main [(unreleased)](https://github.com/whitesmith/rubycritic/compare/v4.9.0...main)
 
+* [CHANGE] Fix some typos (by [@jbampton][])
+
 # v4.9.0 / 2023-10-18 [(commits)](https://github.com/whitesmith/rubycritic/compare/v4.8.1...v4.9.0)
 
 * [CHANGE] Bump aruba, cucumber, fakefs, flog, mdl, minitest, and rubocop dependencies (by [@faisal][])
@@ -103,7 +105,7 @@
 
 # v4.3.0 / 2019-12-26 [(commits)](https://github.com/whitesmith/rubycritic/compare/v4.2.2...v4.3.0)
 
-* [FEATURE] Show which files are uncommited in git (by [@GeoffTidey][])
+* [FEATURE] Show which files are uncommitted in git (by [@GeoffTidey][])
 * [BUGFIX] Fixes TypeError when `.resultset.json` is not found (by [@etagwerker][])
 
 # v4.2.2 / 2019-11-12 [(commits)](https://github.com/whitesmith/rubycritic/compare/v4.2.1...v4.2.2)
@@ -341,7 +343,7 @@
 
 * [FEATURE] Add CI mode that only analyses the last commit
 * [FEATURE] Add partial support for Mercurial
-* [FEATURE] Allow using RubyCritic programatically
+* [FEATURE] Allow using RubyCritic programmatically
 * [CHANGE] Update to Reek 1.6.0 (from 1.3.8)
 * [BUGFIX] Fix issue #18 - Prevent encoding issues when using Git
 

--- a/test/fakefs_helper.rb
+++ b/test/fakefs_helper.rb
@@ -5,7 +5,7 @@ require 'fakefs/safe'
 
 module FakeFS
   class File < StringIO
-    # $VERBOSE = nil to suppress warnings when we overrie flock.
+    # $VERBOSE = nil to suppress warnings when we override flock.
     original_verbose = $VERBOSE
     $VERBOSE = nil
     def flock(*)

--- a/test/lib/rubycritic/commands/compare_test.rb
+++ b/test/lib/rubycritic/commands/compare_test.rb
@@ -101,7 +101,7 @@ describe RubyCritic::Command::Compare do
       @options = RubyCritic::Cli::Options.new(options).parse.to_h
     end
 
-    it 'with -b option withour pull request id' do
+    it 'with -b option without pull request id' do
       _(@options[:base_branch]).must_equal 'base_branch'
       _(@options[:feature_branch]).must_equal 'feature_branch'
       _(@options[:mode]).must_equal :compare_branches

--- a/test/lib/rubycritic/source_control_systems/git/churn_test.rb
+++ b/test/lib/rubycritic/source_control_systems/git/churn_test.rb
@@ -79,7 +79,7 @@ describe RubyCritic::SourceControlSystem::Git::Churn do
         .must_equal 4
     end
 
-    it 'returns 0 for an uncommited file' do
+    it 'returns 0 for an uncommitted file' do
       _(churn.revisions_count('non_existent_file')).must_equal 0
     end
 
@@ -134,7 +134,7 @@ describe RubyCritic::SourceControlSystem::Git::Churn do
         .must_equal '2014-03-19 18:17:28 +0000'
     end
 
-    it 'returns nil for an uncommited file' do
+    it 'returns nil for an uncommitted file' do
       assert_nil(churn.date_of_last_commit('non_existent_file'))
     end
   end


### PR DESCRIPTION
Fixed spelling in the `CHANGELOG.md` and in some Ruby files 

Check list:
- [X] Add an entry to the [changelog](https://github.com/whitesmith/rubycritic/blob/main/CHANGELOG.md)
- [X] [Squash all commits into a single one](https://github.com/whitesmith/rubycritic/blob/main/CONTRIBUTING.md)
- [X] Describe your PR, link issues, etc.

