### PR TITLE
Fixed reference to old cli argument in formatter docs

### DIFF
--- a/docs/formatters.md
+++ b/docs/formatters.md
@@ -59,12 +59,12 @@ See the [Rakefile](https://github.com/MarcGrimme/repo-small-badge/blob/master/Ra
 
 When *rubycritic* is called outside of the structure that has to be **criticized** with just calling the command.
 The path to load as well, as the fully qualified classname of the formatter, have to be passed.
-This happens with the `--formatter` option followed by the path to require (*requirepath*) a `:` as a separator and the fully qualified *classname*.
+This happens with the `--custom-format` option followed by the path to require (*requirepath*) a `:` as a separator and the fully qualified *classname*.
 An example could look as follows:
 
 ``` shell
 gem install my_formatter_gem
-rubycritic --formatter my_formatter:MyFormatter
+rubycritic --custom-format my_formatter:MyFormatter
 ```
 
 This will do the same as above.


### PR DESCRIPTION
Check list:
- [ ] ~Add an entry to the [changelog](https://github.com/whitesmith/rubycritic/blob/main/CHANGELOG.md)~
- [x] ~[Squash all commits into a single one](https://github.com/whitesmith/rubycritic/blob/main/CONTRIBUTING.md)~
- [X] Describe your PR, link issues, etc.

### Issue

Following the docs for adding a custom formatter leads the reader to use cli options that do not work:
```shell
rubycritic --formatter my_formatter:MyFormatter
# => Error: invalid option: --formatter
# => Did you mean?  format
```

### Solution

Looking at the code, `--formatter` is not a valid option and instead `--custom-format` should be used. I'm assuming this was just a missed reference when the arg was updated.