### PR TITLE
Drop Ruby 2.7 support, and take advantage of Ruby 3.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version:
-          - '2.7'
           - '3.0'
           - '3.1'
           - '3.2'
@@ -59,7 +58,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version:
-          - '2.7'
           - '3.0'
           - '3.1'
           - '3.2'
@@ -89,7 +87,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version:
-          - '2.7'
           - '3.0'
           - '3.1'
           - '3.2'
@@ -119,7 +116,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version:
-          - '2.7'
           - '3.0'
           - '3.1'
           - '3.2'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,7 +11,7 @@ AllCops:
     - 'tmp/**/*'
     - 'vendor/**/*'
     - 'gemfiles/*'
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.0
 
 Metrics/BlockLength:
   Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # main [(unreleased)](https://github.com/whitesmith/rubycritic/compare/v4.9.0...main)
 
+* [CHANGE] Drop support for Ruby 2.7.x (by [@faisal][])
 * [CHANGE] Bump cucumber, minitest, parser, rake, reek, rubocop, and ruby_parser dependencies (by [@faisal][])
 * [CHANGE] Fix some typos (by [@jbampton][])
 * [FEATURE] Add coverage_path configuration option (by [@exoego][])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # main [(unreleased)](https://github.com/whitesmith/rubycritic/compare/v4.9.1...main)
+
 * [CHANGE] Drop support for Ruby 2.7.x (by [@faisal][])
 
 # v4.9.1 / 2024-04-14 [(commits)](https://github.com/whitesmith/rubycritic/compare/v4.9.0...v4.9.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # main [(unreleased)](https://github.com/whitesmith/rubycritic/compare/v4.9.1...main)
+* [CHANGE] Drop support for Ruby 2.7.x (by [@faisal][])
 
 # v4.9.1 / 2024-04-14 [(commits)](https://github.com/whitesmith/rubycritic/compare/v4.9.0...v4.9.1)
 
-* [CHANGE] Drop support for Ruby 2.7.x (by [@faisal][])
 * [CHANGE] Bump cucumber, minitest, parser, rake, reek, rubocop, and ruby_parser dependencies (by [@faisal][])
 * [CHANGE] Fix some typos (by [@jbampton][])
 * [FEATURE] Add coverage_path configuration option (by [@exoego][])

--- a/README.md
+++ b/README.md
@@ -241,9 +241,11 @@ RubyCritic is supporting Ruby versions:
 | 2.4 | [v4.7.0](https://github.com/whitesmith/rubycritic/tree/v4.7.0) |
 | 2.5 | [v4.7.0](https://github.com/whitesmith/rubycritic/tree/v4.7.0) |
 | 2.6 | [v4.7.0](https://github.com/whitesmith/rubycritic/tree/v4.7.0) |
-| 2.7 | latest |
+| 2.7 | [v4.9.0](https://github.com/whitesmith/rubycritic/tree/v4.9.0) |
 | 3.0 | latest |
 | 3.1 | latest |
+| 3.2 | latest |
+| 3.3 | latest |
 
 ## Improving RubyCritic
 

--- a/lib/rubycritic/configuration.rb
+++ b/lib/rubycritic/configuration.rb
@@ -70,9 +70,9 @@ module RubyCritic
       !Config.no_browser && %i[compare_branches ci].include?(Config.mode)
     end
 
-    def self.method_missing(method, *args, &block)
+    def self.method_missing(method, ...)
       if configuration.respond_to?(method)
-        configuration.public_send(method, *args, &block)
+        configuration.public_send(method, ...)
       else
         super
       end

--- a/rubycritic.gemspec
+++ b/rubycritic.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'RubyCritic is a Ruby code quality reporter'
   spec.homepage      = 'https://github.com/whitesmith/rubycritic'
   spec.license       = 'MIT'
-  spec.required_ruby_version = '>= 2.7.0'
+  spec.required_ruby_version = '>= 3.0.0'
 
   spec.files = [
     'CHANGELOG.md',
@@ -33,9 +33,9 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'flay', '~> 2.13'
   spec.add_runtime_dependency 'flog', '~> 4.7'
   spec.add_runtime_dependency 'launchy', '>= 2.5.2'
-  spec.add_runtime_dependency 'parser', '>= 3.2.2.4'
+  spec.add_runtime_dependency 'parser', '>= 3.3.0.5'
   spec.add_runtime_dependency 'rainbow', '~> 3.1.1'
-  spec.add_runtime_dependency 'reek', '~> 6.0', '< 6.2'
+  spec.add_runtime_dependency 'reek', '~> 6.3.0', '< 7.0'
   spec.add_runtime_dependency 'rexml'
   spec.add_runtime_dependency 'ruby_parser', '~> 3.21'
   spec.add_runtime_dependency 'simplecov', '>= 0.22.0'
@@ -58,7 +58,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'mocha', '~> 2.2.0'
   spec.add_development_dependency 'rake', '~> 13.2.0', '>= 11.0.0'
   spec.add_development_dependency 'rexml', '>= 3.2.0'
-  spec.add_development_dependency 'rubocop', '~> 1.59.0', '>= 1.54.0' # >= 1.60 requires Ruby 3
+  spec.add_development_dependency 'rubocop', '~> 1.63.0', '>= 1.54.0'
   spec.add_development_dependency 'rubocop-minitest'
   spec.add_development_dependency 'rubocop-performance'
   spec.add_development_dependency 'rubocop-rake'


### PR DESCRIPTION
Drop support for Ruby 2.7.

- In the gemspec, Bump `spec.required_ruby_version` to 3.0, and bump
  some of the `gem` requirements that were held back by the need for
  Ruby 2.7 compatibility.
- Bump rubocop's `TargetRubyVersion` to 3.0. Take safe autocorrections.
- Remove Ruby 2.7 from the `ruby-version` lists in the test matrix.

**Note:** This is one commit _on top of_ the pull request for [updating dependencies that still work on Ruby 2.7](https://github.com/whitesmith/rubycritic/pull/480). I split them this way on the theory that a Rubycritic 4.9.1 could keep Ruby 2.7 support, then a Rubycritic 5.0 could bump the minimum support bar to Ruby 3.0 (which is expected to EOL two days ago). I think it approach gives flexibility while settling on a [compatibility policy](https://github.com/whitesmith/rubycritic/issues/482), but they could also be squashed together.

Check list:
- [x] Add an entry to the [changelog](https://github.com/whitesmith/rubycritic/blob/main/CHANGELOG.md)
- [x] [Squash all commits into a single one](https://github.com/whitesmith/rubycritic/blob/main/CONTRIBUTING.md)
- [x] Describe your PR, link issues, etc.
