### PR TITLE
Fix - Reek version 6.2 drops ruby2.7 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * [CHANGE] Fix some typos (by [@jbampton][])
 * [FEATURE] Add coverage_path configuration option (by [@exoego][])
+* [BUGFIX] Restrict reek version upper limit (by [@brkn][])
 
 # v4.9.0 / 2023-10-18 [(commits)](https://github.com/whitesmith/rubycritic/compare/v4.8.1...v4.9.0)
 

--- a/rubycritic.gemspec
+++ b/rubycritic.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'launchy', '>= 2.5.2'
   spec.add_runtime_dependency 'parser', '>= 3.2.2.1'
   spec.add_runtime_dependency 'rainbow', '~> 3.1.1'
-  spec.add_runtime_dependency 'reek', '~> 6.0', '< 7.0'
+  spec.add_runtime_dependency 'reek', '~> 6.0', '< 6.2'
   spec.add_runtime_dependency 'rexml'
   spec.add_runtime_dependency 'ruby_parser', '~> 3.20'
   spec.add_runtime_dependency 'simplecov', '>= 0.22.0'


### PR DESCRIPTION
Rubycritic's supported ruby version is >= 2.7.0. But reek dropped support for ruby2.7 at [v6.2](https://github.com/troessner/reek/blob/master/CHANGELOG.md#620-2023-12-31). This pr restricts the reek's version to keep the ruby2.7 support