### PR TITLE
Update CI workflow file to check with Ruby 3.3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,6 +32,7 @@ jobs:
           - '3.0'
           - '3.1'
           - '3.2'
+          - '3.3'
         experimental: [false]
         include:
           - ruby-version: 'ruby-head'
@@ -61,6 +62,7 @@ jobs:
           - '3.0'
           - '3.1'
           - '3.2'
+          - '3.3'
         experimental: [false]
         include:
           - ruby-version: 'ruby-head'
@@ -90,6 +92,7 @@ jobs:
           - '3.0'
           - '3.1'
           - '3.2'
+          - '3.3'
         experimental: [false]
         include:
           - ruby-version: 'ruby-head'
@@ -119,6 +122,7 @@ jobs:
           - '3.0'
           - '3.1'
           - '3.2'
+          - '3.3'
         experimental: [false]
         include:
           - ruby-version: 'ruby-head'
@@ -146,7 +150,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.2'
+          ruby-version: '3.3'
           bundler-cache: true
           cache-version: 1
       - name: Run markdownlint


### PR DESCRIPTION
https://github.com/whitesmith/rubycritic/pull/485 dropped support for Ruby 2.7 but didn't update the workflow file to check on Ruby 3.3. This PR fixes that omission:

- Add Ruby 3.3 to the test matrix.
- Run the MarkdownLint task using Ruby 3.3.

Since this is only a change to the workflow file I do not believe it bears a change to `CHANGELOG.md`, so I have removed that item from the check list.

Check list:
- [X] [Squash all commits into a single one](https://github.com/whitesmith/rubycritic/blob/main/CONTRIBUTING.md)
- [X] Describe your PR, link issues, etc.
