### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ See RubyCritic's [contributing guidelines](https://github.com/whitesmith/rubycri
 
 The current core team consists of:
 
-* [Nuno Silva](https://github.com/Onumis)
+* [Nuno Silva](https://github.com/nunosilva800)
 * [Lucas Mazza](https://github.com/lucasmazza)
 * [Timo Rößner](https://github.com/troessner)
 


### PR DESCRIPTION
Updated Nuno Silva's github profile URL. 
After browsing the repo read me I realized Nuno Silva's github URL was broken within the core team list.

Check list:
- [ ] Add an entry to the [changelog](https://github.com/whitesmith/rubycritic/blob/main/CHANGELOG.md)
- [x] [Squash all commits into a single one](https://github.com/whitesmith/rubycritic/blob/main/CONTRIBUTING.md)
- [x] Describe your PR, link issues, etc.
