### PR TITLE
Add Solargraph config, to enable its use in some LSP fluent editors

### DIFF
--- a/.solargraph.yml
+++ b/.solargraph.yml
@@ -1,0 +1,9 @@
+include:
+- "./**/*.rb"
+exclude:
+- ".bundle/**/*"
+require: []
+domains: []
+reporters:
+- rubocop
+- require_not_found

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # main [(unreleased)](https://github.com/whitesmith/rubycritic/compare/v4.9.1...main)
 
+* [CHANGE] Add .solargraph.yml config file to enable Solargraph LSP use in editors such as BBedit (by [@faisal])
 * [CHANGE] Drop support for Ruby 3.0.x (by [@faisal][])
 * [CHANGE] Bump minitest, mocha, rubocop dependencies (by [@faisal][])
 * [CHANGE] Drop support for Ruby 2.7.x (by [@faisal][])


### PR DESCRIPTION
This adds sufficient Solargraph configuration to make it useful when editing in some LSP-compatible editors.

Check list:
- [X] Add an entry to the [changelog](https://github.com/whitesmith/rubycritic/blob/main/CHANGELOG.md)
- [X] [Squash all commits into a single one](https://github.com/whitesmith/rubycritic/blob/main/CONTRIBUTING.md)
- [X] Describe your PR, link issues, etc.
