### PR TITLE
Fakefs 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # main [(unreleased)](https://github.com/whitesmith/rubycritic/compare/v4.9.2...main)
 
+* [CHANGE] Bump fakefs dependency (@by [@faisal][])]
 * [CHANGE] Update CI checkout action to v4 (by [@faisal][])
 
 # v4.9.2 / 2025-04-08 [(commits)](https://github.com/whitesmith/rubycritic/compare/v4.9.1...v4.9.2)

--- a/rubycritic.gemspec
+++ b/rubycritic.gemspec
@@ -51,7 +51,7 @@ Gem::Specification.new do |spec|
   end
   spec.add_development_dependency 'cucumber', '~> 9.2.1', '!= 9.0.0'
   spec.add_development_dependency 'diff-lcs', '~> 1.3'
-  spec.add_development_dependency 'fakefs', '~> 2.6.0'
+  spec.add_development_dependency 'fakefs', '~> 3.0.0'
   spec.add_development_dependency 'irb'
   spec.add_development_dependency 'mdl', '~> 0.13.0', '>= 0.12.0'
   spec.add_development_dependency 'minitest', '~> 5.25.2', '>= 5.3.0'


### PR DESCRIPTION
Pick up the FakeFS 3.0 dependency, which should cut down on warnings about frozen strings.

Check list:
- [x] Add an entry to the [changelog](https://github.com/whitesmith/rubycritic/blob/main/CHANGELOG.md)
- [X] [Squash all commits into a single one](https://github.com/whitesmith/rubycritic/blob/main/CONTRIBUTING.md)
- [X] Describe your PR, link issues, etc.
