### PR TITLE
Update Rubocop dependency to 1.7.3, and adopt new plugins config in Rubocop config.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,4 @@
-require:
+plugins:
   - rubocop-minitest
   - rubocop-performance
   - rubocop-rake

--- a/lib/rubycritic/source_control_systems/mercurial.rb
+++ b/lib/rubycritic/source_control_systems/mercurial.rb
@@ -6,7 +6,8 @@ module RubyCritic
       register_system
 
       def self.supported?
-        `hg verify 2>&1` && $CHILD_STATUS.success?
+        hg_verify = `hg verify 2>&1`
+        hg_verify && $CHILD_STATUS.success?
       end
 
       def self.to_s

--- a/rubycritic.gemspec
+++ b/rubycritic.gemspec
@@ -61,7 +61,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 13.2.0', '>= 11.0.0'
   spec.add_development_dependency 'rdoc'
   spec.add_development_dependency 'rexml', '>= 3.2.0'
-  spec.add_development_dependency 'rubocop', '~> 1.70.0', '>= 1.54.0'
+  spec.add_development_dependency 'rubocop', '~> 1.73.2', '>= 1.72.0'
   spec.add_development_dependency 'rubocop-minitest'
   spec.add_development_dependency 'rubocop-performance'
   spec.add_development_dependency 'rubocop-rake'


### PR DESCRIPTION
Rubocop 1.7.2 introduced a plugins API. This PR updates to this newer Rubocop, and updates the `.rubocop.yml` config to load Rubocop plugins using that API.

Check list:
- [X] Add an entry to the [changelog](https://github.com/whitesmith/rubycritic/blob/main/CHANGELOG.md) - _`main`'s change-log already had a Rubocop update in the pipe, so I didn't change in this commit_
- [X] [Squash all commits into a single one](https://github.com/whitesmith/rubycritic/blob/main/CONTRIBUTING.md)
- [X] Describe your PR, link issues, etc.
