### PR TITLE
Loosen Rubocop dependency to pick up any new versions < 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * [CHANGE] Adds development dependency for gems removed from standard library in Ruby 3.5 -- ostruct, irb, rdoc (by [@faisal][])
 * [CHANGE] Bump aruba, fakefs, minitest, mocha, reek, rubocop dependencies (by [@faisal][])
+* [CHANGE] Loosen Rubocop dependency to pick up any new versions < 2.0 (by [@faisal][])
 * [CHANGE] Add .solargraph.yml config file to enable Solargraph LSP use in editors such as BBedit (by [@faisal][])
 * [CHANGE] Drop support for Ruby 2.7.x, 3.0.x (by [@faisal][])
 * [CHANGE] Cache the reek configuration loading for faster execution (by [@raff-s][])

--- a/rubycritic.gemspec
+++ b/rubycritic.gemspec
@@ -61,7 +61,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 13.2.0', '>= 11.0.0'
   spec.add_development_dependency 'rdoc'
   spec.add_development_dependency 'rexml', '>= 3.2.0'
-  spec.add_development_dependency 'rubocop', '~> 1.73.2', '>= 1.72.0'
+  spec.add_development_dependency 'rubocop', '>= 1.72.0', '< 2.0'
   spec.add_development_dependency 'rubocop-minitest'
   spec.add_development_dependency 'rubocop-performance'
   spec.add_development_dependency 'rubocop-rake'


### PR DESCRIPTION
This change unbinds the version for the Rubocop dependency so it will take any new version prior to 2.0. Rubocop is stable but keeps iterating, so I believe it's worth picking up any new fixes. Since it's a development dependency, doing so should not have a significant risk to the Rubycritic gem itself.

Check list:
- [X] Add an entry to the [changelog](https://github.com/whitesmith/rubycritic/blob/main/CHANGELOG.md)
- [X] [Squash all commits into a single one](https://github.com/whitesmith/rubycritic/blob/main/CONTRIBUTING.md)
- [X] Describe your PR, link issues, etc.
