### PR TITLE
Bump byebug and reek dependencies.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # main [(unreleased)](https://github.com/whitesmith/rubycritic/compare/v4.9.2...main)
 
+* [CHANGE] Bump byebug, reek dependencies (by [@faisal][])
 * [CHANGE] Update CI checkout action to v4 (by [@faisal][])
 
 # v4.9.2 / 2025-04-08 [(commits)](https://github.com/whitesmith/rubycritic/compare/v4.9.1...v4.9.2)

--- a/rubycritic.gemspec
+++ b/rubycritic.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'launchy', '>= 2.5.2'
   spec.add_dependency 'parser', '>= 3.3.0.5'
   spec.add_dependency 'rainbow', '~> 3.1.1'
-  spec.add_dependency 'reek', '~> 6.4.0', '< 7.0'
+  spec.add_dependency 'reek', '~> 6.5.0', '< 7.0'
   spec.add_dependency 'rexml'
   spec.add_dependency 'ruby_parser', '~> 3.21'
   spec.add_dependency 'simplecov', '>= 0.22.0'
@@ -47,7 +47,7 @@ Gem::Specification.new do |spec|
   if RUBY_PLATFORM == 'java'
     spec.add_development_dependency 'pry-debugger-jruby'
   else
-    spec.add_development_dependency 'byebug', '~> 11.0', '>= 10.0'
+    spec.add_development_dependency 'byebug', '~> 12.0', '>= 10.0'
   end
   spec.add_development_dependency 'cucumber', '~> 9.2.1', '!= 9.0.0'
   spec.add_development_dependency 'diff-lcs', '~> 1.3'


### PR DESCRIPTION
This picks up newer dependencies for byebug (which adds support for more Ruby versions, plus some fixes and improvements -- <https://github.com/deivid-rodriguez/byebug/blob/master/CHANGELOG.md>) and reek (of possibly lower value -- <https://github.com/troessner/reek/blob/master/CHANGELOG.md>).

Check list:
- [X] Add an entry to the [changelog](https://github.com/whitesmith/rubycritic/blob/main/CHANGELOG.md)
- [X] [Squash all commits into a single one](https://github.com/whitesmith/rubycritic/blob/main/CONTRIBUTING.md)
- [X] Describe your PR, link issues, etc.
