### PR TITLE
Split experimental steps

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,6 +37,7 @@ jobs:
         include:
           - ruby-version: 'ruby-head'
             experimental: true
+            continue-on-error: true
           - ruby-version: 'jruby-9.4'
             experimental: true
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
           paths_ignore: '["**/README.md", "**/docs/**", "**/CHANGELOG.md"]'
           do_not_skip: '["pull_request", "workflow_dispatch", "schedule"]'
 
-  Features:
+  Features-supported:
     needs: pre_job # skip duplicates
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     runs-on: ubuntu-latest
@@ -34,12 +34,6 @@ jobs:
           - '3.3'
           - '3.4'
         experimental: [false]
-        include:
-          - ruby-version: 'ruby-head'
-            experimental: true
-            continue-on-error: true
-          - ruby-version: 'jruby-9.4'
-            experimental: true
     steps:
       - uses: actions/checkout@v2
       - name: Set up Ruby ${{ matrix.ruby-version }}
@@ -51,7 +45,31 @@ jobs:
       - name: Run Cucumber
         run: bundle exec cucumber features --format progress --color
 
-  Rubocop:
+  Features-experimental:
+    needs: pre_job # skip duplicates
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+    runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.experimental }}
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby-version:
+          - 'ruby-head'
+          - 'jruby-9.4'
+        experimental: [true]
+        continue-on-error: [true]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Ruby ${{ matrix.ruby-version }}
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+          bundler-cache: true
+          cache-version: 1
+      - name: Run Cucumber
+        run: bundle exec cucumber features --format progress --color
+
+  Rubocop-supported:
     needs: pre_job # skip duplicates
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     runs-on: ubuntu-latest
@@ -65,12 +83,6 @@ jobs:
           - '3.3'
           - '3.4'
         experimental: [false]
-        include:
-          - ruby-version: 'ruby-head'
-            experimental: true
-            continue-on-error: true
-          - ruby-version: 'jruby-9.4'
-            experimental: true
     steps:
       - uses: actions/checkout@v2
       - name: Set up Ruby ${{ matrix.ruby-version }}
@@ -82,7 +94,31 @@ jobs:
       - name: Run Rubocop
         run: bundle exec rubocop
 
-  Reek:
+  Rubocop-experimental:
+    needs: pre_job # skip duplicates
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+    runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.experimental }}
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby-version:
+          - 'ruby-head'
+          - 'jruby-9.4'
+        experimental: [true]
+        continue-on-error: [true]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Ruby ${{ matrix.ruby-version }}
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+          bundler-cache: true
+          cache-version: 1
+      - name: Run Rubocop
+        run: bundle exec rubocop
+
+  Reek-supported:
     needs: pre_job # skip duplicates
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     runs-on: ubuntu-latest
@@ -96,12 +132,6 @@ jobs:
           - '3.3'
           - '3.4'
         experimental: [false]
-        include:
-          - ruby-version: 'ruby-head'
-            experimental: true
-            continue-on-error: true
-          - ruby-version: 'jruby-9.4'
-            experimental: true
     steps:
       - uses: actions/checkout@v2
       - name: Set up Ruby ${{ matrix.ruby-version }}
@@ -113,7 +143,31 @@ jobs:
       - name: Run Reek
         run: bundle exec rake reek
 
-  Minitest:
+  Reek-experimental:
+    needs: pre_job # skip duplicates
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+    runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.experimental }}
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby-version:
+          - 'ruby-head'
+          - 'jruby-9.4'
+        experimental: [true]
+        continue-on-error: [true]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Ruby ${{ matrix.ruby-version }}
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+          bundler-cache: true
+          cache-version: 1
+      - name: Run Reek
+        run: bundle exec rake reek
+
+  Minitest-supported:
     needs: pre_job # skip duplicates
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     runs-on: ubuntu-latest
@@ -127,13 +181,30 @@ jobs:
           - '3.3'
           - '3.4'
         experimental: [false]
-        include:
-          - ruby-version: 'ruby-head'
-            experimental: true
-            continue-on-error: true
-          - ruby-version: 'jruby-9.4'
-            experimental: true
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Ruby ${{ matrix.ruby-version }}
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+          bundler-cache: true
+          cache-version: 1
+      - name: Run Unit tests
+        run: bundle exec rake test
 
+  Minitest-experimental:
+    needs: pre_job # skip duplicates
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+    runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.experimental }}
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby-version:
+          - 'ruby-head'
+          - 'jruby-9.4'
+        experimental: [true]
+        continue-on-error: [true]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Ruby ${{ matrix.ruby-version }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,6 +68,7 @@ jobs:
         include:
           - ruby-version: 'ruby-head'
             experimental: true
+            continue-on-error: true
           - ruby-version: 'jruby-9.4'
             experimental: true
     steps:
@@ -98,6 +99,7 @@ jobs:
         include:
           - ruby-version: 'ruby-head'
             experimental: true
+            continue-on-error: true
           - ruby-version: 'jruby-9.4'
             experimental: true
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -127,6 +127,7 @@ jobs:
         include:
           - ruby-version: 'ruby-head'
             experimental: true
+            continue-on-error: true
           - ruby-version: 'jruby-9.4'
             experimental: true
 

--- a/rubycritic.gemspec
+++ b/rubycritic.gemspec
@@ -46,7 +46,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'aruba', '~> 2.3.0'
   spec.add_development_dependency 'bundler', '>= 2.0.0'
   if RUBY_PLATFORM == 'java'
-    spec.add_development_dependency 'jar-dependencies', '~> 0.4.1'
+    spec.add_development_dependency 'jar-dependencies', '~> 0.5.4'
     spec.add_development_dependency 'pry-debugger-jruby'
   else
     spec.add_development_dependency 'byebug', '~> 11.0', '>= 10.0'

--- a/rubycritic.gemspec
+++ b/rubycritic.gemspec
@@ -7,6 +7,11 @@ require 'rubycritic/version'
 Gem::Specification.new do |spec|
   spec.name          = 'rubycritic'
   spec.version       = RubyCritic::VERSION
+  if RUBY_PLATFORM == 'java'
+    spec.platform      = Gem::Platform::JAVA
+  else
+    spec.platform      = Gem::Platform::RUBY
+  end
   spec.authors       = ['Guilherme Simoes']
   spec.email         = ['guilherme.rdems@gmail.com']
   spec.description   = 'RubyCritic is a tool that wraps around various static analysis gems ' \
@@ -46,6 +51,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '>= 2.0.0'
   if RUBY_PLATFORM == 'java'
     spec.add_development_dependency 'pry-debugger-jruby'
+    spec.add_development_dependency 'jar-dependencies', '~> 0.4.1'
   else
     spec.add_development_dependency 'byebug', '~> 11.0', '>= 10.0'
   end

--- a/rubycritic.gemspec
+++ b/rubycritic.gemspec
@@ -7,11 +7,7 @@ require 'rubycritic/version'
 Gem::Specification.new do |spec|
   spec.name          = 'rubycritic'
   spec.version       = RubyCritic::VERSION
-  if RUBY_PLATFORM == 'java'
-    spec.platform      = Gem::Platform::JAVA
-  else
-    spec.platform      = Gem::Platform::RUBY
-  end
+  spec.platform      = RUBY_PLATFORM == 'java' ? Gem::Platform::JAVA : Gem::Platform::RUBY
   spec.authors       = ['Guilherme Simoes']
   spec.email         = ['guilherme.rdems@gmail.com']
   spec.description   = 'RubyCritic is a tool that wraps around various static analysis gems ' \
@@ -50,8 +46,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'aruba', '~> 2.3.0'
   spec.add_development_dependency 'bundler', '>= 2.0.0'
   if RUBY_PLATFORM == 'java'
-    spec.add_development_dependency 'pry-debugger-jruby'
     spec.add_development_dependency 'jar-dependencies', '~> 0.4.1'
+    spec.add_development_dependency 'pry-debugger-jruby'
   else
     spec.add_development_dependency 'byebug', '~> 11.0', '>= 10.0'
   end


### PR DESCRIPTION
This factors the CI, splitting each job into -supported and -experimental steps. This allows us to block merges only only the -supported jobs passing.

For now this PR is based on whitesmith/fixes/jruby-ruby-head, since that PR fixes some noise that would make it hard to debug this one. When that one lands I can clean this up.

Check list:
- [ ] Add an entry to the [changelog](https://github.com/whitesmith/rubycritic/blob/main/CHANGELOG.md)
- [ ] [Squash all commits into a single one](https://github.com/whitesmith/rubycritic/blob/main/CONTRIBUTING.md)
- [ ] Describe your PR, link issues, etc.
