### PR TITLE
Bump the CI's JRuby support to JRuby 10

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,7 @@ jobs:
         include:
           - ruby-version: 'ruby-head'
             experimental: true
-          - ruby-version: 'jruby-9.4'
+          - ruby-version: 'jruby-10'
             experimental: true
     steps:
       - uses: actions/checkout@v4
@@ -67,7 +67,7 @@ jobs:
         include:
           - ruby-version: 'ruby-head'
             experimental: true
-          - ruby-version: 'jruby-9.4'
+          - ruby-version: 'jruby-10'
             experimental: true
     steps:
       - uses: actions/checkout@v4
@@ -97,7 +97,7 @@ jobs:
         include:
           - ruby-version: 'ruby-head'
             experimental: true
-          - ruby-version: 'jruby-9.4'
+          - ruby-version: 'jruby-10'
             experimental: true
     steps:
       - uses: actions/checkout@v4
@@ -127,7 +127,7 @@ jobs:
         include:
           - ruby-version: 'ruby-head'
             experimental: true
-          - ruby-version: 'jruby-9.4'
+          - ruby-version: 'jruby-10'
             experimental: true
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # main [(unreleased)](https://github.com/whitesmith/rubycritic/compare/v4.9.2...main)
 
+* [CHANGE] Bump CI's JRuby checks to JRuby 10 (by [@faisal][])
 * [CHANGE] Update CI checkout action to v4 (by [@faisal][])
 
 # v4.9.2 / 2025-04-08 [(commits)](https://github.com/whitesmith/rubycritic/compare/v4.9.1...v4.9.2)


### PR DESCRIPTION
JRuby 10 is out and JRuby 9.4 supports an EOL'd version of the underlying Ruby language, so this PR updates the CI's JRuby tests to use JRuby 10.

Check list:
- [X] Add an entry to the [changelog](https://github.com/whitesmith/rubycritic/blob/main/CHANGELOG.md)
- [X] [Squash all commits into a single one](https://github.com/whitesmith/rubycritic/blob/main/CONTRIBUTING.md)
- [x] Describe your PR, link issues, etc.
