### PR TITLE
update checkout action to v4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,7 @@ jobs:
           - ruby-version: 'jruby-9.4'
             experimental: true
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Ruby ${{ matrix.ruby-version }}
         uses: ruby/setup-ruby@v1
         with:
@@ -70,7 +70,7 @@ jobs:
           - ruby-version: 'jruby-9.4'
             experimental: true
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Ruby ${{ matrix.ruby-version }}
         uses: ruby/setup-ruby@v1
         with:
@@ -100,7 +100,7 @@ jobs:
           - ruby-version: 'jruby-9.4'
             experimental: true
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Ruby ${{ matrix.ruby-version }}
         uses: ruby/setup-ruby@v1
         with:
@@ -131,7 +131,7 @@ jobs:
             experimental: true
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Ruby ${{ matrix.ruby-version }}
         uses: ruby/setup-ruby@v1
         with:
@@ -146,7 +146,7 @@ jobs:
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # main [(unreleased)](https://github.com/whitesmith/rubycritic/compare/v4.9.2...main)
 
+* [CHANGE] Update CI checkout action to v4 (by [@faisal][])
+
 # v4.9.2 / 2025-04-08 [(commits)](https://github.com/whitesmith/rubycritic/compare/v4.9.1...v4.9.2)
 
 * [CHANGE] Adds development dependency for gems removed from standard library in Ruby 3.5 -- ostruct, irb, rdoc (by [@faisal][])


### PR DESCRIPTION
`actions/checkout@v2` is written for Node12 but (currently) runs on Node20. v2 hasn't been touched [in three years](https://github.com/actions/checkout/tree/v2.6.0). This PR updates the action to use the newer `actions/checkout@v4` so we're using the latest supported config.

```
$ actionlint
.github/workflows/main.yml:43:15: the runner of "actions/checkout@v2" action is too old to run on GitHub Actions. update the action's version to fix this issue [action]
   |
43 |       - uses: actions/checkout@v2
   |               ^~~~~~~~~~~~~~~~~~~
.github/workflows/main.yml:73:15: the runner of "actions/checkout@v2" action is too old to run on GitHub Actions. update the action's version to fix this issue [action]
   |
73 |       - uses: actions/checkout@v2
   |               ^~~~~~~~~~~~~~~~~~~
.github/workflows/main.yml:103:15: the runner of "actions/checkout@v2" action is too old to run on GitHub Actions. update the action's version to fix this issue [action]
    |
103 |       - uses: actions/checkout@v2
    |               ^~~~~~~~~~~~~~~~~~~
.github/workflows/main.yml:134:15: the runner of "actions/checkout@v2" action is too old to run on GitHub Actions. update the action's version to fix this issue [action]
    |
134 |       - uses: actions/checkout@v2
    |               ^~~~~~~~~~~~~~~~~~~
.github/workflows/main.yml:149:15: the runner of "actions/checkout@v2" action is too old to run on GitHub Actions. update the action's version to fix this issue [action]
    |
149 |       - uses: actions/checkout@v2
    |               ^~~~~~~~~~~~~~~~~~~
```

See https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/, https://github.blog/changelog/2023-07-16-github-actions-removal-of-node12-from-the-actions-runner/, https://github.blog/changelog/2024-03-06-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/, https://github.blog/changelog/2024-09-25-end-of-life-for-actions-node16/ for the history of the Node updates.

Check list:
- [X] Add an entry to the [changelog](https://github.com/whitesmith/rubycritic/blob/main/CHANGELOG.md)
- [X] [Squash all commits into a single one](https://github.com/whitesmith/rubycritic/blob/main/CONTRIBUTING.md)
- [X] Describe your PR, link issues, etc.
