### PR TITLE
Apply fixes or suppress warnings for issues spotted by recent rubocop versions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # main [(unreleased)](https://github.com/whitesmith/rubycritic/compare/v4.9.2...main)
 
+* [CHANGE] Add changes or suppress warnings for issues found by newer rubocop (by [@faisal][])
 * [CHANGE] Update CI checkout action to v4 (by [@faisal][])
 
 # v4.9.2 / 2025-04-08 [(commits)](https://github.com/whitesmith/rubycritic/compare/v4.9.1...v4.9.2)

--- a/lib/rubycritic/cli/options/file.rb
+++ b/lib/rubycritic/cli/options/file.rb
@@ -96,10 +96,12 @@ module RubyCritic
           options['paths']
         end
 
+        # rubocop:disable Naming/PredicateMethod
         def value_for(value)
           value = value.to_s
           value == 'true' unless value.empty?
         end
+        # rubocop:enable Naming/PredicateMethod
       end
     end
   end

--- a/lib/rubycritic/commands/status_reporter.rb
+++ b/lib/rubycritic/commands/status_reporter.rb
@@ -26,10 +26,10 @@ module RubyCritic
       end
 
       def current_status
-        satisfy_minimum_score_rule ? SUCCESS : SCORE_BELOW_MINIMUM
+        satisfy_minimum_score_rule? ? SUCCESS : SCORE_BELOW_MINIMUM
       end
 
-      def satisfy_minimum_score_rule
+      def satisfy_minimum_score_rule?
         score >= @options[:minimum_score].to_f
       end
 

--- a/lib/rubycritic/rake_task.rb
+++ b/lib/rubycritic/rake_task.rb
@@ -71,7 +71,7 @@ module RubyCritic
 
     def print_starting_up_output
       puts "\n\n!!! Running `#{name}` rake command\n"
-      puts "!!! Inspecting #{paths} #{options.empty? ? '' : "with options #{options}"}\n\n"
+      puts "!!! Inspecting #{paths} #{"with options #{options}" unless options.empty?}\n\n"
     end
 
     def options_as_arguments

--- a/lib/rubycritic/source_control_systems/git.rb
+++ b/lib/rubycritic/source_control_systems/git.rb
@@ -50,7 +50,7 @@ module RubyCritic
       end
 
       def travel_to_head
-        stash_successful = stash_changes
+        stash_successful = stash_changes?
         yield
       ensure
         travel_to_original_state if stash_successful
@@ -88,7 +88,7 @@ module RubyCritic
 
       private
 
-      def stash_changes
+      def stash_changes?
         stashes_count_before = stashes_count
         git('stash')
         stashes_count_after = stashes_count

--- a/lib/rubycritic/source_control_systems/perforce.rb
+++ b/lib/rubycritic/source_control_systems/perforce.rb
@@ -52,9 +52,11 @@ module RubyCritic
         Time.strptime(perforce_files[Perforce.key_file(path)].last_commit, '%s').strftime('%Y-%m-%d %H:%M:%S %z')
       end
 
+      # rubocop:disable Style/CollectionQuerying
       def revision?
         !perforce_files.values.count(&:opened?).zero?
       end
+      # rubocop:enable Style/CollectionQuerying
 
       def head_reference
         perforce_files.values.map(&:head).max_by(&:to_i)

--- a/test/fakefs_helper.rb
+++ b/test/fakefs_helper.rb
@@ -8,9 +8,12 @@ module FakeFS
     # $VERBOSE = nil to suppress warnings when we override flock.
     original_verbose = $VERBOSE
     $VERBOSE = nil
+
+    # rubocop:disable Naming/PredicateMethod
     def flock(*)
       true
     end
+    # rubocop:enable Naming/PredicateMethod
     $VERBOSE = original_verbose
   end
 end

--- a/test/lib/rubycritic/analysers/helpers/methods_counter_test.rb
+++ b/test/lib/rubycritic/analysers/helpers/methods_counter_test.rb
@@ -8,6 +8,7 @@ describe RubyCritic::MethodsCounter do
     context 'when a file contains Ruby code' do
       it 'calculates the number of methods' do
         analysed_module = AnalysedModuleDouble.new(path: 'test/samples/methods_count.rb')
+
         _(RubyCritic::MethodsCounter.new(analysed_module).count).must_equal 2
       end
     end
@@ -15,6 +16,7 @@ describe RubyCritic::MethodsCounter do
     context 'when a file is empty' do
       it 'returns 0 as the number of methods' do
         analysed_module = AnalysedModuleDouble.new(path: 'test/samples/empty.rb')
+
         _(RubyCritic::MethodsCounter.new(analysed_module).count).must_equal 0
       end
     end
@@ -22,6 +24,7 @@ describe RubyCritic::MethodsCounter do
     context 'when a file has no method' do
       it 'does not blow up and returns 0 as the number of methods' do
         analysed_module = AnalysedModuleDouble.new(path: 'test/samples/no_methods.rb')
+
         capture_output_streams do
           _(RubyCritic::MethodsCounter.new(analysed_module).count).must_equal 0
         end

--- a/test/lib/rubycritic/analysers/helpers/modules_locator_test.rb
+++ b/test/lib/rubycritic/analysers/helpers/modules_locator_test.rb
@@ -13,6 +13,7 @@ describe RubyCritic::ModulesLocator do
           pathname: Pathname.new('test/samples/module_names.rb'),
           methods_count: 1
         )
+
         _(RubyCritic::ModulesLocator.new(analysed_module).names)
           .must_equal ['Foo', 'Foo::Bar', 'Foo::Baz', 'Foo::Qux', 'Foo::Quux::Corge']
       end
@@ -24,6 +25,7 @@ describe RubyCritic::ModulesLocator do
           pathname: Pathname.new('test/samples/empty.rb'),
           methods_count: 1
         )
+
         _(RubyCritic::ModulesLocator.new(analysed_module).names).must_equal ['Empty']
       end
     end
@@ -34,6 +36,7 @@ describe RubyCritic::ModulesLocator do
           pathname: Pathname.new('test/samples/no_methods.rb'),
           methods_count: 0
         )
+
         capture_output_streams do
           _(RubyCritic::ModulesLocator.new(analysed_module).names).must_equal ['Foo::NoMethods']
         end

--- a/test/lib/rubycritic/analysers/smells/flay_test.rb
+++ b/test/lib/rubycritic/analysers/smells/flay_test.rb
@@ -21,16 +21,19 @@ describe RubyCritic::Analyser::FlaySmells do
 
     it 'creates smells with messages' do
       smell = @analysed_modules.first.smells.first
+
       _(smell.message).must_be_instance_of String
     end
 
     it 'creates smells with scores' do
       smell = @analysed_modules.first.smells.first
+
       _(smell.score).must_be_kind_of Numeric
     end
 
     it 'creates smells with more than one location' do
       smell = @analysed_modules.first.smells.first
+
       _(smell.multiple_locations?).must_equal true
     end
 

--- a/test/lib/rubycritic/analysers/smells/flog_test.rb
+++ b/test/lib/rubycritic/analysers/smells/flog_test.rb
@@ -17,11 +17,13 @@ describe RubyCritic::Analyser::FlogSmells do
 
     it 'creates smells with messages' do
       smell = @analysed_module.smells.first
+
       _(smell.message).must_be_instance_of String
     end
 
     it 'creates smells with scores' do
       smell = @analysed_module.smells.first
+
       _(smell.score).must_be :>, 0
     end
   end

--- a/test/lib/rubycritic/analysers/smells/reek_test.rb
+++ b/test/lib/rubycritic/analysers/smells/reek_test.rb
@@ -18,14 +18,17 @@ describe RubyCritic::Analyser::ReekSmells do
 
     it 'respects the .reek file' do
       messages = @analysed_module.smells.map(&:message)
+
       _(messages).wont_include "has the parameter name 'a'"
     end
 
     it 'creates smells with messages' do
       first_smell = @analysed_module.smells.first
+
       _(first_smell.message).must_equal "has boolean parameter 'reek'"
 
       last_smell = @analysed_module.smells.last
+
       _(last_smell.message).must_equal 'has no descriptive comment'
     end
   end

--- a/test/lib/rubycritic/browser_test.rb
+++ b/test/lib/rubycritic/browser_test.rb
@@ -12,6 +12,7 @@ describe RubyCritic::Browser do
   describe '#open' do
     it 'should be open report with launch browser' do
       Launchy.stubs(:open).returns(true)
+
       _(@browser.open).must_equal true
     end
   end

--- a/test/lib/rubycritic/commands/compare_test.rb
+++ b/test/lib/rubycritic/commands/compare_test.rb
@@ -69,6 +69,7 @@ describe RubyCritic::Command::Compare do
           comparison.expects(:abort).once
 
           status_reporter = comparison.execute
+
           _(status_reporter.score).must_equal RubyCritic::Config.feature_branch_score
           _(status_reporter.score).wont_equal RubyCritic::Config.base_branch_score
           _(status_reporter.status_message).must_equal "Score: #{RubyCritic::Config.feature_branch_score}"
@@ -87,6 +88,7 @@ describe RubyCritic::Command::Compare do
         end
         RubyCritic::SourceControlSystem::Git.stub(:switch_branch, copy_proc) do
           status_reporter = RubyCritic::Command::Compare.new(options).execute
+
           _(status_reporter.score).must_equal RubyCritic::Config.feature_branch_score
           _(status_reporter.score).must_equal RubyCritic::Config.base_branch_score
           _(status_reporter.status_message).must_equal "Score: #{RubyCritic::Config.feature_branch_score}"

--- a/test/lib/rubycritic/commands/status_reporter_test.rb
+++ b/test/lib/rubycritic/commands/status_reporter_test.rb
@@ -22,12 +22,14 @@ describe RubyCritic::Command::StatusReporter do
 
     it 'accept a score' do
       @reporter.score = 50.0
+
       _(@reporter.status).must_equal success_status
       _(@reporter.status_message).must_equal 'Score: 50.0'
     end
 
     it 'should format the score' do
       @reporter.score = 98.95258620689656
+
       _(@reporter.status).must_equal success_status
       _(@reporter.status_message).must_equal 'Score: 98.95'
     end
@@ -49,12 +51,14 @@ describe RubyCritic::Command::StatusReporter do
       let(:score) { 98.0 }
       it 'should return the correct status' do
         @reporter.score = score
+
         _(@reporter.status).must_equal score_below_minimum
         _(@reporter.status_message).must_equal 'Score (98.0) is below the minimum 99.0'
       end
 
       it 'should format the score' do
         @reporter.score = 98.95258620689656
+
         _(@reporter.status).must_equal score_below_minimum
         _(@reporter.status_message).must_equal 'Score (98.95) is below the minimum 99.0'
       end
@@ -64,6 +68,7 @@ describe RubyCritic::Command::StatusReporter do
       let(:score) { 99.0 }
       it 'should return the correct status' do
         @reporter.score = score
+
         _(@reporter.status).must_equal success_status
         _(@reporter.status_message).must_equal 'Score: 99.0'
       end
@@ -73,6 +78,7 @@ describe RubyCritic::Command::StatusReporter do
       let(:score) { 100.0 }
       it 'should return the correct status' do
         @reporter.score = score
+
         _(@reporter.status).must_equal success_status
         _(@reporter.status_message).must_equal 'Score: 100.0'
       end

--- a/test/lib/rubycritic/configuration_test.rb
+++ b/test/lib/rubycritic/configuration_test.rb
@@ -16,11 +16,13 @@ describe RubyCritic::Configuration do
 
     it 'can be set to a relative path' do
       RubyCritic::Config.root = 'foo'
+
       _(RubyCritic::Config.root).must_equal File.expand_path('foo')
     end
 
     it 'can be set to an absolute path' do
       RubyCritic::Config.root = '/foo'
+
       _(RubyCritic::Config.root).must_equal '/foo'
     end
 

--- a/test/lib/rubycritic/core/analysed_module_test.rb
+++ b/test/lib/rubycritic/core/analysed_module_test.rb
@@ -50,6 +50,7 @@ describe RubyCritic::AnalysedModule do
     it 'returns the remediation cost of fixing the analysed_module' do
       smells = [SmellDouble.new(cost: 1), SmellDouble.new(cost: 2)]
       analysed_module = RubyCritic::AnalysedModule.new(smells: smells, complexity: 0)
+
       _(analysed_module.cost).must_equal 3
     end
   end
@@ -58,6 +59,7 @@ describe RubyCritic::AnalysedModule do
     context 'when the file has no methods' do
       it 'returns a placeholder' do
         analysed_module = RubyCritic::AnalysedModule.new(complexity: 0, methods_count: 0)
+
         _(analysed_module.complexity_per_method).must_equal 'N/A'
       end
     end
@@ -65,6 +67,7 @@ describe RubyCritic::AnalysedModule do
     context 'when the file has at least one method' do
       it 'returns the average complexity per method' do
         analysed_module = RubyCritic::AnalysedModule.new(complexity: 10, methods_count: 2)
+
         _(analysed_module.complexity_per_method).must_equal 5
       end
     end
@@ -73,6 +76,7 @@ describe RubyCritic::AnalysedModule do
   describe '#smells?' do
     it 'returns true if the analysed_module has at least one smell' do
       analysed_module = RubyCritic::AnalysedModule.new(smells: [SmellDouble.new])
+
       _(analysed_module.smells?).must_equal true
     end
   end
@@ -82,6 +86,7 @@ describe RubyCritic::AnalysedModule do
       location = RubyCritic::Location.new('./foo', '42')
       smells = [RubyCritic::Smell.new(locations: [location])]
       analysed_module = RubyCritic::AnalysedModule.new(smells: smells)
+
       _(analysed_module.smells_at_location(location)).must_equal smells
     end
   end

--- a/test/lib/rubycritic/core/analysed_modules_collection_test.rb
+++ b/test/lib/rubycritic/core/analysed_modules_collection_test.rb
@@ -54,8 +54,10 @@ describe RubyCritic::AnalysedModulesCollection do
 
       it 'registers one AnalysedModule element per existent file' do
         analysed_modules_collection = RubyCritic::AnalysedModulesCollection.new(paths, analysed_modules)
+
         _(analysed_modules_collection.count).must_equal 1
         analysed_module = analysed_modules_collection.first
+
         _(analysed_module.name).must_equal 'Name'
         _(analysed_module.churn).must_equal 2
         _(analysed_module.complexity).must_equal 2

--- a/test/lib/rubycritic/core/location_test.rb
+++ b/test/lib/rubycritic/core/location_test.rb
@@ -27,6 +27,7 @@ describe RubyCritic::Location do
   it 'is comparable' do
     location1 = RubyCritic::Location.new('./foo', 42)
     location2 = RubyCritic::Location.new('./foo', 42)
+
     _(location1).must_equal location2
   end
 
@@ -34,6 +35,7 @@ describe RubyCritic::Location do
     location1 = RubyCritic::Location.new('./foo', 42)
     location2 = RubyCritic::Location.new('./bar', 23)
     location3 = RubyCritic::Location.new('./bar', 16)
+
     _([location1, location2, location3].sort).must_equal [location3, location2, location1]
   end
 end

--- a/test/lib/rubycritic/core/smell_test.rb
+++ b/test/lib/rubycritic/core/smell_test.rb
@@ -45,6 +45,7 @@ describe RubyCritic::Smell do
     it 'returns true if the smell has a location that matches the location passed as argument' do
       location = RubyCritic::Location.new('./foo', '42')
       smell = RubyCritic::Smell.new(locations: [location])
+
       _(smell.at_location?(location)).must_equal true
     end
   end
@@ -54,6 +55,7 @@ describe RubyCritic::Smell do
       location1 = RubyCritic::Location.new('./foo', '42')
       location2 = RubyCritic::Location.new('./foo', '23')
       smell = RubyCritic::Smell.new(locations: [location1, location2])
+
       _(smell.multiple_locations?).must_equal true
     end
   end
@@ -68,6 +70,7 @@ describe RubyCritic::Smell do
       }
       smell1 = RubyCritic::Smell.new(attributes)
       smell2 = RubyCritic::Smell.new(attributes)
+
       _(smell1).must_equal smell2
     end
   end
@@ -106,11 +109,13 @@ describe RubyCritic::Smell do
   describe 'default attributes' do
     it 'has :new for status' do
       smell = RubyCritic::Smell.new
+
       _(smell.status).must_equal(:new)
     end
 
     it 'is has an empty array for locations' do
       smell = RubyCritic::Smell.new
+
       _(smell.locations).must_equal([])
     end
   end

--- a/test/lib/rubycritic/core/smells_array_test.rb
+++ b/test/lib/rubycritic/core/smells_array_test.rb
@@ -11,6 +11,7 @@ describe 'Array of Smells' do
     smell1 = RubyCritic::Smell.new(locations: [location1])
     smell2 = RubyCritic::Smell.new(locations: [location2])
     smell3 = RubyCritic::Smell.new(locations: [location3])
+
     _([smell1, smell2, smell3].sort).must_equal [smell3, smell2, smell1]
   end
 
@@ -18,6 +19,7 @@ describe 'Array of Smells' do
     smell1 = RubyCritic::Smell.new(context: '#bar')
     smell2 = RubyCritic::Smell.new(context: '#bar')
     smell3 = RubyCritic::Smell.new(context: '#foo')
+
     _([smell1, smell3] & [smell2]).must_equal [smell1]
   end
 
@@ -25,6 +27,7 @@ describe 'Array of Smells' do
     smell1 = RubyCritic::Smell.new(context: '#bar')
     smell2 = RubyCritic::Smell.new(context: '#bar')
     smell3 = RubyCritic::Smell.new(context: '#foo')
+
     _([smell1, smell3] | [smell2]).must_equal [smell1, smell3]
   end
 end

--- a/test/lib/rubycritic/generators/turbulence_test.rb
+++ b/test/lib/rubycritic/generators/turbulence_test.rb
@@ -9,6 +9,7 @@ describe RubyCritic::Turbulence do
       files = [AnalysedModuleDouble.new(name: 'Foo', churn: 1, complexity: 2)]
       turbulence_data = RubyCritic::Turbulence.data(files)
       instance_parsed_json = JSON.parse(turbulence_data).first
+
       _(instance_parsed_json['name']).must_equal 'Foo'
       _(instance_parsed_json['x']).must_equal 1
       _(instance_parsed_json['y']).must_equal 2

--- a/test/lib/rubycritic/smells_status_setter_test.rb
+++ b/test/lib/rubycritic/smells_status_setter_test.rb
@@ -13,11 +13,13 @@ describe RubyCritic::SmellsStatusSetter do
 
     it 'marks old smells' do
       RubyCritic::SmellsStatusSetter.set(@smells, @smells)
+
       _(@smell.status).must_equal :old
     end
 
     it 'marks new smells' do
       RubyCritic::SmellsStatusSetter.set([], @smells)
+
       _(@smell.status).must_equal :new
     end
   end

--- a/test/lib/rubycritic/source_control_systems/base_test.rb
+++ b/test/lib/rubycritic/source_control_systems/base_test.rb
@@ -15,6 +15,7 @@ describe RubyCritic::SourceControlSystem::Base do
       it 'creates an instance of that source control system' do
         RubyCritic::SourceControlSystem::Git.stubs(:supported?).returns(true)
         system = RubyCritic::SourceControlSystem::Base.create
+
         _(system).must_be_instance_of RubyCritic::SourceControlSystem::Git
       end
     end
@@ -23,6 +24,7 @@ describe RubyCritic::SourceControlSystem::Base do
       it 'creates a source control system double' do
         capture_output_streams do
           system = RubyCritic::SourceControlSystem::Base.create
+
           _(system).must_be_instance_of RubyCritic::SourceControlSystem::Double
         end
       end

--- a/test/lib/rubycritic/source_control_systems/perforce_test.rb
+++ b/test/lib/rubycritic/source_control_systems/perforce_test.rb
@@ -80,6 +80,7 @@ describe RubyCritic::SourceControlSystem::Perforce do
 
         it 'calls p4 info and parse the result' do
           RubyCritic::SourceControlSystem::Perforce.stubs(:`).with('p4 info').returns(p4_info)
+
           _(RubyCritic::SourceControlSystem::Perforce.in_client_directory?).must_equal true
         end
       end
@@ -100,6 +101,7 @@ describe RubyCritic::SourceControlSystem::Perforce do
 
         it 'calls p4 info and parse the result' do
           RubyCritic::SourceControlSystem::Perforce.stubs(:`).with('p4 info').returns(p4_info)
+
           _(RubyCritic::SourceControlSystem::Perforce.in_client_directory?).must_equal false
         end
       end
@@ -125,9 +127,11 @@ describe RubyCritic::SourceControlSystem::Perforce do
         it 'builds the perforce file cache' do
           RubyCritic::SourceControlSystem::Perforce.stubs(:`).returns(p4_stats)
           file_cache = @system.send(:perforce_files)
+
           _(file_cache.size).must_equal 2
 
           first_file = file_cache['/path/to/client/a_ruby_file.rb']
+
           _(first_file.filename).must_equal '/path/to/client/a_ruby_file.rb'
           _(first_file.revision).must_equal '16'
           _(first_file.last_commit).must_equal '1473075551'
@@ -135,6 +139,7 @@ describe RubyCritic::SourceControlSystem::Perforce do
           _(first_file.opened?).must_equal false
 
           second_file = file_cache['/path/to/client/second_ruby_file.rb']
+
           _(second_file.filename).must_equal '/path/to/client/second_ruby_file.rb'
           _(second_file.revision).must_equal '12'
           _(second_file.last_commit).must_equal '1464601668'
@@ -146,6 +151,7 @@ describe RubyCritic::SourceControlSystem::Perforce do
       it 'retrieves the number revisions of the ruby files' do
         Dir.stubs(:getwd).returns('/path/to/client')
         RubyCritic::SourceControlSystem::Perforce.stubs(:`).once.returns(p4_stats)
+
         _(@system.revisions_count('a_ruby_file.rb')).must_equal 16
         _(@system.revisions_count('second_ruby_file.rb')).must_equal 12
       end
@@ -155,6 +161,7 @@ describe RubyCritic::SourceControlSystem::Perforce do
         ENV['TZ'] = 'utc'
         Dir.stubs(:getwd).returns('/path/to/client')
         RubyCritic::SourceControlSystem::Perforce.stubs(:`).once.returns(p4_stats)
+
         _(@system.date_of_last_commit('a_ruby_file.rb')).must_equal '2016-09-05 11:39:11 +0000'
         _(@system.date_of_last_commit('second_ruby_file.rb')).must_equal '2016-05-30 09:47:48 +0000'
         ENV['TZ'] = oldtz
@@ -163,12 +170,14 @@ describe RubyCritic::SourceControlSystem::Perforce do
       it 'retrieves the information if the ruby file is opened (in the changelist and ready to commit)' do
         Dir.stubs(:getwd).returns('/path/to/client')
         RubyCritic::SourceControlSystem::Perforce.stubs(:`).once.returns(p4_stats)
+
         _(@system.revision?).must_equal true
       end
 
       it 'retrieves the head reference of the repository' do
         Dir.stubs(:getwd).returns('/path/to/client')
         RubyCritic::SourceControlSystem::Perforce.stubs(:`).once.returns(p4_stats)
+
         _(@system.head_reference).must_equal '2103504'
       end
     end

--- a/test/lib/rubycritic/source_locator_test.rb
+++ b/test/lib/rubycritic/source_locator_test.rb
@@ -13,12 +13,14 @@ describe RubyCritic::SourceLocator do
   describe '#paths' do
     it 'finds a single file' do
       paths = ['file0.rb']
+
       _(RubyCritic::SourceLocator.new(paths).paths).must_equal paths
     end
 
     it 'finds all the files inside a given directory' do
       initial_paths = ['dir1']
       final_paths = ['dir1/file1.rb']
+
       _(RubyCritic::SourceLocator.new(initial_paths).paths).must_equal final_paths
     end
 
@@ -36,11 +38,13 @@ describe RubyCritic::SourceLocator do
     it 'finds files with extensions it is configured to find' do
       RubyCritic::Config.stubs(:ruby_extensions).returns(%w[.rb .foo])
       paths = ['file0.rb', 'ruby_file_different_extension.foo']
+
       _(RubyCritic::SourceLocator.new(paths).paths).must_equal paths
     end
 
     it 'finds files which have a ruby shebang' do
       paths = ['file_with_ruby_shebang']
+
       _(RubyCritic::SourceLocator.new(paths).paths).must_equal paths
     end
 
@@ -56,24 +60,28 @@ describe RubyCritic::SourceLocator do
     it 'cleans paths of consecutive slashes and useless dots' do
       initial_paths = ['.//file0.rb']
       final_paths = ['file0.rb']
+
       _(RubyCritic::SourceLocator.new(initial_paths).paths).must_equal final_paths
     end
 
     it 'ignores paths to non-existent files' do
       initial_paths = ['non_existent_dir1/non_existent_file1.rb', 'non_existent_file0.rb']
       final_paths = []
+
       _(RubyCritic::SourceLocator.new(initial_paths).paths).must_equal final_paths
     end
 
     it 'ignores paths to files that do not match the Ruby extension' do
       initial_paths = ['file_with_no_extension', 'file_with_different_extension.py']
       final_paths = []
+
       _(RubyCritic::SourceLocator.new(initial_paths).paths).must_equal final_paths
     end
 
     it 'can deal with nil paths' do
       paths = nil
       final_paths = []
+
       _(RubyCritic::SourceLocator.new(paths).paths).must_equal final_paths
     end
   end
@@ -82,6 +90,7 @@ describe RubyCritic::SourceLocator do
     it 'finds a single file' do
       initial_paths = ['file0.rb']
       final_pathnames = [Pathname.new('file0.rb')]
+
       _(RubyCritic::SourceLocator.new(initial_paths).pathnames).must_equal final_pathnames
     end
   end


### PR DESCRIPTION
Handled more recent rubocop's warnings:
- Add blank lines to test cases
- Rename some predicate methods to the ? form in several places
- Change string interpolation style in lib/rubycritic/rake_task.rb
- Suppress remaining warnings

Check list:
- [X] Add an entry to the [changelog](https://github.com/whitesmith/rubycritic/blob/main/CHANGELOG.md)
- [X] [Squash all commits into a single one](https://github.com/whitesmith/rubycritic/blob/main/CONTRIBUTING.md)
- [X] Describe your PR, link issues, etc.
