### PR TITLE
Allow run RubyCritic outside of project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * [BUGFIX] Work around issue preventing feature execution on Ruby 3.5.0dev (by [@faisal][])
 * [CHANGE] Add changes or suppress warnings for issues found by newer rubocop (by [@faisal][])
 * [CHANGE] Update CI checkout action to v4 (by [@faisal][])
+* [CHANGE] Run RubyCritic outside of the project without losing the churn value (by [@juanvqz][])
 
 # v4.9.2 / 2025-04-08 [(commits)](https://github.com/whitesmith/rubycritic/compare/v4.9.1...v4.9.2)
 

--- a/lib/rubycritic/cli/options/file.rb
+++ b/lib/rubycritic/cli/options/file.rb
@@ -24,11 +24,11 @@ module RubyCritic
             root: root,
             coverage_path: coverage_path,
             formats: formats,
-            deduplicate_symlinks: deduplicate_symlinks,
+            deduplicate_symlinks: deduplicate_symlinks?,
             paths: paths,
-            suppress_ratings: suppress_ratings,
+            suppress_ratings: suppress_ratings?,
             minimum_score: minimum_score,
-            no_browser: no_browser,
+            no_browser: no_browser?,
             base_branch: base_branch,
             feature_branch: feature_branch,
             threshold_score: threshold_score
@@ -68,16 +68,16 @@ module RubyCritic
           options['threshold_score']
         end
 
-        def deduplicate_symlinks
-          value_for(options['deduplicate_symlinks'])
+        def deduplicate_symlinks?
+          value_for?(options['deduplicate_symlinks'])
         end
 
-        def suppress_ratings
-          value_for(options['suppress_ratings'])
+        def suppress_ratings?
+          value_for?(options['suppress_ratings'])
         end
 
-        def no_browser
-          value_for(options['no_browser'])
+        def no_browser?
+          value_for?(options['no_browser'])
         end
 
         def formats
@@ -96,7 +96,7 @@ module RubyCritic
           options['paths']
         end
 
-        def value_for(value)
+        def value_for?(value)
           value = value.to_s
           value == 'true' unless value.empty?
         end

--- a/lib/rubycritic/source_control_systems/git.rb
+++ b/lib/rubycritic/source_control_systems/git.rb
@@ -39,6 +39,7 @@ module RubyCritic
         current_path = File.expand_path(path)
         while current_path != File.dirname(current_path)
           return true if Dir.exist?(File.join(current_path, '.git'))
+
           current_path = File.dirname(current_path)
         end
         false

--- a/lib/rubycritic/source_control_systems/git.rb
+++ b/lib/rubycritic/source_control_systems/git.rb
@@ -21,8 +21,27 @@ module RubyCritic
         self.class.git(arg)
       end
 
+      # :reek:DuplicateMethodCall
+      # :reek:NilCheck
       def self.supported?
-        git('branch 2>&1') && $CHILD_STATUS.success?
+        return true if git('branch 2>&1') && $CHILD_STATUS.success?
+
+        return false if Config.paths.nil? || Config.paths.empty?
+
+        Config.paths.any? do |path|
+          absolute_path = File.expand_path(path)
+          check_git_repository?(absolute_path)
+        end
+      end
+
+      # :reek:DuplicateMethodCall
+      def self.check_git_repository?(path)
+        current_path = File.expand_path(path)
+        while current_path != File.dirname(current_path)
+          return true if Dir.exist?(File.join(current_path, '.git'))
+          current_path = File.dirname(current_path)
+        end
+        false
       end
 
       def self.to_s

--- a/lib/rubycritic/source_control_systems/git/churn.rb
+++ b/lib/rubycritic/source_control_systems/git/churn.rb
@@ -21,6 +21,7 @@ module RubyCritic
       end
 
       # :reek:TooManyInstanceVariables
+      # rubocop:disable Metrics/ClassLength
       class Churn
         # :reek:TooManyStatements
         def initialize(churn_after: nil, paths: ['.'])
@@ -48,9 +49,8 @@ module RubyCritic
           @paths.each do |path|
             current_path = File.expand_path(path)
             while current_path != File.dirname(current_path)
-              if Dir.exist?(File.join(current_path, '.git'))
-                return current_path
-              end
+              return current_path if Dir.exist?(File.join(current_path, '.git'))
+
               current_path = File.dirname(current_path)
             end
           end
@@ -86,7 +86,7 @@ module RubyCritic
           absolute_path = File.expand_path(path)
           if absolute_path.start_with?(@git_root)
             # Convert to relative path from git root
-            absolute_path[@git_root.length + 1..-1] || '.'
+            absolute_path[(@git_root.length + 1)..] || '.'
           else
             # If path is not within git root, use as is
             path
@@ -122,15 +122,15 @@ module RubyCritic
 
         # :reek:DuplicateMethodCall
         def filename_for_subdirectory(filename)
-          if @git_root != Dir.pwd
-            filename
-          else
+          if @git_root == Dir.pwd
             git_path = Git.git('rev-parse --show-toplevel')
             cd_path = Dir.pwd
             if cd_path.length > git_path.length
               filename = filename.sub(/^#{Regexp.escape("#{File.basename(cd_path)}/")}/, '')
             end
             [filename]
+          else
+            filename
           end
         end
 
@@ -148,6 +148,7 @@ module RubyCritic
         end
 
         # :reek:TooManyStatements
+        # rubocop:disable Metrics/MethodLength
         def stats(path)
           # Try the path as-is first
           result = @stats.fetch(path, nil)
@@ -156,12 +157,12 @@ module RubyCritic
           # If not found, try converting absolute path to relative path from git root
           absolute_path = File.expand_path(path)
           if absolute_path.start_with?(@git_root)
-            relative_path = absolute_path[@git_root.length + 1..-1]
+            relative_path = absolute_path[(@git_root.length + 1)..]
             return @stats.fetch(relative_path, Stats.new(0))
           end
 
           # If still not found, try converting relative path to absolute path
-          if !path.start_with?('/')
+          unless path.start_with?('/')
             absolute_path = File.expand_path(path, @git_root)
             return @stats.fetch(absolute_path, Stats.new(0))
           end
@@ -169,7 +170,9 @@ module RubyCritic
           # Default fallback
           @stats.fetch(path, Stats.new(0))
         end
+        # rubocop:enable Metrics/MethodLength
       end
+      # rubocop:enable Metrics/ClassLength
     end
   end
 end


### PR DESCRIPTION
## Context

Previously, obtaining the `churn` value required running the `rubycritic` command from within the project directory, as it depended on being in a `.git` context. This limitation prevented running the command from outside the project.

This PR addresses the issue by inspecting `RubyCritic::Config.paths` to locate the project root—identified by the presence of a `.git` directory. The `churn` context is then established from this root directory, allowing the `rubycritic` command to be executed from any location, not just within the project directory.

This change improves flexibility and usability for users running `rubycritic`.



## Check list:
- [x] Add an entry to the [changelog](https://github.com/whitesmith/rubycritic/blob/main/CHANGELOG.md)
- [x] [Squash all commits into a single one](https://github.com/whitesmith/rubycritic/blob/main/CONTRIBUTING.md)
  I didn't do it but you can do it when merging into main, is that fine?
- [x] Describe your PR, link issues, etc.
