### PR TITLE
JRuby integration improvements.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version:
-          - '3.1'
           - '3.2'
           - '3.3'
           - '3.4'
@@ -37,8 +36,9 @@ jobs:
         include:
           - ruby-version: 'ruby-head'
             experimental: true
-          - ruby-version: 'jruby-9.4'
+          - ruby-version: 'jruby-10'
             experimental: true
+            continue-on-error: true
     steps:
       - uses: actions/checkout@v4
       - name: Set up Ruby ${{ matrix.ruby-version }}
@@ -59,7 +59,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version:
-          - '3.1'
           - '3.2'
           - '3.3'
           - '3.4'
@@ -67,8 +66,9 @@ jobs:
         include:
           - ruby-version: 'ruby-head'
             experimental: true
-          - ruby-version: 'jruby-9.4'
+          - ruby-version: 'jruby-10'
             experimental: true
+            continue-on-error: true
     steps:
       - uses: actions/checkout@v4
       - name: Set up Ruby ${{ matrix.ruby-version }}
@@ -89,7 +89,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version:
-          - '3.1'
           - '3.2'
           - '3.3'
           - '3.4'
@@ -97,8 +96,9 @@ jobs:
         include:
           - ruby-version: 'ruby-head'
             experimental: true
-          - ruby-version: 'jruby-9.4'
+          - ruby-version: 'jruby-10'
             experimental: true
+            continue-on-error: true
     steps:
       - uses: actions/checkout@v4
       - name: Set up Ruby ${{ matrix.ruby-version }}
@@ -119,7 +119,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version:
-          - '3.1'
           - '3.2'
           - '3.3'
           - '3.4'
@@ -127,8 +126,9 @@ jobs:
         include:
           - ruby-version: 'ruby-head'
             experimental: true
-          - ruby-version: 'jruby-9.4'
+          - ruby-version: 'jruby-10'
             experimental: true
+            continue-on-error: true
 
     steps:
       - uses: actions/checkout@v4

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,7 +11,7 @@ AllCops:
     - 'tmp/**/*'
     - 'vendor/**/*'
     - 'gemfiles/*'
-  TargetRubyVersion: 3.1
+  TargetRubyVersion: 3.2
 
 Metrics/BlockLength:
   Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # main [(unreleased)](https://github.com/whitesmith/rubycritic/compare/v4.9.2...main)
 
+* [CHANGE] Drop support for Ruby 3.1.x, including moving CI from JRuby 9.4 to JRuby 10 (by [@faisal][])
 * [CHANGE] Bump aruba, byebug, cucumber, fakefs, rake, reek dependencies (by [@faisal][])
 * [BUGFIX] Work around issue preventing feature execution on Ruby 3.5.0dev (by [@faisal][])
 * [CHANGE] Add changes or suppress warnings for issues found by newer rubocop (by [@faisal][])

--- a/rubycritic.gemspec
+++ b/rubycritic.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'RubyCritic is a Ruby code quality reporter'
   spec.homepage      = 'https://github.com/whitesmith/rubycritic'
   spec.license       = 'MIT'
-  spec.required_ruby_version = '>= 3.1.0'
+  spec.required_ruby_version = '>= 3.2.0'
 
   spec.files = [
     'CHANGELOG.md',

--- a/rubycritic.gemspec
+++ b/rubycritic.gemspec
@@ -7,6 +7,7 @@ require 'rubycritic/version'
 Gem::Specification.new do |spec|
   spec.name          = 'rubycritic'
   spec.version       = RubyCritic::VERSION
+  spec.platform      = RUBY_PLATFORM == 'java' ? Gem::Platform::JAVA : Gem::Platform::RUBY
   spec.authors       = ['Guilherme Simoes']
   spec.email         = ['guilherme.rdems@gmail.com']
   spec.description   = 'RubyCritic is a tool that wraps around various static analysis gems ' \
@@ -45,6 +46,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'aruba', '~> 2.3.1', '>= 2.3.1'
   spec.add_development_dependency 'bundler', '>= 2.0.0'
   if RUBY_PLATFORM == 'java'
+    spec.add_development_dependency 'jar-dependencies', '~> 0.5.4'
     spec.add_development_dependency 'pry-debugger-jruby'
   else
     spec.add_development_dependency 'byebug', '~> 12.0', '>= 10.0'


### PR DESCRIPTION
This is an experimental attempt to drop support for Ruby 3.1 and add support for JRuby 10. In the process it adapts some of the changes from https://github.com/whitesmith/rubycritic/pull/508 to better integrate JRuby.

Check list:
- [ ] Add an entry to the [changelog](https://github.com/whitesmith/rubycritic/blob/main/CHANGELOG.md)
- [ ] [Squash all commits into a single one](https://github.com/whitesmith/rubycritic/blob/main/CONTRIBUTING.md)
- [X] Describe your PR, link issues, etc.
