### PR TITLE
[CHANGE] bump minitest dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # main [(unreleased)](https://github.com/whitesmith/rubycritic/compare/v4.9.2...main)
 
+* [CHANGE] Bump minitest dependency. (by [@faisal][])
+
 # v4.10.0 / 2025-07-30 [(commits)](https://github.com/whitesmith/rubycritic/compare/v4.9.2...v4.10.0)
 
 * [CHANGE] Bump aruba, byebug, cucumber, fakefs, rake, reek dependencies (by [@faisal][])

--- a/rubycritic.gemspec
+++ b/rubycritic.gemspec
@@ -54,7 +54,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'fakefs', '~> 3.0.0'
   spec.add_development_dependency 'irb'
   spec.add_development_dependency 'mdl', '~> 0.13.0', '>= 0.12.0'
-  spec.add_development_dependency 'minitest', '~> 5.25.2', '>= 5.3.0'
+  spec.add_development_dependency 'minitest', '~> 5.26.0', '>= 5.3.0'
   spec.add_development_dependency 'minitest-around', '~> 0.5.0', '>= 0.4.0'
   spec.add_development_dependency 'mocha', '~> 2.7.1'
   spec.add_development_dependency 'ostruct'


### PR DESCRIPTION
Bump the Minitest dependency to the current Minitest version.

Check list:
- [X] Add an entry to the [changelog](https://github.com/whitesmith/rubycritic/blob/main/CHANGELOG.md)
- [X] [Squash all commits into a single one](https://github.com/whitesmith/rubycritic/blob/main/CONTRIBUTING.md)
- [X] Describe your PR, link issues, etc.
