### PR TITLE
HYGIENE  grab changelog changes from v4.11.0 tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
-# main [(unreleased)](https://github.com/whitesmith/rubycritic/compare/v4.10.0...main)
+# main [(unreleased)](https://github.com/whitesmith/rubycritic/compare/v4.11.0...main)
+
+* <INSERT YOUR CHANGES HERE>
+
+# v4.11.0 / 2025-10-15 [(commits)](https://github.com/whitesmith/rubycritic/compare/v4.10.0...v4.11.0)
 
 * [CHANGE] Bump cucumber dependency (by [@faisal][])
-* [CHANGE] Memoize call to `git rev-parse --show-toplevel` for churn calculations (by [@mateusdeap][])
+* [CHANGE] Performance improvement for churn calculation: Memoize call to `git rev-parse --show-toplevel` for churn calculations (by [@mateusdeap][])
 * [CHANGE] Bump minitest dependency. (by [@faisal][])
 
 # v4.10.0 / 2025-07-30 [(commits)](https://github.com/whitesmith/rubycritic/compare/v4.9.2...v4.10.0)


### PR DESCRIPTION
This is a trivial fix to pull back the changelog updates from the v4.11.0 tag, so any future work in main builds on them.

Check list:
- [X] Add an entry to the [changelog](https://github.com/whitesmith/rubycritic/blob/main/CHANGELOG.md) - in a sense
- [X] [Squash all commits into a single one](https://github.com/whitesmith/rubycritic/blob/main/CONTRIBUTING.md)
- [X] Describe your PR, link issues, etc.
