### PR TITLE
fix: Respect exclude_paths in reek config

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -1,4 +1,6 @@
 ---
+exclude_paths:
+  - test/samples/reek/excluded.rb
 detectors:
   InstanceVariableAssumption:
     exclude:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * [FEATURE] ...
 
 * [CHORE] Uses prism instead of parser for Ruby 3.4 and above (by [@torresga][] and [@julioalucero][])
+* [BUGFIX] Respect excluded paths from .reek configuration file during reek analysis (by [@fbuys][])
 
 # v4.11.0 / 2025-10-15 [(commits)](https://github.com/whitesmith/rubycritic/compare/v4.10.0...v4.11.0)
 

--- a/lib/rubycritic/analysers/smells/reek.rb
+++ b/lib/rubycritic/analysers/smells/reek.rb
@@ -10,7 +10,7 @@ module RubyCritic
       include Colorize
 
       def initialize(analysed_modules)
-        @analysed_modules = analysed_modules
+        @analysed_modules = analysed_modules.reject { Reek.configuration.path_excluded?(_1.pathname) }
       end
 
       def run

--- a/test/lib/rubycritic/analysers/smells/reek_test.rb
+++ b/test/lib/rubycritic/analysers/smells/reek_test.rb
@@ -6,9 +6,17 @@ require 'rubycritic/analysers/smells/reek'
 describe RubyCritic::Analyser::ReekSmells do
   context 'when analysing a smelly file' do
     before do
-      pathname = Pathname.new('test/samples/reek/smelly.rb')
-      @analysed_module = AnalysedModuleDouble.new(pathname: pathname, smells: [])
-      analysed_modules = [@analysed_module]
+      # Reset Reek configuration between tests
+      # Config is cached and can leak between tests
+      RubyCritic::Reek.instance_variable_set(:@configuration, nil)
+
+      analysed_path = Pathname.new('test/samples/reek/smelly.rb')
+      @analysed_module = AnalysedModuleDouble.new(pathname: analysed_path, smells: [])
+
+      excluded_path = Pathname.new('test/samples/reek/excluded.rb')
+      @excluded_module = AnalysedModuleDouble.new(pathname: excluded_path, smells: [])
+
+      analysed_modules = [@analysed_module, @excluded_module]
       RubyCritic::Analyser::ReekSmells.new(analysed_modules).run
     end
 
@@ -20,6 +28,10 @@ describe RubyCritic::Analyser::ReekSmells do
       messages = @analysed_module.smells.map(&:message)
 
       _(messages).wont_include "has the parameter name 'a'"
+    end
+
+    it 'ignores excluded files' do
+      _(@excluded_module.smells).must_be :empty?
     end
 
     it 'creates smells with messages' do

--- a/test/lib/rubycritic/generators/lint_report_test.rb
+++ b/test/lib/rubycritic/generators/lint_report_test.rb
@@ -3,18 +3,17 @@
 require 'test_helper'
 require 'rubycritic/analysers_runner'
 require 'rubycritic/generators/lint_report'
-require 'fakefs/safe'
 
 describe RubyCritic::Generator::LintReport do
   describe '#generate_report' do
-    around do |example|
-      capture_output_streams do
-        with_cloned_fs(&example)
-      end
+    before do
+      # Reset Reek configuration between tests
+      # Config is cached and can leak between tests
+      RubyCritic::Reek.instance_variable_set(:@configuration, nil)
     end
 
     it 'report file has data inside' do
-      sample_files = Dir['test/samples/**/*.rb'].reject { |f| File.empty?(f) }
+      sample_files = Dir['test/samples/**/*.rb'].reject { |f| File.empty?(f) || f.include?('excluded') }
       create_analysed_modules_collection
       generate_report
       lines = File.readlines('test/samples/lint.txt').map(&:strip).reject(&:empty?)

--- a/test/samples/reek/excluded.rb
+++ b/test/samples/reek/excluded.rb
@@ -1,0 +1,11 @@
+class Tyrion
+  def reeks?(reek = true)
+    reek
+  end
+
+  def flayed?(a)
+    a
+  end
+end
+
+# Reek should exclude this file entirely based on the .reek.yml configuration


### PR DESCRIPTION
Add ability to exclude files from Reek analysis using the `exclude_paths` option in `.reek.yml`. Updated the analyser to skip excluded files and added tests to verify excluded files are ignored. Also added a sample excluded file for testing.

Fixes: https://github.com/whitesmith/rubycritic/issues/537

Check list:
- [x] Add an entry to the [changelog](https://github.com/whitesmith/rubycritic/blob/main/CHANGELOG.md)
- [x] [Squash all commits into a single one](https://github.com/whitesmith/rubycritic/blob/main/CONTRIBUTING.md)
- [x] Describe your PR, link issues, etc.
