### PR TITLE
Release 4.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 * [CHORE] ...
 * [FEATURE] ...
 
+# v4.12.0 / 2026-01-01 [(commits)](https://github.com/whitesmith/rubycritic/compare/v4.11.0...v4.12.0)
+
 * [CHANGE] Bump cucumber dependency (by [@faisal][])
 * [BUGFIX] Fixed regression in compatibility with Flog 4.9.0 (by [@faisal][])
 * [CHANGE] Bump mocha dependency (by [@faisal][])

--- a/README.md
+++ b/README.md
@@ -244,9 +244,9 @@ RubyCritic is supporting Ruby versions:
 | 2.4 | [v4.7.0](https://github.com/whitesmith/rubycritic/tree/v4.7.0) |
 | 2.5 | [v4.7.0](https://github.com/whitesmith/rubycritic/tree/v4.7.0) |
 | 2.6 | [v4.7.0](https://github.com/whitesmith/rubycritic/tree/v4.7.0) |
-| 2.7 | [v4.9.x](https://github.com/whitesmith/rubycritic/tree/v4.9.1) |
-| 3.0 | latest |
-| 3.1 | latest |
+| 2.7 | [v4.9.1](https://github.com/whitesmith/rubycritic/tree/v4.9.1) |
+| 3.0 | [v4.9.2](https://github.com/whitesmith/rubycritic/tree/v4.9.1) |
+| 3.1 | [v4.12.0](https://github.com/whitesmith/rubycritic/tree/v4.12.0) |
 | 3.2 | latest |
 | 3.3 | latest |
 

--- a/lib/rubycritic/version.rb
+++ b/lib/rubycritic/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RubyCritic
-  VERSION = '4.10.0'
+  VERSION = '4.12.0'
 end


### PR DESCRIPTION
Hey @faisal, 

Thanks for working on this branch! 

I don't think I'm going to merge this PR, I will simply use it to cut the 4.12.0 release.

I wanted to submit the PR for a quick sanity check and to get CI to run the tests with Ruby 3.1.x one last time. 

Check list:

- [x] Add an entry to the [changelog](https://github.com/whitesmith/rubycritic/blob/main/CHANGELOG.md)
- [x] [Squash all commits into a single one](https://github.com/whitesmith/rubycritic/blob/main/CONTRIBUTING.md)
- [x] Describe your PR, link issues, etc.
