### PR TITLE
Support float maximum_decrease and rename YAML key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 * [CHANGE] Replace Aruba with direct API calls in specs (by [@faisal][])
 * [CHANGE] Replace all Cucumber features with Minitest/Spec specs (by [@faisal][])
 * [BUGFIX] Add `lang="en"` to the report's `<html>` element, give the menu-toggle anchor an `aria-label`, and make the per-rating summary IDs unique. Fixes 17 WCAG 2.1 AA structural errors on `overview.html`. (by [@MarcusAl][])
+* [FEATURE] `--maximum-decrease` / `maximum_decrease` now accepts float values (e.g. `0.5`), mirroring how `minimum_score` is handled (by [@siklodi-mariusz][])
+* [CHANGE] Rename the `threshold_score` YAML key to `maximum_decrease` to match the `--maximum-decrease` CLI flag. The old `threshold_score` key still works but emits a deprecation warning; when both are present, `maximum_decrease` wins (by [@siklodi-mariusz][])
 
 # v5.0.0 / 2026-01-26 [(commits)](https://github.com/whitesmith/rubycritic/compare/v4.12.0...v5.0.0)
 
@@ -507,3 +509,4 @@
 [@exoego]: https://github.com/exoego
 [@raff-s]: https://github.com/raff-s
 [@MarcusAl]: https://github.com/MarcusAl
+[@siklodi-mariusz]: https://github.com/siklodi-mariusz

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ $ rubycritic --help
 - `lint`
 2. See [custom formatters docs](/docs/formatters.md)
 3. Faster, analyses diffs w.r.t base_branch (default: main), see `-b`
-4. Works only with `-b`, default: 0
+4. Works only with `-b`. Accepts a FLOAT (ex: 0.5), default: 0
 
 You also can use a config file. Just create a `.rubycritic.yml` on your project root path.
 
@@ -144,7 +144,7 @@ mode_ci:
 branch: 'production' # default is main
 path: '/tmp/mycustompath' # Set path where report will be saved (tmp/rubycritic by default)
 coverage_path: '/tmp/coverage' # Set path where SimpleCov coverage will be saved (./coverage by default)
-threshold_score: 10 # default is 0
+maximum_decrease: 0.5 # FLOAT, default is 0.0
 deduplicate_symlinks: true # default is false
 suppress_ratings: true # default is false
 no_browser: true # default is false

--- a/lib/rubycritic/cli/options/argv.rb
+++ b/lib/rubycritic/cli/options/argv.rb
@@ -32,7 +32,7 @@ module RubyCritic
               '--maximum-decrease [MAX_DECREASE]',
               'Set a threshold for score difference between two branches (works only with -b)'
             ) do |threshold_score|
-              self.threshold_score = Integer(threshold_score)
+              self.threshold_score = Float(threshold_score)
             end
 
             formats = []

--- a/lib/rubycritic/cli/options/file.rb
+++ b/lib/rubycritic/cli/options/file.rb
@@ -64,8 +64,21 @@ module RubyCritic
           options['coverage_path']
         end
 
+        # The YAML key is `maximum_decrease` (matching the `--maximum-decrease`
+        # CLI flag). The legacy `threshold_score` key is still honoured for
+        # backward compatibility but is deprecated. When both are present, the
+        # new `maximum_decrease` key takes precedence.
         def threshold_score
-          options['threshold_score']
+          warn_threshold_score_deprecation if options.key?('threshold_score')
+
+          options.fetch('maximum_decrease') { options['threshold_score'] }
+        end
+
+        def warn_threshold_score_deprecation
+          warn(
+            '[DEPRECATION] The `threshold_score` key in .rubycritic.yml is deprecated ' \
+            'and will be removed in a future release. Please use `maximum_decrease` instead.'
+          )
         end
 
         def deduplicate_symlinks?

--- a/lib/rubycritic/configuration.rb
+++ b/lib/rubycritic/configuration.rb
@@ -20,7 +20,7 @@ module RubyCritic
       self.open_with = options[:open_with]
       self.no_browser = options[:no_browser]
       self.coverage_path = options[:coverage_path]
-      self.threshold_score = options[:threshold_score].to_i
+      self.threshold_score = options[:threshold_score].to_f
       setup_paths_for_targets(options) if options[:paths]
       setup_analysis_targets(options)
       setup_version_control(options)

--- a/test/lib/rubycritic/cli/options/file_test.rb
+++ b/test/lib/rubycritic/cli/options/file_test.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'tmpdir'
+require 'fileutils'
+require 'yaml'
+require 'rubycritic/cli/options/file'
+
+describe RubyCritic::Cli::Options::File do
+  before do
+    @dir = Dir.mktmpdir('rubycritic-file-options-')
+  end
+
+  after do
+    FileUtils.remove_entry(@dir) if @dir && File.directory?(@dir)
+  end
+
+  def options_for(config)
+    path = File.join(@dir, '.rubycritic.yml')
+    File.write(path, YAML.dump(config))
+    options = RubyCritic::Cli::Options::File.new(path)
+    options.parse
+    options
+  end
+
+  def capture_stderr
+    original = $stderr
+    $stderr = StringIO.new
+    yield
+    $stderr.string
+  ensure
+    $stderr = original
+  end
+
+  describe 'maximum_decrease YAML key' do
+    it 'reads a float maximum_decrease value' do
+      options = options_for('maximum_decrease' => 0.5)
+
+      _(options.to_h[:threshold_score]).must_equal 0.5
+    end
+
+    it 'does not emit a deprecation warning for the canonical key' do
+      options = options_for('maximum_decrease' => 0.5)
+
+      warning = capture_stderr { options.to_h }
+
+      _(warning).must_equal ''
+    end
+  end
+
+  describe 'legacy threshold_score YAML key' do
+    it 'is still honoured for backward compatibility' do
+      options = options_for('threshold_score' => 0.5)
+
+      result = nil
+      capture_stderr { result = options.to_h }
+
+      _(result[:threshold_score]).must_equal 0.5
+    end
+
+    it 'emits a deprecation warning pointing to maximum_decrease' do
+      options = options_for('threshold_score' => 10)
+
+      warning = capture_stderr { options.to_h }
+
+      _(warning).must_include 'DEPRECATION'
+      _(warning).must_include 'threshold_score'
+      _(warning).must_include 'maximum_decrease'
+    end
+  end
+
+  describe 'when both keys are present' do
+    it 'prefers the canonical maximum_decrease key' do
+      options = options_for('maximum_decrease' => 0.5, 'threshold_score' => 10)
+
+      result = nil
+      capture_stderr { result = options.to_h }
+
+      _(result[:threshold_score]).must_equal 0.5
+    end
+
+    it 'still warns about the deprecated threshold_score key' do
+      options = options_for('maximum_decrease' => 0.5, 'threshold_score' => 10)
+
+      warning = capture_stderr { options.to_h }
+
+      _(warning).must_include 'DEPRECATION'
+    end
+  end
+end

--- a/test/lib/rubycritic/commands/compare_test.rb
+++ b/test/lib/rubycritic/commands/compare_test.rb
@@ -98,6 +98,31 @@ describe RubyCritic::Command::Compare do
     end
   end
 
+  describe 'float threshold (maximum_decrease)' do
+    it 'parses a fractional -t value as a float instead of coercing to an integer' do
+      options = ['-b', 'base_branch', '-t', '0.5', 'test/samples/compare_file.rb']
+      options = RubyCritic::Cli::Options.new(options).parse.to_h
+
+      _(options[:threshold_score]).must_equal 0.5
+    end
+
+    it 'respects a fractional threshold when comparing branch scores' do
+      options = ['-b', 'base_branch', '-t', '0.5', 'test/samples/compare_file.rb']
+      options = RubyCritic::Cli::Options.new(options).parse.to_h
+      RubyCritic::Config.set(options)
+      comparison = RubyCritic::Command::Compare.new(options)
+
+      RubyCritic::Config.base_branch_score = 92.31
+      RubyCritic::Config.feature_branch_score = 92.0
+      # difference is 0.31, below the 0.5 threshold -> build must not fail
+      _(comparison.send(:threshold_reached?)).must_equal false
+
+      RubyCritic::Config.feature_branch_score = 91.5
+      # difference is 0.81, above the 0.5 threshold -> build must fail
+      _(comparison.send(:threshold_reached?)).must_equal true
+    end
+  end
+
   describe 'with default options passing two branches' do
     before do
       options = ['-b', 'base_branch', '-t', '10', 'test/samples/compare_file.rb']


### PR DESCRIPTION
## What & why

This PR makes two related, backward-compatible changes to the score-decrease threshold used in compare mode (`-b <branch>`), which fails a build when a feature branch's score drops too far below the base branch.

### 1. Accept float values for the threshold

`threshold_score` was coerced to an integer in two places, so the smallest non-zero tolerance was a full point — you couldn't express `0.5` or `0.05`:

- `lib/rubycritic/cli/options/argv.rb`: `Integer(threshold_score)`
- `lib/rubycritic/configuration.rb`: `options[:threshold_score].to_i`

This was arbitrary and inconsistent: the sibling `minimum_score` — the same kind of value, a 2-decimal code-quality score — is already coerced as a **float** in the same files. The comparison in `compare.rb` already does `Float > Float`, so nothing downstream required a whole number.

This PR mirrors `minimum_score`:

- `argv.rb`: `Integer(...)` → `Float(...)`
- `configuration.rb`: `.to_i` → `.to_f`

So `--maximum-decrease 0.5` (or `maximum_decrease: 0.5` in YAML) now works as expected.

### 2. Rename the YAML key to match the CLI flag

The same setting had two different names on the two surfaces:

- CLI flag: `--maximum-decrease`
- YAML key: `threshold_score`

The YAML key is renamed to **`maximum_decrease`** so it matches the flag. This is backward compatible:

- `maximum_decrease:` is the new canonical key.
- The legacy `threshold_score:` key still works but emits a **deprecation warning** (via `Kernel#warn`) telling users to switch.
- When **both** keys are present, the new `maximum_decrease` key wins.

The internal `Config.threshold_score` attribute is intentionally left named as-is to limit churn — only the user-facing YAML key changed.

## Docs

- README: the `--maximum-decrease` footnote now notes FLOAT support, and the `.rubycritic.yml` example uses `maximum_decrease`.
- CHANGELOG entries for both changes.
